### PR TITLE
Fixed. Only prevent commas from being inserted into numbers

### DIFF
--- a/framework/src/main/scala/skinny/controller/Params.scala
+++ b/framework/src/main/scala/skinny/controller/Params.scala
@@ -112,15 +112,9 @@ case class Params(underlying: Map[String, Any]) extends Dynamic {
    * @return value if exists
    */
   def selectDynamic(key: String): Option[Any] = underlying.get(key).map {
-    // #toString is work around for issue #11
-    // 'v' should not be an `Any` value because 1234: Any will be converted to '1,234'.
-    case Some(true) => true
-    case Some(false) => false
-    case Some(v) => v.toString
+    case Some(v) => v
     case None => null
-    case true => true
-    case false => false
-    case v => v.toString
+    case v => v
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/ScalateTemplateEngineFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/ScalateTemplateEngineFeature.scala
@@ -1,11 +1,13 @@
 package skinny.controller.feature
 
 import org.scalatra.scalate._
-import org.fusesource.scalate.TemplateEngine
+import org.fusesource.scalate.{ TemplateEngine, RenderContext }
 import org.fusesource.scalate.layout.DefaultLayoutStrategy
 import skinny._
-import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
 import scala.annotation.tailrec
+import java.io.PrintWriter
+import java.text.DecimalFormat
 
 /**
  * Scalate implementation of TemplateEngineSupport.
@@ -27,7 +29,6 @@ import scala.annotation.tailrec
  * And then, Skinny expects "src/main/webapp/WEB-INF/views/members/index.html.scaml"
  */
 trait ScalateTemplateEngineFeature extends TemplateEngineFeature
-    with ScalateSupport
     with ScalateUrlGeneratorSupport {
 
   /**
@@ -55,6 +56,24 @@ trait ScalateTemplateEngineFeature extends TemplateEngineFeature
     engine.layoutStrategy = new DefaultLayoutStrategy(engine, TemplateEngine.templateTypes.map("/WEB-INF/layouts/default." + _): _*)
     engine.packagePrefix = "templates"
     engine
+  }
+
+  /**
+   * Creates a RenderContext instance for Skinny app.
+   */
+  override protected def createRenderContext(req: HttpServletRequest = request, resp: HttpServletResponse = response, out: PrintWriter = response.getWriter): RenderContext = {
+    val context = super.createRenderContext(req, resp, out)
+    context.numberFormat = numberFormat
+    context
+  }
+
+  /**
+   * Creates a DecimalFormat instance to be use by default.
+   */
+  def numberFormat: DecimalFormat = {
+    val df = new DecimalFormat
+    df.setGroupingUsed(false) // prevent commas from being inserted into numbers
+    df
   }
 
   /**

--- a/framework/src/test/resources/WEB-INF/views/foo/numeric.html.ssp
+++ b/framework/src/test/resources/WEB-INF/views/foo/numeric.html.ssp
@@ -1,0 +1,2 @@
+<%@val numericParam: Long %>
+${numericParam}

--- a/framework/src/test/scala/skinny/controller/ScalateTemplateEngineFeaturespec.scala
+++ b/framework/src/test/scala/skinny/controller/ScalateTemplateEngineFeaturespec.scala
@@ -69,11 +69,23 @@ class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAf
     get("/custom-layout/a")(a)
   }
 
+  object NumericFormatController extends SkinnyController {
+    override def scalateExtensions = List("ssp")
+
+    def a = {
+      set("numericParam" -> 12345L)
+      render("foo/numeric")
+    }
+
+    get("/numeric-format/a")(a)
+  }
+
   addFilter(DefaultController, "/*")
   addFilter(SspOnlyController, "/*")
   addFilter(JadeOnlyController, "/*")
   addFilter(AnythingButSspController, "/*")
   addFilter(CustomLayoutController, "/*")
+  addFilter(NumericFormatController, "/*")
 
   before {
     // Delete any auto-generated templates
@@ -143,6 +155,13 @@ class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAf
       status should be(200)
       body should include("<p>This is SSP template A")
       body should include("<p>Custom Jade footer")
+    }
+  }
+
+  it should "prevent commas from being inserted into numbers" in {
+    get("/numeric-format/a") {
+      status should be(200)
+      body should include("12345")
     }
   }
 }


### PR DESCRIPTION
Calling `toString` at all instance will cause weird behavior at some instance( eg call Vector, Seq, etc)

refs #11.
