### PR TITLE
Fixed: ModelGenerator doesn't shows Usage when arguments is not enough

### DIFF
--- a/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
@@ -26,7 +26,7 @@ trait ModelGenerator extends CodeGenerator {
   }
 
   def run(args: List[String]) {
-    val completedArgs: Seq[String] = if (args(1).contains(":")) Seq("") ++ args
+    val completedArgs: Seq[String] = if (args.size >= 2 && args(1).contains(":")) Seq("") ++ args
     else args
     completedArgs.toList match {
       case namespace :: name :: attributes =>


### PR DESCRIPTION
ModelGenerator doesn't show usage, but it shows stacktrace when running the task without arguments or with 1 argument.
This change will fix it.
