### PR TITLE
Added packege support in generator tasks.

### DIFF
--- a/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
@@ -13,6 +13,15 @@ trait CodeGenerator {
 
   protected def toClassName(name: String) = name.head.toUpper + name.tail
 
+  protected def toNamespace(basePackage: String, namespaces: Seq[String]): String =
+    (Seq(basePackage) ++ namespaces).filter(!_.isEmpty).reduceLeft { (a, b) => a + "." + b }
+
+  protected def toDirectoryPath(baseDir: String, namespaces: Seq[String]): String =
+    (Seq(baseDir) ++ namespaces).filter(!_.isEmpty).reduceLeft { (a, b) => a + "/" + b }
+
+  protected def toResourcesBasePath(namespaces: Seq[String]): String = if (namespaces.filter(!_.isEmpty).isEmpty) ""
+  else "/" + namespaces.filter(!_.isEmpty).reduceLeft { (a, b) => a + "/" + b }
+
   protected def toControllerClassName(name: String) = toClassName(name) + "Controller"
 
   protected def isOptionClassName(t: String): Boolean = t.trim().startsWith("Option")

--- a/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
@@ -26,8 +26,10 @@ trait ModelGenerator extends CodeGenerator {
   }
 
   def run(args: List[String]) {
-    args.toList match {
-      case name :: attributes =>
+    val completedArgs: Seq[String] = if (args(1).contains(":")) Seq("") ++ args
+    else args
+    completedArgs.toList match {
+      case namespace :: name :: attributes =>
         showSkinnyGenerator()
         val attributePairs: Seq[(String, String)] = attributes.flatMap { attribute =>
           attribute.toString.split(":") match {
@@ -35,14 +37,15 @@ trait ModelGenerator extends CodeGenerator {
             case _ => None
           }
         }
-        generate(name, None, attributePairs)
+        generate(namespace.split('.'), name, None, attributePairs)
         println("")
 
       case _ => showUsage
     }
   }
 
-  def code(name: String, tableName: Option[String], attributePairs: Seq[(String, String)]): String = {
+  def code(namespaces: Seq[String], name: String, tableName: Option[String], attributePairs: Seq[(String, String)]): String = {
+    val namespace = toNamespace("model", namespaces)
     val modelClassName = toClassName(name)
     val alias = modelClassName.filter(_.isUpper).map(_.toLower).mkString
     val timestampsTraitIfExists = if (withTimestamps) s"with TimestampsFeature[${modelClassName}] " else ""
@@ -69,7 +72,7 @@ trait ModelGenerator extends CodeGenerator {
         |${if (attributePairs.isEmpty) "" else attributePairs.map { case (k, t) => "    " + k + " = rs.get(rn." + k + ")" }.mkString("", ",\n", ",\n")}${timestampsExtraction}
         |""".stripMargin
 
-    s"""package model
+    s"""package ${namespace}
         |
         |import skinny.orm._, feature._
         |import scalikejdbc._, SQLInterpolation._
@@ -89,13 +92,13 @@ trait ModelGenerator extends CodeGenerator {
         |""".stripMargin
   }
 
-  def generate(name: String, tableName: Option[String], attributePairs: Seq[(String, String)]) {
-    val productionFile = new File(s"src/main/scala/model/${toClassName(name)}.scala")
-    writeIfAbsent(productionFile, code(name, tableName, attributePairs))
+  def generate(namespaces: Seq[String], name: String, tableName: Option[String], attributePairs: Seq[(String, String)]) {
+    val productionFile = new File(s"src/main/scala/${toDirectoryPath("model", namespaces)}/${toClassName(name)}.scala")
+    writeIfAbsent(productionFile, code(namespaces, name, tableName, attributePairs))
   }
 
-  def spec(name: String): String = {
-    s"""package model
+  def spec(namespaces: Seq[String], name: String): String = {
+    s"""package ${toNamespace("model", namespaces)}
         |
         |import skinny.test._
         |import org.scalatest.fixture.FlatSpec
@@ -108,10 +111,10 @@ trait ModelGenerator extends CodeGenerator {
         |""".stripMargin
   }
 
-  def generateSpec(name: String, attributePairs: Seq[(String, String)]) {
-    val specFile = new File(s"src/test/scala/model/${toClassName(name)}Spec.scala")
+  def generateSpec(namespaces: Seq[String], name: String, attributePairs: Seq[(String, String)]) {
+    val specFile = new File(s"src/test/scala/${toDirectoryPath("model", namespaces)}/${toClassName(name)}Spec.scala")
     FileUtils.forceMkdir(specFile.getParentFile)
-    writeIfAbsent(specFile, spec(name))
+    writeIfAbsent(specFile, spec(namespaces, name))
   }
 
 }

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -89,9 +89,12 @@ trait ScaffoldGenerator extends CodeGenerator {
       return
     }
 
-    args match {
-      case rs :: r :: attributes =>
-        val (resources, resource) = (toFirstCharLower(rs), toFirstCharLower(r))
+    val completedArgs = if (args(2).contains(":")) Seq("") ++ args
+    else args
+
+    completedArgs match {
+      case ns :: rs :: r :: attributes =>
+        val (namespaces, resources, resource) = (ns.split('.'), toFirstCharLower(rs), toFirstCharLower(r))
         val errorMessages = attributes.flatMap {
           case attr if !attr.contains(":") => Some(s"Invalid parameter (${attr}) found. Scaffold parameter must be delimited with colon(:)")
           case attr => attr.split(":") match {
@@ -116,9 +119,9 @@ trait ScaffoldGenerator extends CodeGenerator {
 
           // Controller
           generateApplicationControllerIfAbsent()
-          generateResourceController(resources, resource, template, generatorArgs)
-          appendToScalatraBootstrap(resources)
-          generateResourceControllerSpec(resources, resource, attributePairs)
+          generateResourceController(namespaces, resources, resource, template, generatorArgs)
+          appendToScalatraBootstrap(namespaces, resources)
+          generateResourceControllerSpec(namespaces, resources, resource, attributePairs)
           appendToFactoriesConf(resource, attributePairs)
 
           // Model
@@ -127,15 +130,15 @@ trait ScaffoldGenerator extends CodeGenerator {
             override def primaryKeyName = self.primaryKeyName
             override def withTimestamps = self.withTimestamps
           }
-          modelGenerator.generate(resource, tableName.orElse(Some(toSnakeCase(resources))), attributePairs)
-          modelGenerator.generateSpec(resource, attributePairs)
+          modelGenerator.generate(namespaces, resource, tableName.orElse(Some(toSnakeCase(resources))), attributePairs)
+          modelGenerator.generateSpec(namespaces, resource, attributePairs)
 
           // Views
-          generateFormView(resources, resource, attributePairs)
-          generateNewView(resources, resource, attributePairs)
-          generateEditView(resources, resource, attributePairs)
-          generateIndexView(resources, resource, attributePairs)
-          generateShowView(resources, resource, attributePairs)
+          generateFormView(namespaces, resources, resource, attributePairs)
+          generateNewView(namespaces, resources, resource, attributePairs)
+          generateEditView(namespaces, resources, resource, attributePairs)
+          generateIndexView(namespaces, resources, resource, attributePairs)
+          generateShowView(namespaces, resources, resource, attributePairs)
 
           // messages.conf
           generateMessages(resources, resource, attributePairs)
@@ -178,7 +181,8 @@ trait ScaffoldGenerator extends CodeGenerator {
       """.stripMargin)
   }
 
-  def controllerCode(resources: String, resource: String, template: String, args: Seq[ScaffoldGeneratorArg]): String = {
+  def controllerCode(namespaces: Seq[String], resources: String, resource: String, template: String, args: Seq[ScaffoldGeneratorArg]): String = {
+    val namespace = toNamespace("controller", namespaces)
     val controllerClassName = toClassName(resources) + "Controller"
     val modelClassName = toClassName(resource)
 
@@ -217,11 +221,12 @@ trait ScaffoldGenerator extends CodeGenerator {
         }
     }.mkString
 
-    s"""package controller
+    s"""package ${namespace}
         |
         |import skinny._
         |import skinny.validator._
-        |import model.${modelClassName}
+        |import _root_.controller._
+        |import ${toNamespace("model", namespaces)}.${modelClassName}
         |
         |object ${controllerClassName} extends SkinnyResource with ApplicationController {
         |  protectFromForgery()
@@ -230,7 +235,8 @@ trait ScaffoldGenerator extends CodeGenerator {
         |  override def resourcesName = "${resources}"
         |  override def resourceName = "${resource}"${primaryKeyNameIfNotId}
         |
-        |  override def resourcesBasePath = s"/$${toSnakeCase(resourcesName)}"
+        |  override def resourcesBasePath = s"${toResourcesBasePath(namespaces)}/$${toSnakeCase(resourcesName)}"
+        |  override def viewsDirectoryPath = s"${toResourcesBasePath(namespaces)}/$${toSnakeCase(resourcesName)}"
         |  override def useSnakeCasedParamKeys = true
         |
         |  override def createForm = validation(createParams,
@@ -253,13 +259,15 @@ trait ScaffoldGenerator extends CodeGenerator {
         |""".stripMargin
   }
 
-  def generateResourceController(resources: String, resource: String, template: String, args: Seq[ScaffoldGeneratorArg]) {
+  def generateResourceController(namespaces: Seq[String], resources: String, resource: String, template: String, args: Seq[ScaffoldGeneratorArg]) {
     val controllerClassName = toClassName(resources) + "Controller"
-    val file = new File(s"src/main/scala/controller/${controllerClassName}.scala")
-    writeIfAbsent(file, controllerCode(resources, resource, template, args))
+    val dir = toDirectoryPath("controller", namespaces)
+    val file = new File(s"src/main/scala/${dir}/${controllerClassName}.scala")
+    writeIfAbsent(file, controllerCode(namespaces, resources, resource, template, args))
   }
 
-  def controllerSpecCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  def controllerSpecCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+    val namespace = toNamespace("controller", namespaces)
     val controllerClassName = toClassName(resources) + "Controller"
     val modelClassName = toClassName(resource)
 
@@ -277,12 +285,12 @@ trait ScaffoldGenerator extends CodeGenerator {
       case (k, _) => "\"" + k + "\" -> \"dummy\""
     }.mkString(",")
 
-    s"""package controller
+    s"""package ${namespace}
         |
         |import org.scalatra.test.scalatest._
         |import skinny._, test._
         |import org.joda.time._
-        |import model._
+        |import ${toNamespace("model", namespaces)}._
         |
         |class ${controllerClassName}Spec extends ScalatraFlatSpec with SkinnyTestSupport with DBSettings {
         |  addFilter(${controllerClassName}, "/*")
@@ -290,45 +298,45 @@ trait ScaffoldGenerator extends CodeGenerator {
         |  def ${resource} = FactoryGirl(${modelClassName}).create()
         |
         |  it should "show ${resources}" in {
-        |    get("/${toSnakeCase(resources)}") {
+        |    get("${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}") {
         |      status should equal(200)
         |    }
-        |    get("/${toSnakeCase(resources)}/") {
+        |    get("${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/") {
         |      status should equal(200)
         |    }
-        |    get("/${toSnakeCase(resources)}.json") {
+        |    get("${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}.json") {
         |      status should equal(200)
         |    }
-        |    get("/${toSnakeCase(resources)}.xml") {
+        |    get("${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}.xml") {
         |      status should equal(200)
         |    }
         |  }
         |
         |  it should "show a ${resource} in detail" in {
-        |    get(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}") {
+        |    get(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}") {
         |      status should equal(200)
         |    }
-        |    get(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}.xml") {
+        |    get(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}.xml") {
         |      status should equal(200)
         |    }
-        |    get(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}.json") {
+        |    get(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}.json") {
         |      status should equal(200)
         |    }
         |  }
         |
         |  it should "show new entry form" in {
-        |    get(s"/${toSnakeCase(resources)}/new") {
+        |    get(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/new") {
         |      status should equal(200)
         |    }
         |  }
         |
         |  it should "create a ${resource}" in {
-        |    post(s"/${toSnakeCase(resources)}", ${params}) {
+        |    post(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}", ${params}) {
         |      status should equal(403)
         |    }
         |
         |    withSession("csrf-token" -> "12345") {
-        |      post(s"/${toSnakeCase(resources)}", ${params}, "csrf-token" -> "12345") {
+        |      post(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}", ${params}, "csrf-token" -> "12345") {
         |        status should equal(302)
         |        val id = header("Location").split("/").last.toLong
         |        ${modelClassName}.findById(id).isDefined should equal(true)
@@ -337,18 +345,18 @@ trait ScaffoldGenerator extends CodeGenerator {
         |  }
         |
         |  it should "show the edit form" in {
-        |    get(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}/edit") {
+        |    get(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}/edit") {
         |      status should equal(200)
         |    }
         |  }
         |
         |  it should "update a ${resource}" in {
-        |    put(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}", ${params}) {
+        |    put(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}", ${params}) {
         |      status should equal(403)
         |    }
         |
         |    withSession("csrf-token" -> "12345") {
-        |      put(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}", ${params}, "csrf-token" -> "12345") {
+        |      put(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}", ${params}, "csrf-token" -> "12345") {
         |        status should equal(302)
         |      }
         |    }
@@ -356,11 +364,11 @@ trait ScaffoldGenerator extends CodeGenerator {
         |
         |  it should "delete a ${resource}" in {
         |    val ${resource} = FactoryGirl(${modelClassName}).create()
-        |    delete(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}") {
+        |    delete(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}") {
         |      status should equal(403)
         |    }
         |    withSession("csrf-token" -> "aaaaaa") {
-        |      delete(s"/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}?csrf-token=aaaaaa") {
+        |      delete(s"${toResourcesBasePath(namespaces)}/${toSnakeCase(resources)}/$${${resource}.${primaryKeyName}}?csrf-token=aaaaaa") {
         |        status should equal(200)
         |      }
         |    }
@@ -370,21 +378,23 @@ trait ScaffoldGenerator extends CodeGenerator {
         |""".stripMargin
   }
 
-  def generateResourceControllerSpec(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+  def generateResourceControllerSpec(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
     val controllerClassName = toClassName(resources) + "Controller"
-    val file = new File(s"src/test/scala/controller/${controllerClassName}Spec.scala")
-    writeIfAbsent(file, controllerSpecCode(resources, resource, attributePairs))
+    val dir = toDirectoryPath("controller", namespaces)
+    val file = new File(s"src/test/scala/${dir}/${controllerClassName}Spec.scala")
+    writeIfAbsent(file, controllerSpecCode(namespaces, resources, resource, attributePairs))
   }
 
   // --------------------------
   // ScalatraBootstrap.scala
   // --------------------------
 
-  def appendToScalatraBootstrap(resources: String) {
+  def appendToScalatraBootstrap(namespaces: Seq[String], resources: String) {
+    val namespace = toNamespace("_root_.controller", namespaces)
     val controllerClassName = toClassName(resources) + "Controller"
     val newCode =
       s"""override def initSkinnyApp(ctx: ServletContext) {
-        |    ${controllerClassName}.mount(ctx)""".stripMargin
+        |    ${namespace}.${controllerClassName}.mount(ctx)""".stripMargin
     val file = new File("src/main/scala/ScalatraBootstrap.scala")
     if (file.exists()) {
       val code = Source.fromFile(file).mkString.replaceFirst(
@@ -499,68 +509,73 @@ trait ScaffoldGenerator extends CodeGenerator {
   // Views
   // --------------------------
 
-  def formHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String
-  def newHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String
-  def editHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String
-  def indexHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String
-  def showHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String
+  def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String
+  def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String
+  def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String
+  def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String
+  def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String
 
-  def generateFormView(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
-    val viewDir = s"src/main/webapp/WEB-INF/views/${resources}"
+  def generateFormView(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+    val dir = toDirectoryPath("views", namespaces)
+    val viewDir = s"src/main/webapp/WEB-INF/${dir}/${resources}"
     FileUtils.forceMkdir(new File(viewDir))
     val file = new File(s"${viewDir}/_form.html.${template}")
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, formHtmlCode(resources, resource, attributePairs))
+      FileUtils.write(file, formHtmlCode(namespaces, resources, resource, attributePairs))
       println("  \"" + file.getPath + "\" created.")
     }
   }
 
-  def generateNewView(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
-    val viewDir = s"src/main/webapp/WEB-INF/views/${resources}"
+  def generateNewView(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+    val dir = toDirectoryPath("views", namespaces)
+    val viewDir = s"src/main/webapp/WEB-INF/${dir}/${resources}"
     FileUtils.forceMkdir(new File(viewDir))
     val file = new File(s"${viewDir}/new.html.${template}")
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, newHtmlCode(resources, resource, attributePairs))
+      FileUtils.write(file, newHtmlCode(namespaces, resources, resource, attributePairs))
       println("  \"" + file.getPath + "\" created.")
     }
   }
 
-  def generateEditView(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
-    val viewDir = s"src/main/webapp/WEB-INF/views/${resources}"
+  def generateEditView(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+    val dir = toDirectoryPath("views", namespaces)
+    val viewDir = s"src/main/webapp/WEB-INF/${dir}/${resources}"
     FileUtils.forceMkdir(new File(viewDir))
     val file = new File(s"${viewDir}/edit.html.${template}")
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, editHtmlCode(resources, resource, attributePairs))
+      FileUtils.write(file, editHtmlCode(namespaces, resources, resource, attributePairs))
       println("  \"" + file.getPath + "\" created.")
     }
   }
 
-  def generateIndexView(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
-    val viewDir = s"src/main/webapp/WEB-INF/views/${resources}"
+  def generateIndexView(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+    val dir = toDirectoryPath("views", namespaces)
+    val viewDir = s"src/main/webapp/WEB-INF/${dir}/${resources}"
     FileUtils.forceMkdir(new File(viewDir))
     val file = new File(s"${viewDir}/index.html.${template}")
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, indexHtmlCode(resources, resource, attributePairs))
+      FileUtils.write(file, indexHtmlCode(namespaces, resources, resource, attributePairs))
       println("  \"" + file.getPath + "\" created.")
     }
   }
 
-  def generateShowView(resources: String, resource: String, attributePairs: Seq[(String, String)]) {
-    val viewDir = s"src/main/webapp/WEB-INF/views/${resources}"
+  def generateShowView(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]) {
+    val dir = toDirectoryPath("views", namespaces)
+    val viewDir = s"src/main/webapp/WEB-INF/${dir}/${resources}"
     FileUtils.forceMkdir(new File(viewDir))
     val file = new File(s"${viewDir}/show.html.${template}")
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, showHtmlCode(resources, resource, attributePairs))
+      FileUtils.write(file, showHtmlCode(namespaces, resources, resource, attributePairs))
       println("  \"" + file.getPath + "\" created.")
     }
   }

--- a/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
@@ -14,10 +14,11 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
 
   protected override def template: String = "jade"
 
-  override def formHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     "-@val s: skinny.Skinny\n" +
       "-@val keyAndErrorMessages: skinny.KeyAndErrorMessages\n\n" +
+      s"- import ${toNamespace("controller", namespaces)}.${controllerClassName}\n\n" +
       attributePairs.toList.map { case (k, t) => (k, toParamType(t)) }.map {
         case (name, "Boolean") =>
           s"""div(class="form-group")
@@ -104,9 +105,11 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def newHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     s"""-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |h3 #{s.i18n.get("${resource}.new")}
         |hr
@@ -119,9 +122,11 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def editHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     s"""-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |h3 #{s.i18n.get("${resource}.edit")}
         |hr
@@ -134,12 +139,14 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def indexHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
     s"""-@val s: skinny.Skinny
-        |-@val items: Seq[model.${modelClassName}]
+        |-@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}]
         |-@val totalPages: Int
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |h3 #{s.i18n.get("${resource}.list")}
         |hr
@@ -174,7 +181,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def showHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
     val attributesPart = ((primaryKeyName -> "Long") :: attributePairs.toList).map {
@@ -185,8 +192,10 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
     }.mkString
 
-    s"""-@val item: model.${modelClassName}
+    s"""-@val item: ${toNamespace("model", namespaces)}.${modelClassName}
         |-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |h3 #{s.i18n.get("${resource}.detail")}
         |hr

--- a/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
@@ -14,10 +14,11 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
 
   protected override def template: String = "scaml"
 
-  override def formHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     "-@val s: skinny.Skinny\n" +
       "-@val keyAndErrorMessages: skinny.KeyAndErrorMessages\n\n" +
+      s"- import ${toNamespace("controller", namespaces)}.${controllerClassName}\n\n" +
       attributePairs.toList.map { case (k, t) => (k, toParamType(t)) }.map {
         case (name, "Boolean") =>
           s"""%div(class="form-group")
@@ -104,9 +105,11 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def newHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     s"""-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |%h3 #{s.i18n.get("${resource}.new")}
         |%hr
@@ -119,9 +122,11 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def editHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     s"""-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |%h3 #{s.i18n.get("${resource}.edit")}
         |%hr
@@ -134,12 +139,14 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def indexHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
     s"""-@val s: skinny.Skinny
-        |-@val items: Seq[model.${modelClassName}]
+        |-@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}]
         |-@val totalPages: Int
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |%h3 #{s.i18n.get("${resource}.list")}
         |%hr
@@ -174,7 +181,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def showHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
 
@@ -186,8 +193,10 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
     }.mkString
 
-    s"""-@val item: model.${modelClassName}
+    s"""-@val item: ${toNamespace("model", namespaces)}.${modelClassName}
         |-@val s: skinny.Skinny
+        |
+        |- import ${toNamespace("controller", namespaces)}.${controllerClassName}
         |
         |%h3 #{s.i18n.get("${resource}.detail")}
         |%hr

--- a/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
@@ -12,10 +12,12 @@ object ScaffoldSspGenerator extends ScaffoldSspGenerator
  */
 trait ScaffoldSspGenerator extends ScaffoldGenerator {
 
-  override def formHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
+    val importController = s"${toNamespace("controller", namespaces)}.${controllerClassName}"
     "<%@val s: skinny.Skinny %>\n" +
       "<%@val keyAndErrorMessages: skinny.KeyAndErrorMessages %>\n\n" +
+      s"<% import ${importController} %>\n\n" +
       attributePairs.toList.map { case (k, t) => (k, toParamType(t)) }.map {
         case (name, "Boolean") =>
           s"""<div class="form-group">
@@ -150,9 +152,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def newHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
+    val importController = s"${toNamespace("controller", namespaces)}.${controllerClassName}"
     s"""<%@val s: skinny.Skinny %>
+        |
+        |<% import ${importController} %>
         |
         |<h3>$${s.i18n.get("${resource}.new")}</h3>
         |<hr/>
@@ -168,9 +173,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def editHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
+    val importController = s"${toNamespace("controller", namespaces)}.${controllerClassName}"
     s"""<%@val s: skinny.Skinny %>
+        |
+        |<% import ${importController} %>
         |
         |<h3>$${s.i18n.get("${resource}.edit")}</h3>
         |<hr/>
@@ -186,12 +194,15 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def indexHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
+    val importController = s"${toNamespace("controller", namespaces)}.${controllerClassName}"
     s"""<%@val s: skinny.Skinny %>
-        |<%@val items: Seq[model.${modelClassName}] %>
+        |<%@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}] %>
         |<%@val totalPages: Int %>
+        |
+        |<% import ${importController} %>
         |
         |<h3>$${s.i18n.get("${resource}.list")}</h3>
         |<hr/>
@@ -241,9 +252,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |""".stripMargin
   }
 
-  override def showHtmlCode(resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
+  override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerClassName = toControllerClassName(resources)
     val modelClassName = toClassName(resource)
+    val controllerNamespace = toNamespace("controller", namespaces)
+    val modelNamespace = toNamespace("model", namespaces)
+    val importController = s"${controllerNamespace}.${controllerClassName}"
     val attributesPart = ((primaryKeyName -> "Long") :: attributePairs.toList).map {
       case (name, _) =>
         s"""  <tr>
@@ -253,8 +267,10 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |""".stripMargin
     }.mkString
 
-    s"""<%@val item: model.${modelClassName} %>
+    s"""<%@val item: ${modelNamespace}.${modelClassName} %>
         |<%@val s: skinny.Skinny %>
+        |
+        |<% import ${importController} %>
         |
         |<h3>$${s.i18n.get("${resource}.detail")}</h3>
         |<hr/>

--- a/task/src/test/scala/skinny/task/generator/ControllerGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ControllerGeneratorSpec.scala
@@ -9,9 +9,9 @@ class ControllerGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("Controller") {
     it("should be created as expected") {
-      val code = generator.code("members")
+      val code = generator.code(Seq("admin"), "members")
       val expected =
-        """package controller
+        """package controller.admin
           |
           |import skinny._
           |import skinny.validator._
@@ -19,7 +19,7 @@ class ControllerGeneratorSpec extends FunSpec with ShouldMatchers {
           |class MembersController extends ApplicationController {
           |  protectFromForgery()
           |
-          |  def index = render("/members/index")
+          |  def index = render("/admin/members/index")
           |
           |}
           |""".stripMargin
@@ -29,9 +29,9 @@ class ControllerGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("ControllerSpec") {
     it("should be created as expected") {
-      val code = generator.spec("members")
+      val code = generator.spec(Seq("admin"), "members")
       val expected =
-        """package controller
+        """package controller.admin
           |
           |import _root_.controller._
           |import _root_.model._

--- a/task/src/test/scala/skinny/task/generator/ModelGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ModelGeneratorSpec.scala
@@ -9,13 +9,13 @@ class ModelGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("Model") {
     it("should be created as expected with tableName") {
-      val code = generator.code("member", Some("members"), Seq(
+      val code = generator.code(Seq("admin"), "member", Some("members"), Seq(
         "name" -> "String",
         "isActivated" -> "Boolean",
         "birthday" -> "Option[LocalDate]"
       ))
       val expected =
-        """package model
+        """package model.admin
           |
           |import skinny.orm._, feature._
           |import scalikejdbc._, SQLInterpolation._
@@ -49,13 +49,13 @@ class ModelGeneratorSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should be created as expected without tableName") {
-      val code = generator.code("projectMember", None, Seq(
+      val code = generator.code(Seq("admin"), "projectMember", None, Seq(
         "name" -> "String",
         "isActivated" -> "Boolean",
         "birthday" -> "Option[LocalDate]"
       ))
       val expected =
-        """package model
+        """package model.admin
           |
           |import skinny.orm._, feature._
           |import scalikejdbc._, SQLInterpolation._
@@ -89,9 +89,9 @@ class ModelGeneratorSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should be created as expected without attributes") {
-      val code = generator.code("member", None, Seq())
+      val code = generator.code(Seq("admin"), "member", None, Seq())
       val expected =
-        """package model
+        """package model.admin
           |
           |import skinny.orm._, feature._
           |import scalikejdbc._, SQLInterpolation._
@@ -121,9 +121,9 @@ class ModelGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("Model") {
     it("should be created as expected") {
-      val code = generator.spec("projectMember")
+      val code = generator.spec(Seq("admin"), "projectMember")
       val expected =
-        """package model
+        """package model.admin
           |
           |import skinny.test._
           |import org.scalatest.fixture.FlatSpec

--- a/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
@@ -9,7 +9,7 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("Controller (SkinnyResource)") {
     it("should be created as expected") {
-      val code = generator.controllerCode("members", "member", "ssp", Seq(
+      val code = generator.controllerCode(Seq("admin"), "members", "member", "ssp", Seq(
         ScaffoldGeneratorArg("name", "String", None),
         ScaffoldGeneratorArg("favoriteIntNumber", "Int", None),
         ScaffoldGeneratorArg("favoriteLongNumber", "Long", None),
@@ -24,11 +24,12 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
 
       val expected =
-        """package controller
+        """package controller.admin
           |
           |import skinny._
           |import skinny.validator._
-          |import model.Member
+          |import _root_.controller._
+          |import model.admin.Member
           |
           |object MembersController extends SkinnyResource with ApplicationController {
           |  protectFromForgery()
@@ -37,7 +38,8 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
           |  override def resourcesName = "members"
           |  override def resourceName = "member"
           |
-          |  override def resourcesBasePath = s"/${toSnakeCase(resourcesName)}"
+          |  override def resourcesBasePath = s"/admin/${toSnakeCase(resourcesName)}"
+          |  override def viewsDirectoryPath = s"/admin/${toSnakeCase(resourcesName)}"
           |  override def useSnakeCasedParamKeys = true
           |
           |  override def createForm = validation(createParams,
@@ -102,7 +104,7 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("Spec for Controller (SkinnyResource)") {
     it("should be created as expected") {
-      val code = generator.controllerSpecCode("members", "member", Seq(
+      val code = generator.controllerSpecCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteIntNumber" -> "Int",
         "favoriteLongNumber" -> "Long",
@@ -114,12 +116,12 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
 
       val expected =
-        """package controller
+        """package controller.admin
           |
           |import org.scalatra.test.scalatest._
           |import skinny._, test._
           |import org.joda.time._
-          |import model._
+          |import model.admin._
           |
           |class MembersControllerSpec extends ScalatraFlatSpec with SkinnyTestSupport with DBSettings {
           |  addFilter(MembersController, "/*")
@@ -127,45 +129,45 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
           |  def member = FactoryGirl(Member).create()
           |
           |  it should "show members" in {
-          |    get("/members") {
+          |    get("/admin/members") {
           |      status should equal(200)
           |    }
-          |    get("/members/") {
+          |    get("/admin/members/") {
           |      status should equal(200)
           |    }
-          |    get("/members.json") {
+          |    get("/admin/members.json") {
           |      status should equal(200)
           |    }
-          |    get("/members.xml") {
+          |    get("/admin/members.xml") {
           |      status should equal(200)
           |    }
           |  }
           |
           |  it should "show a member in detail" in {
-          |    get(s"/members/${member.id}") {
+          |    get(s"/admin/members/${member.id}") {
           |      status should equal(200)
           |    }
-          |    get(s"/members/${member.id}.xml") {
+          |    get(s"/admin/members/${member.id}.xml") {
           |      status should equal(200)
           |    }
-          |    get(s"/members/${member.id}.json") {
+          |    get(s"/admin/members/${member.id}.json") {
           |      status should equal(200)
           |    }
           |  }
           |
           |  it should "show new entry form" in {
-          |    get(s"/members/new") {
+          |    get(s"/admin/members/new") {
           |      status should equal(200)
           |    }
           |  }
           |
           |  it should "create a member" in {
-          |    post(s"/members", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd")) {
+          |    post(s"/admin/members", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd")) {
           |      status should equal(403)
           |    }
           |
           |    withSession("csrf-token" -> "12345") {
-          |      post(s"/members", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd"), "csrf-token" -> "12345") {
+          |      post(s"/admin/members", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd"), "csrf-token" -> "12345") {
           |        status should equal(302)
           |        val id = header("Location").split("/").last.toLong
           |        Member.findById(id).isDefined should equal(true)
@@ -174,18 +176,18 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
           |  }
           |
           |  it should "show the edit form" in {
-          |    get(s"/members/${member.id}/edit") {
+          |    get(s"/admin/members/${member.id}/edit") {
           |      status should equal(200)
           |    }
           |  }
           |
           |  it should "update a member" in {
-          |    put(s"/members/${member.id}", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd")) {
+          |    put(s"/admin/members/${member.id}", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd")) {
           |      status should equal(403)
           |    }
           |
           |    withSession("csrf-token" -> "12345") {
-          |      put(s"/members/${member.id}", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd"), "csrf-token" -> "12345") {
+          |      put(s"/admin/members/${member.id}", "name" -> "dummy","favorite_int_number" -> Int.MaxValue.toString(),"favorite_long_number" -> Long.MaxValue.toString(),"favorite_short_number" -> Short.MaxValue.toString(),"favorite_double_number" -> Double.MaxValue.toString(),"favorite_float_number" -> Float.MaxValue.toString(),"is_activated" -> "true","birthday" -> new LocalDate().toString("YYYY-MM-dd"), "csrf-token" -> "12345") {
           |        status should equal(302)
           |      }
           |    }
@@ -193,11 +195,11 @@ class ScaffoldGeneratorSpec extends FunSpec with ShouldMatchers {
           |
           |  it should "delete a member" in {
           |    val member = FactoryGirl(Member).create()
-          |    delete(s"/members/${member.id}") {
+          |    delete(s"/admin/members/${member.id}") {
           |      status should equal(403)
           |    }
           |    withSession("csrf-token" -> "aaaaaa") {
-          |      delete(s"/members/${member.id}?csrf-token=aaaaaa") {
+          |      delete(s"/admin/members/${member.id}?csrf-token=aaaaaa") {
           |        status should equal(200)
           |      }
           |    }

--- a/task/src/test/scala/skinny/task/generator/ScaffoldJadeGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldJadeGeneratorSpec.scala
@@ -9,7 +9,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/_form.html.jade") {
     it("should be created as expected") {
-      val code = generator.formHtmlCode("members", "member", Seq(
+      val code = generator.formHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -20,6 +20,8 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
       val expected =
         """-@val s: skinny.Skinny
           |-@val keyAndErrorMessages: skinny.KeyAndErrorMessages
+          |
+          |- import controller.admin.MembersController
           |
           |div(class="form-group")
           |  label(class="control-label" for="name") #{s.i18n.get("member.name")}
@@ -85,7 +87,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/new.html.jade") {
     it("should be created as expected") {
-      val code = generator.newHtmlCode("members", "member", Seq(
+      val code = generator.newHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -95,6 +97,8 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |h3 #{s.i18n.get("member.new")}
           |hr
@@ -111,7 +115,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/edit.html.jade") {
     it("should be created as expected") {
-      val code = generator.editHtmlCode("members", "member", Seq(
+      val code = generator.editHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -121,6 +125,8 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |h3 #{s.i18n.get("member.edit")}
           |hr
@@ -137,7 +143,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/index.html.jade") {
     it("should be created as expected") {
-      val code = generator.indexHtmlCode("members", "member", Seq(
+      val code = generator.indexHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -147,8 +153,10 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
-          |-@val items: Seq[model.Member]
+          |-@val items: Seq[model.admin.Member]
           |-@val totalPages: Int
+          |
+          |- import controller.admin.MembersController
           |
           |h3 #{s.i18n.get("member.list")}
           |hr
@@ -197,7 +205,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/show.html.jade") {
     it("should be created as expected") {
-      val code = generator.showHtmlCode("members", "member", Seq(
+      val code = generator.showHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -206,8 +214,10 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
 
       val expected =
-        """-@val item: model.Member
+        """-@val item: model.admin.Member
           |-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |h3 #{s.i18n.get("member.detail")}
           |hr

--- a/task/src/test/scala/skinny/task/generator/ScaffoldScamlGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldScamlGeneratorSpec.scala
@@ -9,7 +9,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/_form.html.scaml") {
     it("should be created as expected") {
-      val code = generator.formHtmlCode("members", "member", Seq(
+      val code = generator.formHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -20,6 +20,8 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
       val expected =
         """-@val s: skinny.Skinny
           |-@val keyAndErrorMessages: skinny.KeyAndErrorMessages
+          |
+          |- import controller.admin.MembersController
           |
           |%div(class="form-group")
           |  %label(class="control-label" for="name") #{s.i18n.get("member.name")}
@@ -85,7 +87,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/new.html.scaml") {
     it("should be created as expected") {
-      val code = generator.newHtmlCode("members", "member", Seq(
+      val code = generator.newHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -95,6 +97,8 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |%h3 #{s.i18n.get("member.new")}
           |%hr
@@ -111,7 +115,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/edit.html.scaml") {
     it("should be created as expected") {
-      val code = generator.editHtmlCode("members", "member", Seq(
+      val code = generator.editHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -121,6 +125,8 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |%h3 #{s.i18n.get("member.edit")}
           |%hr
@@ -137,7 +143,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/index.html.scaml") {
     it("should be created as expected") {
-      val code = generator.indexHtmlCode("members", "member", Seq(
+      val code = generator.indexHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -147,8 +153,10 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
       val expected =
         """-@val s: skinny.Skinny
-          |-@val items: Seq[model.Member]
+          |-@val items: Seq[model.admin.Member]
           |-@val totalPages: Int
+          |
+          |- import controller.admin.MembersController
           |
           |%h3 #{s.i18n.get("member.list")}
           |%hr
@@ -197,7 +205,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/show.html.scaml") {
     it("should be created as expected") {
-      val code = generator.showHtmlCode("members", "member", Seq(
+      val code = generator.showHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -206,8 +214,10 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
 
       val expected =
-        """-@val item: model.Member
+        """-@val item: model.admin.Member
           |-@val s: skinny.Skinny
+          |
+          |- import controller.admin.MembersController
           |
           |%h3 #{s.i18n.get("member.detail")}
           |%hr

--- a/task/src/test/scala/skinny/task/generator/ScaffoldSspGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldSspGeneratorSpec.scala
@@ -9,7 +9,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/_form.html.ssp") {
     it("should be created as expected") {
-      val code = generator.formHtmlCode("members", "member", Seq(
+      val code = generator.formHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -20,6 +20,8 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
       val expected =
         """<%@val s: skinny.Skinny %>
           |<%@val keyAndErrorMessages: skinny.KeyAndErrorMessages %>
+          |
+          |<% import controller.admin.MembersController %>
           |
           |<div class="form-group">
           |  <label class="control-label" for="name">
@@ -126,7 +128,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/new.html.ssp") {
     it("should be created as expected") {
-      val code = generator.newHtmlCode("members", "member", Seq(
+      val code = generator.newHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -135,6 +137,8 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
       val expected =
         """<%@val s: skinny.Skinny %>
+          |
+          |<% import controller.admin.MembersController %>
           |
           |<h3>${s.i18n.get("member.new")}</h3>
           |<hr/>
@@ -154,7 +158,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/edit.html.ssp") {
     it("should be created as expected") {
-      val code = generator.editHtmlCode("members", "member", Seq(
+      val code = generator.editHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -163,6 +167,8 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
       val expected =
         """<%@val s: skinny.Skinny %>
+          |
+          |<% import controller.admin.MembersController %>
           |
           |<h3>${s.i18n.get("member.edit")}</h3>
           |<hr/>
@@ -182,7 +188,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/index.html.ssp") {
     it("should be created as expected") {
-      val code = generator.indexHtmlCode("members", "member", Seq(
+      val code = generator.indexHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -191,8 +197,10 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
       ))
       val expected =
         """<%@val s: skinny.Skinny %>
-          |<%@val items: Seq[model.Member] %>
+          |<%@val items: Seq[model.admin.Member] %>
           |<%@val totalPages: Int %>
+          |
+          |<% import controller.admin.MembersController %>
           |
           |<h3>${s.i18n.get("member.list")}</h3>
           |<hr/>
@@ -256,7 +264,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
 
   describe("/show.html.ssp") {
     it("should be created as expected") {
-      val code = generator.showHtmlCode("members", "member", Seq(
+      val code = generator.showHtmlCode(Seq("admin"), "members", "member", Seq(
         "name" -> "String",
         "favoriteNumber" -> "Long",
         "magicNumber" -> "Option[Int]",
@@ -264,8 +272,10 @@ class ScaffoldSspGeneratorSpec extends FunSpec with ShouldMatchers {
         "birthday" -> "Option[LocalDate]"
       ))
       val expected =
-        """<%@val item: model.Member %>
+        """<%@val item: model.admin.Member %>
           |<%@val s: skinny.Skinny %>
+          |
+          |<% import controller.admin.MembersController %>
           |
           |<h3>${s.i18n.get("member.detail")}</h3>
           |<hr/>


### PR DESCRIPTION
```
./skinny g scaffold:jade blog entries entry title:String body:String
```

will generate

src/main/scala/controller/blog/EntriesController.scala
src/main/scala/model/blog/Entry.scala
src/main/webapp/WEB-INF/views/blog/entries/*.jade
src/test/scala/controller/blog/EntriesControllerSpec.scala

```
./skinny g scaffold:jade entries entry title:String body:String
```

will generate

src/main/scala/controller/EntriesController.scala
src/main/scala/model/Entry.scala
src/main/webapp/WEB-INF/views/entries/*.jade
src/test/scala/controller/EntriesControllerSpec.scala
