### PR TITLE
Pre compiled template classes in packaged .war-file does not loaded, on jetty9

### DIFF
--- a/ScalatePackage.scala
+++ b/ScalatePackage.scala
@@ -1,0 +1,17 @@
+package templates
+
+import org.fusesource.scalate.support.TemplatePackage
+import org.fusesource.scalate.{Binding, TemplateSource}
+
+
+/**
+ * Defines some common imports, attributes and methods across templates in package foo and below
+ */
+class ScalatePackage extends TemplatePackage {
+
+  /** Returns the Scala code to add to the top of the generated template method */
+   def header(source: TemplateSource, bindings: List[Binding]) = """
+import model._
+  """
+}
+

--- a/yeoman-generator-skinny/app/templates/build.sbt
+++ b/yeoman-generator-skinny/app/templates/build.sbt
@@ -7,3 +7,9 @@ import scalikejdbc._, SQLInterpolation._, config._
 DBsWithEnv("development").setupAll()
 """
 
+seq(scalateSettings:_*)
+
+// Scalate Precompilation and Bindings
+scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
+  Seq( TemplateConfig(file(".") / "src" / "main" / "webapp" / "WEB-INF",  Nil,  Nil,  Some("templates")))
+}

--- a/yeoman-generator-skinny/app/templates/src/main/scala/templates/ScalatePackage.scala
+++ b/yeoman-generator-skinny/app/templates/src/main/scala/templates/ScalatePackage.scala
@@ -1,0 +1,17 @@
+package templates
+
+import org.fusesource.scalate.support.TemplatePackage
+import org.fusesource.scalate.{Binding, TemplateSource}
+
+
+/**
+ * Defines some common imports, attributes and methods across templates in package foo and below
+ */
+class ScalatePackage extends TemplatePackage {
+
+  /** Returns the Scala code to add to the top of the generated template method */
+   def header(source: TemplateSource, bindings: List[Binding]) = """
+import model._
+  """
+}
+


### PR DESCRIPTION
To loading pre-compiled template classes,  org.fusesource.scalate.support.TemplateFinder
expects `template.ScalatePackage` class-file in classpath.

F.Y.I
https://github.com/scalate/scalate/blob/scala_2.10/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplatePackage.scala#L44
