### PR TITLE
Enabled set url prefix

### DIFF
--- a/standalone/src/main/scala/skinny/standalone/JettyLauncher.scala
+++ b/standalone/src/main/scala/skinny/standalone/JettyLauncher.scala
@@ -21,7 +21,9 @@ object JettyLauncher {
 
     val server = new Server(port)
     val context = new WebAppContext()
-    context setContextPath "/"
+    context setContextPath sys.env.get("SKINNY_PREFIX")
+	  .orElse(getEnvVarOrSysProp("skinny.prefix"))
+	  .getOrElse("/")
     context.setResourceBase("src/main/webapp")
     context.addEventListener(new ScalatraListener)
     context.addServlet(classOf[DefaultServlet], "/")


### PR DESCRIPTION
I added prefix option to set sub-url when you run standalone jar.
You can set context-path in a similar way to set port.

If you run standalone jar with below command,

```
java -jar -Dskinny.prefix=sub-url standalone-build/target/scala-2.10/skinny-standalone-app-assembly-0.1.0-SNAPSHOT.jar
```

application top is below url.

```
http://localhost/sub-url/
```
