### PR TITLE
Add SkinnyNoIdCRUDMapper support into ReverseScaffoldGenerator.

### DIFF
--- a/task/src/main/scala/skinny/task/generator/ReverseScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseScaffoldGenerator.scala
@@ -42,51 +42,88 @@ trait ReverseScaffoldGenerator extends CodeGenerator {
       DBSettings.initialize()
 
       val columns = extractColumns(tableName)
-      if (columns.find(_.isPrimaryKey).isEmpty) {
-        throw new IllegalStateException(
-          s"Since this table (${tableName}}) has no primary key, generator couldn't create scaffold files")
+      val hasId = if (columns.find(_.isPrimaryKey).isEmpty) {
+        println(
+          s"""
+            |Since this table (${tableName}) has no primary key, a NoIdCRUDMapper model is created.
+            |A controller and a view are not created.
+            |""".stripMargin)
+        false
       } else if (columns.filter(_.isPrimaryKey).size > 1) {
-        throw new IllegalStateException(
-          s"Since this table (${tableName}}) has composite primary keys, generator couldn't create scaffold files")
+        println(
+          s"""
+            |Since this table (${tableName}) has composite primary key, a NoIdCRUDMapper model is created.
+            |A controller and a view are not created.
+            |""".stripMargin)
+        false
+      } else {
+        true
       }
-      val pkName = toCamelCase(columns.find(_.isPrimaryKey).get.name.toLowerCase(Locale.ENGLISH))
-      val pkType = convertJdbcSqlTypeToParamType(columns.find(_.isPrimaryKey).get.typeCode)
-      val fields = columns
-        .map(column => toScaffoldFieldDef(column))
-        .filter(param => param != "id:Long" && param != "id:Option[Long]")
-        .filter(param => !param.startsWith(pkName + ":"))
-        .map(param => toCamelCase(param))
+      val pkName = if (hasId) {
+        Some(toCamelCase(columns.find(_.isPrimaryKey).get.name.toLowerCase(Locale.ENGLISH)))
+      } else {
+        None
+      }
+      val pkType = if (hasId) {
+        Some(convertJdbcSqlTypeToParamType(columns.find(_.isPrimaryKey).get.typeCode))
+      } else {
+        None
+      }
+      val fields = if (hasId) {
+        columns
+          .map(column => toScaffoldFieldDef(column))
+          .filter(param => param != "id:Long" && param != "id:Option[Long]")
+          .filter(param => !param.startsWith(pkName.get + ":"))
+          .map(param => toCamelCase(param))
+      } else {
+        columns
+          .map(column => toScaffoldFieldDef(column))
+          .map(param => toCamelCase(param))
+      }
 
-      println(s"""
-              | *** Skinny Reverse Engineering Task ***
-              |
-              |  Table     : ${tableName}
-              |  ID        : ${pkName}:${pkType}
-              |  Resources : ${resources}
-              |  Resource  : ${resource}
-              |
-              |  Columns:
-              |${fields.map(f => s"   - ${f}").mkString("\n")}""".stripMargin)
+      println(if (hasId) {
+        s"""
+        | *** Skinny Reverse Engineering Task ***
+        |
+        |  Table     : ${tableName}
+        |  ID        : ${pkName}:${pkType}
+        |  Resources : ${resources}
+        |  Resource  : ${resource}
+        |
+        |  Columns:
+        |${fields.map(f => s"   - ${f}").mkString("\n")}""".stripMargin
+      } else {
+        s"""
+        | *** Skinny Reverse Engineering Task ***
+        |
+        |  Table     : ${tableName}
+        |
+        |  Columns:
+        |${fields.map(f => s"   - ${f}").mkString("\n")}""".stripMargin
+      })
 
       val table = tableName
       val generator = templateType match {
         case "ssp" => new ScaffoldSspGenerator {
-          override def primaryKeyName = pkName
-          override def primaryKeyType = pkType
+          override def withId = hasId
+          override def primaryKeyName = pkName.getOrElse(super.primaryKeyName)
+          override def primaryKeyType = pkType.getOrElse(super.primaryKeyType)
           override def withTimestamps: Boolean = false
           override def skipDBMigration = true
           override def tableName = Some(table)
         }
         case "scaml" => new ScaffoldScamlGenerator {
-          override def primaryKeyName = pkName
-          override def primaryKeyType = pkType
+          override def withId = hasId
+          override def primaryKeyName = pkName.getOrElse(super.primaryKeyName)
+          override def primaryKeyType = pkType.getOrElse(super.primaryKeyType)
           override def withTimestamps: Boolean = false
           override def skipDBMigration = true
           override def tableName = Some(table)
         }
         case "jade" => new ScaffoldJadeGenerator {
-          override def primaryKeyName = pkName
-          override def primaryKeyType = pkType
+          override def withId = hasId
+          override def primaryKeyName = pkName.getOrElse(super.primaryKeyName)
+          override def primaryKeyType = pkType.getOrElse(super.primaryKeyType)
           override def withTimestamps: Boolean = false
           override def skipDBMigration = true
           override def tableName = Some(table)

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -13,6 +13,8 @@ trait ScaffoldGenerator extends CodeGenerator {
 
   protected def template: String = "ssp"
 
+  protected def withId: Boolean = true
+
   protected def withTimestamps: Boolean = true
 
   protected def primaryKeyName: String = "id"
@@ -121,36 +123,41 @@ trait ScaffoldGenerator extends CodeGenerator {
           }
           val attributePairs: Seq[(String, String)] = generatorArgs.map(a => (a.name, a.typeName))
 
-          // Controller
-          generateApplicationControllerIfAbsent()
-          generateResourceController(namespaces, resources, resource, template, generatorArgs)
-          appendToControllers(namespaces, resources)
-          generateControllerSpec(namespaces, resources, resource, attributePairs)
-          generateIntegrationTestSpec(namespaces, resources, resource, attributePairs)
-          appendToFactoriesConf(resource, attributePairs)
+          if (withId) {
+            // Controller
+            generateApplicationControllerIfAbsent()
+            generateResourceController(namespaces, resources, resource, template, generatorArgs)
+            appendToControllers(namespaces, resources)
+            generateControllerSpec(namespaces, resources, resource, attributePairs)
+            generateIntegrationTestSpec(namespaces, resources, resource, attributePairs)
+            appendToFactoriesConf(resource, attributePairs)
+          }
 
           // Model
           val self = this
           val modelGenerator = new ModelGenerator {
             override def primaryKeyName = self.primaryKeyName
             override def primaryKeyType = self.primaryKeyType
+            override def withId = self.withId
             override def withTimestamps = self.withTimestamps
           }
           modelGenerator.generate(namespaces, resource, tableName.orElse(Some(toSnakeCase(resources))), attributePairs)
           modelGenerator.generateSpec(namespaces, resource, attributePairs)
 
-          // Views
-          generateFormView(namespaces, resources, resource, attributePairs)
-          generateNewView(namespaces, resources, resource, attributePairs)
-          generateEditView(namespaces, resources, resource, attributePairs)
-          generateIndexView(namespaces, resources, resource, attributePairs)
-          generateShowView(namespaces, resources, resource, attributePairs)
+          if (withId) {
+            // Views
+            generateFormView(namespaces, resources, resource, attributePairs)
+            generateNewView(namespaces, resources, resource, attributePairs)
+            generateEditView(namespaces, resources, resource, attributePairs)
+            generateIndexView(namespaces, resources, resource, attributePairs)
+            generateShowView(namespaces, resources, resource, attributePairs)
 
-          // messages.conf
-          generateMessages(resources, resource, attributePairs)
+            // messages.conf
+            generateMessages(resources, resource, attributePairs)
+          }
 
           // migration SQL
-          generateMigrationSQL(resources, resource, generatorArgs, skipDBMigration)
+          generateMigrationSQL(resources, resource, generatorArgs, skipDBMigration, withId)
 
           println("")
 
@@ -228,6 +235,7 @@ trait ScaffoldGenerator extends CodeGenerator {
         }
     }.mkString
 
+    val resourceNameLine = s"""override def resourceName = "${resource}"${primaryKeyNameIfNotId}"""
     s"""package ${namespace}
         |
         |import skinny._
@@ -240,7 +248,7 @@ trait ScaffoldGenerator extends CodeGenerator {
         |
         |  override def model = ${modelClassName}
         |  override def resourcesName = "${resources}"
-        |  override def resourceName = "${resource}"${primaryKeyNameIfNotId}
+        |  ${resourceNameLine}
         |
         |  override def resourcesBasePath = s"${toResourcesBasePath(namespaces)}/$${toSnakeCase(resourcesName)}"
         |  override def useSnakeCasedParamKeys = true
@@ -662,7 +670,7 @@ trait ScaffoldGenerator extends CodeGenerator {
   // Flyway migration SQL
   // --------------------------
 
-  def migrationSQL(resources: String, resource: String, generatorArgs: Seq[ScaffoldGeneratorArg]): String = {
+  def migrationSQL(resources: String, resource: String, generatorArgs: Seq[ScaffoldGeneratorArg], withId: Boolean = true): String = {
     val name = tableName.getOrElse(toSnakeCase(resources))
     val columns = generatorArgs.map { a =>
       s"  ${toSnakeCase(a.name)} ${a.columnName.getOrElse(toDBType(a.typeName))}" +
@@ -674,18 +682,26 @@ trait ScaffoldGenerator extends CodeGenerator {
       |  updated_at timestamp not null""".stripMargin
     } else ""
 
-    s"""-- For H2 Database
-        |create table ${name} (
-        |  ${toSnakeCase(primaryKeyName)} bigserial not null primary key,
-        |${columns}${timestamps}
-        |)
-        |""".stripMargin
+    if (withId) {
+      s"""-- For H2 Database
+          |create table ${name} (
+          |  ${toSnakeCase(primaryKeyName)} bigserial not null primary key,
+          |${columns}${timestamps}
+          |)
+          |""".stripMargin
+    } else {
+      s"""-- For H2 Database : Please add suitable restrictions if needed.
+          |create table ${name} (
+          |${columns}${timestamps}
+          |)
+          |""".stripMargin
+    }
   }
 
-  def generateMigrationSQL(resources: String, resource: String, generatorArgs: Seq[ScaffoldGeneratorArg], skip: Boolean) {
+  def generateMigrationSQL(resources: String, resource: String, generatorArgs: Seq[ScaffoldGeneratorArg], skip: Boolean, withId: Boolean) {
     val version = DateTime.now.toString("yyyyMMddHHmmss")
     val file = new File(s"src/main/resources/db/migration/V${version}__Create_${resources}_table.sql")
-    val sql = migrationSQL(resources, resource, generatorArgs)
+    val sql = migrationSQL(resources, resource, generatorArgs, withId)
     writeIfAbsent(file, if (skip) s"/*\n${sql}\n*/" else sql)
   }
 

--- a/task/src/test/scala/skinny/task/generator/ModelGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ModelGeneratorSpec.scala
@@ -184,4 +184,162 @@ class ModelGeneratorSpec extends FunSpec with ShouldMatchers {
     }
   }
 
+  describe("NoIdModel") {
+    it("should be created as expected with tableName") {
+      val generator = new ModelGenerator {
+        override def withId = false
+      }
+      val code = generator.code(Seq("admin"), "noIdMember", Some("no_id_members"), Seq(
+        "name" -> "String",
+        "isActivated" -> "Boolean",
+        "bytes" -> "ByteArray",
+        "bytesOpt" -> "Option[ByteArray]",
+        "birthday" -> "Option[LocalDate]"
+      ))
+      val expected = """package model.admin
+                       |
+                       |import skinny.orm._, feature._
+                       |import scalikejdbc._, SQLInterpolation._
+                       |import org.joda.time._
+                       |
+                       |// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+                       |case class NoIdMember(
+                       |  name: String,
+                       |  isActivated: Boolean,
+                       |  bytes: Array[Byte],
+                       |  bytesOpt: Option[Array[Byte]] = None,
+                       |  birthday: Option[LocalDate] = None,
+                       |  createdAt: DateTime,
+                       |  updatedAt: DateTime
+                       |)
+                       |
+                       |object NoIdMember extends SkinnyNoIdCRUDMapper[NoIdMember] with TimestampsFeature[NoIdMember] {
+                       |  override lazy val tableName = "no_id_members"
+                       |  override lazy val defaultAlias = createAlias("nim")
+                       |
+                       |  override def extract(rs: WrappedResultSet, rn: ResultName[NoIdMember]): NoIdMember = new NoIdMember(
+                       |    name = rs.get(rn.name),
+                       |    isActivated = rs.get(rn.isActivated),
+                       |    bytes = rs.get(rn.bytes),
+                       |    bytesOpt = rs.get(rn.bytesOpt),
+                       |    birthday = rs.get(rn.birthday),
+                       |    createdAt = rs.get(rn.createdAt),
+                       |    updatedAt = rs.get(rn.updatedAt)
+                       |  )
+                       |}
+                       |""".stripMargin
+      code should equal(expected)
+    }
+
+    it("should be created as expected without tableName") {
+      val generator = new ModelGenerator {
+        override def withId = false
+        override def withTimestamps = false
+      }
+      val code = generator.code(Nil, "noIdProjectMember", None, Seq(
+        "name" -> "String",
+        "isActivated" -> "Boolean",
+        "birthday" -> "Option[LocalDate]"
+      ))
+      val expected =
+        """package model
+          |
+          |import skinny.orm._, feature._
+          |import scalikejdbc._, SQLInterpolation._
+          |import org.joda.time._
+          |
+          |// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+          |case class NoIdProjectMember(
+          |  name: String,
+          |  isActivated: Boolean,
+          |  birthday: Option[LocalDate] = None
+          |)
+          |
+          |object NoIdProjectMember extends SkinnyNoIdCRUDMapper[NoIdProjectMember] {
+          |
+          |  override lazy val defaultAlias = createAlias("nipm")
+          |
+          |  override def extract(rs: WrappedResultSet, rn: ResultName[NoIdProjectMember]): NoIdProjectMember = new NoIdProjectMember(
+          |    name = rs.get(rn.name),
+          |    isActivated = rs.get(rn.isActivated),
+          |    birthday = rs.get(rn.birthday)
+          |  )
+          |}
+          |""".stripMargin
+      code should equal(expected)
+    }
+
+    it("should be created as expected without timestamps") {
+      val generator = new ModelGenerator {
+        override def withId = false
+      }
+      val code = generator.code(Seq("admin"), "noIdProjectMember", None, Seq(
+        "name" -> "String",
+        "isActivated" -> "Boolean",
+        "birthday" -> "Option[LocalDate]"
+      ))
+      val expected =
+        """package model.admin
+          |
+          |import skinny.orm._, feature._
+          |import scalikejdbc._, SQLInterpolation._
+          |import org.joda.time._
+          |
+          |// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+          |case class NoIdProjectMember(
+          |  name: String,
+          |  isActivated: Boolean,
+          |  birthday: Option[LocalDate] = None,
+          |  createdAt: DateTime,
+          |  updatedAt: DateTime
+          |)
+          |
+          |object NoIdProjectMember extends SkinnyNoIdCRUDMapper[NoIdProjectMember] with TimestampsFeature[NoIdProjectMember] {
+          |
+          |  override lazy val defaultAlias = createAlias("nipm")
+          |
+          |  override def extract(rs: WrappedResultSet, rn: ResultName[NoIdProjectMember]): NoIdProjectMember = new NoIdProjectMember(
+          |    name = rs.get(rn.name),
+          |    isActivated = rs.get(rn.isActivated),
+          |    birthday = rs.get(rn.birthday),
+          |    createdAt = rs.get(rn.createdAt),
+          |    updatedAt = rs.get(rn.updatedAt)
+          |  )
+          |}
+          |""".stripMargin
+      code should equal(expected)
+    }
+
+    it("should be created as expected without attributes") {
+      val generator = new ModelGenerator {
+        override def withId = false
+      }
+      val code = generator.code(Seq("admin"), "noIdMember", None, Seq())
+      val expected =
+        """package model.admin
+          |
+          |import skinny.orm._, feature._
+          |import scalikejdbc._, SQLInterpolation._
+          |import org.joda.time._
+          |
+          |// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+          |case class NoIdMember(
+          |  createdAt: DateTime,
+          |  updatedAt: DateTime
+          |)
+          |
+          |object NoIdMember extends SkinnyNoIdCRUDMapper[NoIdMember] with TimestampsFeature[NoIdMember] {
+          |
+          |  override lazy val defaultAlias = createAlias("nim")
+          |
+          |  override def extract(rs: WrappedResultSet, rn: ResultName[NoIdMember]): NoIdMember = new NoIdMember(
+          |    createdAt = rs.get(rn.createdAt),
+          |    updatedAt = rs.get(rn.updatedAt)
+          |  )
+          |}
+          |""".stripMargin
+      code should equal(expected)
+    }
+  }
+
 }


### PR DESCRIPTION
Please review this PR.

ReverseScaffoldGenerator just create "SkinnyNoIdCRUDMapper" if target table has no primary key or has composite primary keys.
