### PR TITLE
Remove the syntax of hgignore from gitignore

### DIFF
--- a/yeoman-generator-skinny/app/templates/_gitignore
+++ b/yeoman-generator-skinny/app/templates/_gitignore
@@ -16,8 +16,6 @@ task/src/main/resources/
 build/target/
 standalone-build/
 
-# use glob syntax.
-syntax: glob
 *.ser
 *.class
 *~


### PR DESCRIPTION
Hi :high_brightness: 

I think it's unnecessary.
