### PR TITLE
fix shebang to /bin/bash from /bin/sh

### DIFF
--- a/yeoman-generator-skinny/app/templates/sbt
+++ b/yeoman-generator-skinny/app/templates/sbt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 SBT_OPTS="-XX:MaxPermSize=256M"
 if [ ! -f $HOME/.sbtconfig ]; then
   echo "export SBT_OPTS=\"-XX:MaxPermSize=256M\"" > ${HOME}/.sbtconfig

--- a/yeoman-generator-skinny/app/templates/skinny
+++ b/yeoman-generator-skinny/app/templates/skinny
@@ -1,4 +1,4 @@
-#!/bin/sh  
+#!/bin/bash
 
 current_dir=`dirname $0`
 sbt_path=`which sbt`


### PR DESCRIPTION
these shell scripts are written by bash syntax.
but, on a debian, /bin/sh is not linked to /bin/bash.
