### PR TITLE
Fix an issue: view-templates and assets are not available in standalone

### DIFF
--- a/yeoman-generator-skinny/app/templates/skinny
+++ b/yeoman-generator-skinny/app/templates/skinny
@@ -31,8 +31,8 @@ function setup_standalone_build() {
   rm -rf standalone-build
   mkdir standalone-build
   cp -pr src standalone-build/src
-  cp -pr build.sbt standalone-build/build.sbt
-  cp -pr _skinny_assembly_settings.sbt standalone-build/build.sbt
+  cp -p build.sbt standalone-build/
+  cp -p _skinny_assembly_settings.sbt standalone-build/
 }
 function copy_resources_to_task() {
   rm -rf task/src/main/resources
@@ -157,12 +157,24 @@ assemblySettings
 mainClass in assembly := Some(\"skinny.standalone.JettyLauncher\")
 
 _root_.sbt.Keys.test in assembly := {}
+
+resourceGenerators in Compile <+= (resourceManaged, baseDirectory) map { (managedBase, base) =>
+  val webappBase = base / \"src\" / \"main\" / \"webapp\"
+  for ( (from, to) <- webappBase ** \"*\" \`pair\` rebase(webappBase, managedBase / \"main/\") )
+  yield {
+    Sync.copy(from, to)
+    to
+  }
+}
 " > "${current_dir}/_skinny_assembly_settings.sbt"
   fi
 
   setup_standalone_build
   copy_resources_to_task
-  ${sbt_path} "task/run assets:precompile" standalone-build/assembly
+  ${sbt_path} "task/run assets:precompile standalone-build"
+  rm -fr standalone-build/src/main/webapp/WEB-INF/assets
+  mv standalone-build/src/main/webapp/assets standalone-build/src/main/webapp/WEB-INF/
+  ${sbt_path} standalone-build/assembly
 elif [ "$command" == "publish" ];then
   setup_build
   copy_resources_to_task

--- a/yeoman-generator-skinny/app/templates/skinny.bat
+++ b/yeoman-generator-skinny/app/templates/skinny.bat
@@ -203,15 +203,24 @@ IF %command%==package (
 IF "%command%"=="package:standalone" (
   IF NOT EXIST "project\_skinny_assembly.sbt" (
     ECHO addSbtPlugin^(^"com.eed3si9n^" %% ^"sbt-assembly^" %% ^"0.11.2^"^) > "project\_skinny_assembly.sbt"
-
-    SET SETTINGS_FILE="_skinny_assembly_settings.sbt"
-    ECHO import AssemblyKeys._ > "_skinny_assembly_settings.sbt"
-    ECHO. >> "_skinny_assembly_settings.sbt"
-    ECHO assemblySettings >> "_skinny_assembly_settings.sbt"
-    ECHO. >> "_skinny_assembly_settings.sbt"
-    ECHO mainClass in assembly := Some^(^"skinny.standalone.JettyLauncher^"^) >> "_skinny_assembly_settings.sbt"
-    ECHO. >> "_skinny_assembly_settings.sbt"
-    ECHO _root_.sbt.Keys.test in assembly := {} >> "_skinny_assembly_settings.sbt"
+    (
+      ECHO import AssemblyKeys._
+      ECHO.
+      ECHO assemblySettings
+      ECHO.
+      ECHO mainClass in assembly := Some^(^"skinny.standalone.JettyLauncher^"^)
+      ECHO.
+      ECHO _root_.sbt.Keys.test in assembly := {}
+      ECHO.
+      ECHO.resourceGenerators in Compile ^<+= ^(resourceManaged, baseDirectory^) ^map { ^(managedBase, base^) =^>
+      ECHO.  val webappBase = base / "src" / "main" / "webapp"
+      ECHO.  for ^( ^(from, to^) ^<- ^webappBase ** "*" `pair` rebase(webappBase, managedBase / "main/"^) ^)
+      ECHO.  yield {
+      ECHO.    Sync.copy^(from, to^)
+      ECHO.    to
+      ECHO.  }
+      ECHO.}
+    )> "_skinny_assembly_settings.sbt"
   )
   RMDIR standalone-build /S /q
   MKDIR standalone-build


### PR DESCRIPTION
Please review this PR.

Running standalone.jar in the directory in which it differs from a directory I have built,
precompiled templates and assets are not available.

This PR contains 2 changes.
- adds resourceGenerators
- removes assets and copies precompiled assets to WEB-INF
