### PR TITLE
Accept skinny.port as a sys prop; Add SKINNY_PORT as a supported env var

### DIFF
--- a/standalone/src/main/scala/skinny/standalone/JettyLauncher.scala
+++ b/standalone/src/main/scala/skinny/standalone/JettyLauncher.scala
@@ -13,7 +13,10 @@ import org.scalatra.servlet.ScalatraListener
 object JettyLauncher {
 
   def main(args: Array[String]) {
-    val port = getEnvVarOrSysProp("skinny.port").map(_.toInt) getOrElse 8080
+    val port = sys.env.get("SKINNY_PORT") 
+        .orElse(getEnvVarOrSysProp("skinny.port"))
+        .map(_.toInt)
+        .getOrElse(8080)
     val server = new Server(port)
     val context = new WebAppContext()
     context setContextPath "/"


### PR DESCRIPTION
Standalone app launcher was only looking for an environment variable, but it should also look
for a system property.

Added SKINNY_PORT as a supported env variable, because env vars with dots in them are quite painful to work with.
