### PR TITLE
sbtconfig takes external SBT_OPTS

### DIFF
--- a/yeoman-generator-skinny/app/templates/sbt
+++ b/yeoman-generator-skinny/app/templates/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 cd `dirname $0`
 current_dir=`pwd`
 sbt_config=${current_dir}/.sbtconfig
@@ -11,7 +11,7 @@ if [ \$java_major_version -ge 8 ]; then
 else
   PERM_OPT=\"-XX:MaxPermSize=256M\"
 fi
-export SBT_OPTS=\"-XX:+CMSClassUnloadingEnabled \${PERM_OPT}\"
+export SBT_OPTS=\"-XX:+CMSClassUnloadingEnabled \${PERM_OPT} \${SBT_OPTS}\"
 " > ${sbt_config}
 fi
 


### PR DESCRIPTION
```
% bash -x ./sbt compile
...
++ PERM_OPT=-XX:MaxMetaspaceSize=386M
++ export 'SBT_OPTS=-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M '
++ SBT_OPTS='-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M '
+ exec java -Xmx1024M -XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M -jar /skinny-app/bin/sbt-launch.jar compile


% export SBT_OPTS=-Dhoge=foo
% bash -x ./sbt compile
...
++ PERM_OPT=-XX:MaxMetaspaceSize=386M
++ export 'SBT_OPTS=-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M -Dhoge=foo'
++ SBT_OPTS='-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M -Dhoge=foo'
+ exec java -Xmx1024M -XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=386M -Dhoge=foo -jar /skinny-app/bin/sbt-launch.jar compile
```
