### PR TITLE
Add scalatra-scalatest dependency to Yeoman-generated apps

### DIFF
--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -8,6 +8,7 @@ import ScalateKeys._
 object SkinnyAppBuild extends Build {
 
   val skinnyVersion = "0.9.27"
+  val scalatraVersion = "2.2.2"
 
   // In some cases, Jety 9.1 looks very slow (didn't investigate the reason)
   //val jettyVersion = "9.1.0.v20131115"
@@ -24,6 +25,7 @@ object SkinnyAppBuild extends Build {
       "com.h2database"          %  "h2"                 % "1.3.174",      // your own JDBC driver
       "ch.qos.logback"          %  "logback-classic"    % "1.0.13",
       "org.skinny-framework"    %% "skinny-test"        % skinnyVersion         % "test",
+      "org.scalatra"            %% "scalatra-scalatest" % scalatraVersion       % "test", 
       "org.eclipse.jetty"       %  "jetty-webapp"       % jettyVersion          % "container",
       "org.eclipse.jetty"       %  "jetty-plus"         % jettyVersion          % "container",
       "org.eclipse.jetty.orbit" %  "javax.servlet"      % "3.0.0.v201112011016" % "container;provided;test"


### PR DESCRIPTION
The Yeoman generator template didn't include a dependency on scalatra-scalatest. 
It's a `provided` dependency of skinny-test, so it needs to be included explicitly.

```
mkdir skinny-sandbox
cd $_
yo skinny
./skinny test
```

```
[error] /Users/chris/code/skinny-sandbox/src/test/scala/controller/RootControllerSpec.scala:3: object test is not a member of package org.scalatra
[error] import org.scalatra.test.scalatest._
[error]                     ^
[error] /Users/chris/code/skinny-sandbox/src/test/scala/controller/RootControllerSpec.scala:6: not found: type ScalatraFlatSpec
[error] class RootControllerSpec extends ScalatraFlatSpec with SkinnyTestSupport {
[error]                                  ^
[error] /Users/chris/code/skinny-sandbox/src/test/scala/controller/RootControllerSpec.scala:8: not found: value addFilter
[error]   addFilter(Controllers.root, "/*")
[error]   ^
[error] /Users/chris/code/skinny-sandbox/src/test/scala/controller/RootControllerSpec.scala:10: not found: value it
[error]   it should "show top page" in {
[error]   ^
[error] four errors found
[error] (dev/test:compile) Compilation failed
```
