### PR TITLE
Fix SkinnyMailer multibyte characters encoding failure

### DIFF
--- a/mailer/src/main/scala/skinny/mailer/JavaMailOps.scala
+++ b/mailer/src/main/scala/skinny/mailer/JavaMailOps.scala
@@ -15,7 +15,7 @@ object JavaMailOps extends Logging {
     new Transport(session, null) {
       def sendMessage(msg: Message, addresses: Array[Address]): Unit = {
         val mimeMsg = msg.asInstanceOf[MimeMessage]
-        val content = try Source.fromInputStream(mimeMsg.getInputStream).mkString
+        val content = try mimeMsg.getContent
         catch { case e: MessagingException => "" }
         logger.info {
           s"""

--- a/mailer/src/main/scala/skinny/mailer/feature/MessageBuilderFeature.scala
+++ b/mailer/src/main/scala/skinny/mailer/feature/MessageBuilderFeature.scala
@@ -56,7 +56,7 @@ trait MessageBuilderFeature extends SkinnyMailerBase {
     }
 
     def subject(subject: String): SkinnyMessageBuilder = {
-      message.subject = subject
+      message.setSubject(subject, config.charset)
       this
     }
 


### PR DESCRIPTION
Fix SkinnyMailer multibyte characters encoding failure
1. (MessageBuilderFeature) Mailer does not encode email subject including multibyte characters.
2. (JavaMailOps) Sending email including multibyte characters in logging mode, the exception occurs: "java.nio.charset.UnmappableCharacterException: Input length = 2".

These issues occur on both Windows and MacOSX.
