### PR TITLE
Smooth async support

### DIFF
--- a/example/src/main/scala/controller/Controllers.scala
+++ b/example/src/main/scala/controller/Controllers.scala
@@ -21,6 +21,7 @@ object Controllers {
     freemarker.mount(ctx)
     sampleApi.mount(ctx)
     scaldi.mount(ctx)
+    dashboard.mount(ctx)
 
     SkillsController.mount(ctx)
     CommentsController.mount(ctx)
@@ -81,6 +82,10 @@ object Controllers {
 
   object scaldi extends ScaldiController with Routes {
     val indexUrl = get("/scaldi/")(index).as('index)
+  }
+
+  object dashboard extends DashboardController with Routes {
+    val indexUrl = get("/dashboard/")(index).as('index)
   }
 
 }

--- a/example/src/main/scala/controller/DashboardController.scala
+++ b/example/src/main/scala/controller/DashboardController.scala
@@ -1,0 +1,113 @@
+package controller
+
+import org.joda.time._
+import model._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import javax.servlet.http.HttpServletRequest
+
+case class DashboardOps(controller: DashboardController) {
+  def setCurrentUser(implicit req: HttpServletRequest) = {
+    val userId = controller.currentUserId.getOrElse(controller.halt(401))
+    controller.set("currentUser" -> controller.adminUserService.getCurrentUser(userId))
+  }
+}
+
+class DashboardController extends ApplicationController {
+
+  override implicit def request: HttpServletRequest = {
+    val stackTraces = Thread.currentThread().getStackTrace.drop(2).take(20)
+    if (stackTraces.exists(_.toString.contains("Future.scala"))) {
+      println()
+      stackTraces.foreach(s => println("  " + s))
+      println()
+      throw new RuntimeException("#request within Future detected")
+    }
+    super.request
+  }
+
+  val adminUserService = new AdminUserService
+  val accessService = new AccessLogService
+  val alertService = new AlertService
+  val ops = DashboardOps(this)
+
+  def index = warnElapsedTimeWithRequest(500) {
+    if (currentUserId(request).isEmpty) session += "userId" -> 1
+
+    val scope: scala.collection.concurrent.Map[String, Any] = requestScope()
+
+    awaitFutures(5.seconds)(
+
+      // simply define operation inside of this controller
+      futureWithRequest { implicit req =>
+        // [error] example/src/main/scala/controller/DashboardController.scala:43: ambiguous implicit values:
+        // [error]  both value req of type javax.servlet.http.HttpServletRequest
+        // [error]  and method request in class DashboardController of type => javax.servlet.http.HttpServletRequest
+        // [error]  match expected type javax.servlet.http.HttpServletRequest
+        // [error]         set("hourlyStats", accessService.getHourlyStatsForGraph(new LocalDate))
+        // [error]            ^
+        // [error] one error found
+
+        //set("hourlyStats", accessService.getHourlyStatsForGraph(new LocalDate))
+        set("hourlyStats", accessService.getHourlyStatsForGraph(new LocalDate))(req)
+      },
+
+      // separate operation to outside of this controller
+      futureWithRequest(req => ops.setCurrentUser(req)),
+
+      // just use Future directly
+      Future {
+        // When using Future directly, you must be aware of Scalatra's DynamicScope's thread local request.
+        // In this case, you cannot use request here. requestScope, session and so on should be captured outside of this Future value.
+        scope.update("alerts", alertService.findAll())
+      }
+    )
+    render("/dashboard/index")
+  }
+
+  private[controller] def currentUserId(implicit req: HttpServletRequest): Option[Long] = session(req).getAs[Long]("userId")
+
+  class AdminUserService extends skinny.util.TimeLogging {
+
+    private[this] val users = Seq(AdminUser(1, "Alice", "alice@example.com"))
+
+    def getCurrentUser(id: Long): Option[AdminUser] = warnElapsedTime(100) {
+      Thread.sleep(50L)
+      users.find(_.id == id)
+    }
+  }
+
+  class AccessLogService extends skinny.util.TimeLogging {
+
+    def getHourlyStatsForGraph(date: LocalDate): Seq[HourlyStat] = warnElapsedTime(200) {
+      Thread.sleep(300L)
+      Seq(
+        HourlyStat("2014072000", 224.5, 200000, 21),
+        HourlyStat("2014072001", 254.0, 170000, 4),
+        HourlyStat("2014072002", 180.2, 92000, 0),
+        HourlyStat("2014072003", 192.8, 64000, 0),
+        HourlyStat("2014072004", 160.1, 41000, 0),
+        HourlyStat("2014072005", 201.5, 58000, 10),
+        HourlyStat("2014072006", 724.2, 78000, 7453),
+        HourlyStat("2014072007", 157.7, 91000, 15),
+        HourlyStat("2014072008", 189.3, 155000, 0)
+      )
+    }
+  }
+
+  class AlertService extends skinny.util.TimeLogging {
+
+    def findAll(): Seq[String] = warnElapsedTime(200) {
+      Thread.sleep(150L)
+      Seq(
+        "New Record!!!",
+        "Please register master data."
+      )
+    }
+  }
+
+}
+

--- a/example/src/main/scala/model/AdminUser.scala
+++ b/example/src/main/scala/model/AdminUser.scala
@@ -1,0 +1,3 @@
+package model
+
+case class AdminUser(id: Long, name: String, email: String)

--- a/example/src/main/scala/model/HourlyStat.scala
+++ b/example/src/main/scala/model/HourlyStat.scala
@@ -1,0 +1,3 @@
+package model
+
+case class HourlyStat(yyyymmddhh: String, responseTimeMillis: Double, totalCount: Long, errorCount: Long)

--- a/example/src/main/webapp/WEB-INF/views/dashboard/index.html.ssp
+++ b/example/src/main/webapp/WEB-INF/views/dashboard/index.html.ssp
@@ -1,0 +1,46 @@
+<%@val currentUser: Option[AdminUser] %>
+<%@val hourlyStats: Seq[HourlyStat] %>
+<%@val alerts: Seq[String] %>
+
+<h3>Dashboard</h3>
+<div class="pull-right">Login User: ${currentUser.map(_.name)}</div>
+<hr/>
+
+<div class="alert alert-success">
+<ul>
+#for (alert <- alerts)
+<li>${alert}</li>
+#end
+</ul>
+</div>
+
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript">
+  google.load("visualization", "1", {packages:["corechart"]});
+  google.setOnLoadCallback(drawCharts);
+  function drawCharts() {
+    var data = google.visualization.arrayToDataTable([
+      ['YYYYMMDDHH', 'totalCount', 'errorCount'],
+      #for (s <- hourlyStats)
+      ['${s.yyyymmddhh}', ${s.totalCount}, ${s.errorCount}],
+      #end
+    ]);
+    var options = { title: 'Access Count', hAxis: {title: 'yyyymmddhh',  titleTextStyle: {color: '#333'}}, vAxis: {minValue: 0} };
+    var countChart = new google.visualization.AreaChart(document.getElementById('countChart'));
+    countChart.draw(data, options);
+
+    data = google.visualization.arrayToDataTable([
+      ['YYYYMMDDHH', 'responseTimeMillis'],
+      #for (s <- hourlyStats)
+      ['${s.yyyymmddhh}', ${s.responseTimeMillis}],
+      #end
+    ]);
+    options = { title: 'Response Time', hAxis: {title: 'yyyymmddhh',  titleTextStyle: {color: '#333'}}, vAxis: {minValue: 0} };
+    var responseTimeChart = new google.visualization.AreaChart(document.getElementById('responseTimeChart'));
+    responseTimeChart.draw(data, options);
+  }
+</script>
+
+<div id="countChart" style="width: 900px; height: 500px;"></div>
+<div id="responseTimeChart" style="width: 900px; height: 500px;"></div>
+

--- a/example/src/test/scala/controller/CompaniesControllerSpec.scala
+++ b/example/src/test/scala/controller/CompaniesControllerSpec.scala
@@ -41,6 +41,7 @@ class CompaniesControllerSpec extends FunSpec with Matchers with DBSettings {
 
         controller.status should equal(200)
         controller.requestScope[Company]("item") should equal(Some(company))
+        controller.getFromRequestScope[Company]("item") should equal(Some(company))
         controller.renderCall.map(_.path) should equal(Some("/companies/show"))
       }
     }

--- a/example/src/test/scala/controller/DashboardControllerSpec.scala
+++ b/example/src/test/scala/controller/DashboardControllerSpec.scala
@@ -1,0 +1,18 @@
+package controller
+
+import org.scalatest._
+import skinny.test.MockController
+
+class DashboardControllerSpec extends FunSpec with Matchers {
+
+  def createMockController = new DashboardController with MockController
+
+  describe("DashboardController") {
+    it("works with Futures") {
+      val controller = createMockController
+      controller.index
+      controller.status should equal(200)
+    }
+  }
+
+}

--- a/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
@@ -25,6 +25,7 @@ trait SkinnyControllerBase
     with ActionDefinitionFeature
     with RequestScopeFeature
     with BeforeAfterActionFeature
+    with FutureOpsFeature
     with LocaleFeature
     with ValidationFeature
     with JSONFeature

--- a/framework/src/main/scala/skinny/controller/feature/FutureOpsFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/FutureOpsFeature.scala
@@ -1,0 +1,66 @@
+package skinny.controller.feature
+
+import skinny.controller.SkinnyControllerBase
+import javax.servlet.http.HttpServletRequest
+import scala.concurrent._
+import scala.concurrent.duration.Duration
+
+/**
+ * Provides seamless Future operations within SkinnyController.
+ * This trait enables accessing request, session and RequestScope from Future operations safely.
+ *
+ * {{{
+ *   import scala.concurrent._
+ *   import scala.concurrent.duration._
+ *   import scala.concurrent.ExecutionContext.Implicits.global
+ *
+ *   class SomeControllerOps(controller: SomeController) {
+ *     def setOther(implicit req: HttpServletRequest) = {
+ *       controller.set("bar", Seq(1,2,3)) // implicit request is not ambiguous here
+ *     }
+ *   }
+ *
+ *   class SomeController extends ApplicationController {
+ *     def index = {
+ *       val ops = new SomeControllerOps(this)
+ *       awaitFutures(5.seconds)(
+ *         futureWithRequest { implicit req =>
+ *           // Explicitly specify HttpServletRequest here
+ *           set("foo" -> FooService.getSomething()))(req)
+ *         },
+ *         futureWithRequest(req => ops.setOther(req))
+ *       )
+ *       render("/some/index")
+ *     }
+ *   }
+ * }}}
+ */
+trait FutureOpsFeature { self: SkinnyControllerBase =>
+
+  /**
+   * Creates a future with implicit request.
+   *
+   * @param op operation inside this future
+   * @param ec execution context
+   * @param req request
+   * @tparam A response type
+   * @return response value
+   */
+  def futureWithRequest[A](op: (HttpServletRequest) => A)(
+    implicit ec: ExecutionContext, req: HttpServletRequest): Future[A] = {
+    Future { op(req) }
+  }
+
+  /**
+   * Awaits multiple Future's results.
+   *
+   * @param duration duration to await futures
+   * @param fs futures
+   * @param ec execution context
+   * @return results
+   */
+  def awaitFutures[A](duration: Duration)(fs: Future[A]*)(implicit ec: ExecutionContext): Seq[A] = {
+    Await.result(Future.sequence(fs), duration)
+  }
+
+}

--- a/framework/src/main/scala/skinny/controller/feature/LocaleFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/LocaleFeature.scala
@@ -1,6 +1,7 @@
 package skinny.controller.feature
 
 import java.util.Locale
+import javax.servlet.http.HttpServletRequest
 import org.scalatra.ScalatraBase
 
 /**
@@ -24,16 +25,21 @@ trait LocaleFeature extends ScalatraBase {
    *
    * @param locale locale string
    */
-  protected def setCurrentLocale(locale: String): Unit = session.put(sessionLocaleKey, locale)
+  protected def setCurrentLocale(locale: String)(implicit req: HttpServletRequest = request): Unit = {
+    session(req).put(sessionLocaleKey, locale)
+  }
 
   /**
    * Returns current locale for this request.
    *
    * @return current locale
    */
-  protected def currentLocale: Option[Locale] = {
+  protected def currentLocale(implicit req: HttpServletRequest = request): Option[Locale] = {
     // avoid creating a session
-    sessionOption.flatMap(_.get(sessionLocaleKey)).map(l => new Locale(l.toString)).orElse(defaultLocale)
+    sessionOption(req)
+      .flatMap(_.get(sessionLocaleKey))
+      .map(locale => new Locale(locale.toString))
+      .orElse(defaultLocale)
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/RequestScopeFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/RequestScopeFeature.scala
@@ -74,29 +74,38 @@ object RequestScopeFeature extends Logging {
  */
 trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature with LocaleFeature with Logging {
 
+  // ---------------------------------------------------
+  // Notice: Due to org.scalatra.DynamicScope's implicit conversion, we need to specify request explicitly.
+
+  // [error] ambiguous implicit values:
+  // [error]  both value req of type javax.servlet.http.HttpServletRequest
+  // [error]  and method request in class DashboardController of type => javax.servlet.http.HttpServletRequest
+  // [error]  match expected type javax.servlet.http.HttpServletRequest
+  // ---------------------------------------------------
+
   import RequestScopeFeature._
 
   /**
    * Registers default attributes in the request scope.
    */
-  before()(initializeRequestScopeAttributes)
+  before()(initializeRequestScopeAttributes(request))
 
-  def initializeRequestScopeAttributes = {
-    if (requestScope().get(ATTR_SKINNY).isEmpty) {
-      set(ATTR_SKINNY, skinny.Skinny(requestScope()))
+  def initializeRequestScopeAttributes(implicit req: HttpServletRequest) = {
+    if (requestScope(req).get(ATTR_SKINNY).isEmpty) {
+      set(ATTR_SKINNY, skinny.Skinny(requestScope(req)))(req)
       // requestPath/contextPath
-      val requestPathWithContext = contextPath + requestPath
+      val requestPathWithContext = contextPath + requestPath(req)
       val queryStringPart = Option(request.getQueryString).map(qs => "?" + qs).getOrElse("")
-      set(ATTR_CONTEXT_PATH -> contextPath)
-      set(ATTR_REQUEST_PATH -> requestPathWithContext)
-      set(ATTR_REQUEST_PATH_WITH_QUERY_STRING -> s"${requestPathWithContext}${queryStringPart}")
+      set(ATTR_CONTEXT_PATH -> contextPath)(req)
+      set(ATTR_REQUEST_PATH -> requestPathWithContext)(req)
+      set(ATTR_REQUEST_PATH_WITH_QUERY_STRING -> s"${requestPathWithContext}${queryStringPart}")(req)
       // for forms/validator
-      set(ATTR_PARAMS -> skinny.controller.Params(params))
-      set(ATTR_MULTI_PARAMS -> skinny.controller.MultiParams(multiParams))
-      set(ATTR_ERROR_MESSAGES -> Seq())
-      set(ATTR_KEY_AND_ERROR_MESSAGES -> KeyAndErrorMessages())
+      set(ATTR_PARAMS -> skinny.controller.Params(params(req)))(req)
+      set(ATTR_MULTI_PARAMS -> skinny.controller.MultiParams(multiParams(req)))(req)
+      set(ATTR_ERROR_MESSAGES -> Seq())(req)
+      set(ATTR_KEY_AND_ERROR_MESSAGES -> KeyAndErrorMessages())(req)
       // i18n in view templates
-      setI18n()
+      setI18n(req)
     }
   }
 
@@ -105,14 +114,18 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    *
    * @return whole attributes
    */
-  def requestScope(): scala.collection.concurrent.Map[String, Any] = RequestScopeFeature.requestScope(request)
+  def requestScope(implicit req: HttpServletRequest = request): scala.collection.concurrent.Map[String, Any] = {
+    RequestScopeFeature.requestScope(req)
+  }
   /**
    * Set attribute to request scope.
    *
    * @param keyAndValue key and value
    * @return self
    */
-  def requestScope(keyAndValue: (String, Any)): RequestScopeFeature = requestScope(Seq(keyAndValue))
+  def requestScope(keyAndValue: (String, Any))(implicit req: HttpServletRequest): RequestScopeFeature = {
+    requestScope(Seq(keyAndValue))(req)
+  }
 
   /**
    * Set attributes to request scope.
@@ -120,7 +133,7 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    * @param keyAndValues collection of key and value.
    * @return self
    */
-  def requestScope(keyAndValues: Seq[(String, Any)]): RequestScopeFeature = {
+  def requestScope(keyAndValues: Seq[(String, Any)])(implicit req: HttpServletRequest): RequestScopeFeature = {
     keyAndValues.foreach {
       case (key, _) =>
         if (key == "layout") {
@@ -129,19 +142,26 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
             "Or if you'd like to change layout for this action, use layout(\"/other\") instead.")
         }
     }
-    requestScope() ++= keyAndValues
+    requestScope(req) ++= keyAndValues
     this
   }
 
   /**
    * Set attribute to request scope.
    */
-  def set(keyAndValue: (String, Any)): RequestScopeFeature = requestScope(Seq(keyAndValue))
+  def set(keyAndValue: (String, Any))(implicit req: HttpServletRequest): RequestScopeFeature = {
+    requestScope(Seq(keyAndValue))(req)
+  }
 
   /**
    * Set attributes to request scope.
    */
-  def set(keyAndValues: Seq[(String, Any)]): RequestScopeFeature = requestScope(keyAndValues)
+  def set(keyAndValues: Seq[(String, Any)])(implicit req: HttpServletRequest): RequestScopeFeature = {
+    requestScope(keyAndValues)(req)
+  }
+
+  @deprecated("Use #getFromRequestScope instead. This method will be removed since 1.3.", "1.2.0")
+  def requestScope[A](key: String): Option[A] = getFromRequestScope(key)(request)
 
   /**
    * Fetches value from request scope.
@@ -150,13 +170,13 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    * @tparam A type
    * @return value if exists
    */
-  def requestScope[A](key: String): Option[A] = {
-    requestScope().get(key).map { v =>
+  def getFromRequestScope[A](key: String)(implicit req: HttpServletRequest = request): Option[A] = {
+    requestScope(req).get(key).map { v =>
       try v.asInstanceOf[A]
       catch {
         case e: ClassCastException =>
-          throw new RequestScopeConflictException(
-            s"""\"${key}\" value in request scope is unexpected. (actual: ${v}, error: ${e.getMessage}})""")
+          val message = s"""\"${key}\" value in request scope is unexpected. (actual: ${v}, error: ${e.getMessage}})"""
+          throw new RequestScopeConflictException(message)
       }
     }
   }
@@ -166,97 +186,97 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    *
    * @param model model instance
    */
-  def setAsParams(model: Any): Unit = {
+  def setAsParams(model: Any)(implicit req: HttpServletRequest = request): Unit = {
     import skinny.util.StringUtil.toSnakeCase
 
     getterNamesFromEntity(model).foreach { getterName =>
       val value = model.getClass.getDeclaredMethod(getterName).invoke(model)
       if (useSnakeCasedParamKeys) {
-        addParam(toSnakeCase(getterName), value)
+        addParam(toSnakeCase(getterName), value)(req)
       } else {
-        addParam(getterName, value)
+        addParam(getterName, value)(req)
       }
 
       value match {
         case opt: Option[_] => opt foreach {
           case dt: DateTime =>
             if (useSnakeCasedParamKeys) {
-              addParam(toSnakeCase(s"${getterName}Year"), dt.getYearOfEra)
-              addParam(toSnakeCase(s"${getterName}Month"), dt.getMonthOfYear)
-              addParam(toSnakeCase(s"${getterName}Day"), dt.getDayOfMonth)
-              addParam(toSnakeCase(s"${getterName}Hour"), dt.getHourOfDay)
-              addParam(toSnakeCase(s"${getterName}Minute"), dt.getMinuteOfHour)
-              addParam(toSnakeCase(s"${getterName}Second"), dt.getSecondOfMinute)
+              addParam(toSnakeCase(s"${getterName}Year"), dt.getYearOfEra)(req)
+              addParam(toSnakeCase(s"${getterName}Month"), dt.getMonthOfYear)(req)
+              addParam(toSnakeCase(s"${getterName}Day"), dt.getDayOfMonth)(req)
+              addParam(toSnakeCase(s"${getterName}Hour"), dt.getHourOfDay)(req)
+              addParam(toSnakeCase(s"${getterName}Minute"), dt.getMinuteOfHour)(req)
+              addParam(toSnakeCase(s"${getterName}Second"), dt.getSecondOfMinute)(req)
             } else {
-              addParam(s"${getterName}Year", dt.getYearOfEra)
-              addParam(s"${getterName}Month", dt.getMonthOfYear)
-              addParam(s"${getterName}Day", dt.getDayOfMonth)
-              addParam(s"${getterName}Hour", dt.getHourOfDay)
-              addParam(s"${getterName}Minute", dt.getMinuteOfHour)
-              addParam(s"${getterName}Second", dt.getSecondOfMinute)
+              addParam(s"${getterName}Year", dt.getYearOfEra)(req)
+              addParam(s"${getterName}Month", dt.getMonthOfYear)(req)
+              addParam(s"${getterName}Day", dt.getDayOfMonth)(req)
+              addParam(s"${getterName}Hour", dt.getHourOfDay)(req)
+              addParam(s"${getterName}Minute", dt.getMinuteOfHour)(req)
+              addParam(s"${getterName}Second", dt.getSecondOfMinute)(req)
             }
 
           case ld: LocalDate =>
             if (useSnakeCasedParamKeys) {
-              addParam(toSnakeCase(s"${getterName}Year"), ld.getYearOfEra)
-              addParam(toSnakeCase(s"${getterName}Month"), ld.getMonthOfYear)
-              addParam(toSnakeCase(s"${getterName}Day"), ld.getDayOfMonth)
+              addParam(toSnakeCase(s"${getterName}Year"), ld.getYearOfEra)(req)
+              addParam(toSnakeCase(s"${getterName}Month"), ld.getMonthOfYear)(req)
+              addParam(toSnakeCase(s"${getterName}Day"), ld.getDayOfMonth)(req)
             } else {
-              addParam(s"${getterName}Year", ld.getYearOfEra)
-              addParam(s"${getterName}Month", ld.getMonthOfYear)
-              addParam(s"${getterName}Day", ld.getDayOfMonth)
+              addParam(s"${getterName}Year", ld.getYearOfEra)(req)
+              addParam(s"${getterName}Month", ld.getMonthOfYear)(req)
+              addParam(s"${getterName}Day", ld.getDayOfMonth)(req)
             }
 
           case lt: LocalTime =>
             if (useSnakeCasedParamKeys) {
-              addParam(toSnakeCase(s"${getterName}Hour"), lt.getHourOfDay)
-              addParam(toSnakeCase(s"${getterName}Minute"), lt.getMinuteOfHour)
-              addParam(toSnakeCase(s"${getterName}Second"), lt.getSecondOfMinute)
+              addParam(toSnakeCase(s"${getterName}Hour"), lt.getHourOfDay)(req)
+              addParam(toSnakeCase(s"${getterName}Minute"), lt.getMinuteOfHour)(req)
+              addParam(toSnakeCase(s"${getterName}Second"), lt.getSecondOfMinute)(req)
             } else {
-              addParam(s"${getterName}Hour", lt.getHourOfDay)
-              addParam(s"${getterName}Minute", lt.getMinuteOfHour)
-              addParam(s"${getterName}Second", lt.getSecondOfMinute)
+              addParam(s"${getterName}Hour", lt.getHourOfDay)(req)
+              addParam(s"${getterName}Minute", lt.getMinuteOfHour)(req)
+              addParam(s"${getterName}Second", lt.getSecondOfMinute)(req)
             }
 
           case value =>
         }
         case dt: DateTime =>
           if (useSnakeCasedParamKeys) {
-            addParam(toSnakeCase(s"${getterName}Year"), dt.getYearOfEra)
-            addParam(toSnakeCase(s"${getterName}Month"), dt.getMonthOfYear)
-            addParam(toSnakeCase(s"${getterName}Day"), dt.getDayOfMonth)
-            addParam(toSnakeCase(s"${getterName}Hour"), dt.getHourOfDay)
-            addParam(toSnakeCase(s"${getterName}Minute"), dt.getMinuteOfHour)
-            addParam(toSnakeCase(s"${getterName}Second"), dt.getSecondOfMinute)
+            addParam(toSnakeCase(s"${getterName}Year"), dt.getYearOfEra)(req)
+            addParam(toSnakeCase(s"${getterName}Month"), dt.getMonthOfYear)(req)
+            addParam(toSnakeCase(s"${getterName}Day"), dt.getDayOfMonth)(req)
+            addParam(toSnakeCase(s"${getterName}Hour"), dt.getHourOfDay)(req)
+            addParam(toSnakeCase(s"${getterName}Minute"), dt.getMinuteOfHour)(req)
+            addParam(toSnakeCase(s"${getterName}Second"), dt.getSecondOfMinute)(req)
           } else {
-            addParam(s"${getterName}Year", dt.getYearOfEra)
-            addParam(s"${getterName}Month", dt.getMonthOfYear)
-            addParam(s"${getterName}Day", dt.getDayOfMonth)
-            addParam(s"${getterName}Hour", dt.getHourOfDay)
-            addParam(s"${getterName}Minute", dt.getMinuteOfHour)
-            addParam(s"${getterName}Second", dt.getSecondOfMinute)
+            addParam(s"${getterName}Year", dt.getYearOfEra)(req)
+            addParam(s"${getterName}Month", dt.getMonthOfYear)(req)
+            addParam(s"${getterName}Day", dt.getDayOfMonth)(req)
+            addParam(s"${getterName}Hour", dt.getHourOfDay)(req)
+            addParam(s"${getterName}Minute", dt.getMinuteOfHour)(req)
+            addParam(s"${getterName}Second", dt.getSecondOfMinute)(req)
           }
 
         case ld: LocalDate =>
           if (useSnakeCasedParamKeys) {
-            addParam(toSnakeCase(s"${getterName}Year"), ld.getYearOfEra)
-            addParam(toSnakeCase(s"${getterName}Month"), ld.getMonthOfYear)
-            addParam(toSnakeCase(s"${getterName}Day"), ld.getDayOfMonth)
+            addParam(toSnakeCase(s"${getterName}Year"), ld.getYearOfEra)(req)
+            addParam(toSnakeCase(s"${getterName}Month"), ld.getMonthOfYear)(req)
+            addParam(toSnakeCase(s"${getterName}Day"), ld.getDayOfMonth)(req)
           } else {
-            addParam(s"${getterName}Year", ld.getYearOfEra)
-            addParam(s"${getterName}Month", ld.getMonthOfYear)
-            addParam(s"${getterName}Day", ld.getDayOfMonth)
+            addParam(s"${getterName}Year", ld.getYearOfEra)(req)
+            addParam(s"${getterName}Month", ld.getMonthOfYear)(req)
+            addParam(s"${getterName}Day", ld.getDayOfMonth)(req)
           }
 
         case lt: LocalTime =>
           if (useSnakeCasedParamKeys) {
-            addParam(toSnakeCase(s"${getterName}Hour"), lt.getHourOfDay)
-            addParam(toSnakeCase(s"${getterName}Minute"), lt.getMinuteOfHour)
-            addParam(toSnakeCase(s"${getterName}Second"), lt.getSecondOfMinute)
+            addParam(toSnakeCase(s"${getterName}Hour"), lt.getHourOfDay)(req)
+            addParam(toSnakeCase(s"${getterName}Minute"), lt.getMinuteOfHour)(req)
+            addParam(toSnakeCase(s"${getterName}Second"), lt.getSecondOfMinute)(req)
           } else {
-            addParam(s"${getterName}Hour", lt.getHourOfDay)
-            addParam(s"${getterName}Minute", lt.getMinuteOfHour)
-            addParam(s"${getterName}Second", lt.getSecondOfMinute)
+            addParam(s"${getterName}Hour", lt.getHourOfDay)(req)
+            addParam(s"${getterName}Minute", lt.getMinuteOfHour)(req)
+            addParam(s"${getterName}Second", lt.getSecondOfMinute)(req)
           }
 
         case value =>
@@ -288,12 +308,12 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
   /**
    * Set params to request scope.
    */
-  def setParams() = setParamsToRequestScope()
+  def setParams(implicit req: HttpServletRequest = request) = setParamsToRequestScope(req)
 
   /**
    * Set params to request scope.
    */
-  def setParamsToRequestScope(): Unit = set(ATTR_PARAMS -> Params(params))
+  def setParamsToRequestScope(implicit req: HttpServletRequest = request): Unit = set(ATTR_PARAMS -> Params(params(req)))(req)
 
   /**
    * Set {{skinny.I18n}} object for the current request to request scope.
@@ -301,8 +321,8 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    * @param locale current locale
    * @return self
    */
-  def setI18n()(implicit locale: Locale = currentLocale.orNull[Locale]) = {
-    set(RequestScopeFeature.ATTR_I18N, I18n(locale))
+  def setI18n(implicit req: HttpServletRequest = request, locale: Locale = currentLocale(request).orNull[Locale]) = {
+    set(RequestScopeFeature.ATTR_I18N, I18n(locale))(req)
   }
 
   /**
@@ -311,41 +331,41 @@ trait RequestScopeFeature extends ScalatraBase with SnakeCasedParamKeysFeature w
    * @param name name
    * @param value value
    */
-  def addParam(name: String, value: Any): Unit = {
+  def addParam(name: String, value: Any)(implicit req: HttpServletRequest = request): Unit = {
 
     // ensure "params" in the request scope is valid
     // don't delete requestScope[Any] 's `Any` (because cannot cast Nothing to Params)
-    val isParamsInRequestScopeValid = requestScope[Any](ATTR_PARAMS).map(_.isInstanceOf[Params]).getOrElse(false)
+    val isParamsInRequestScopeValid = getFromRequestScope[Any](ATTR_PARAMS)(req).map(_.isInstanceOf[Params]).getOrElse(false)
 
     if (isParamsInRequestScopeValid) {
       val updatedParams: Params = {
-        Params(requestScope[Params]("params")
+        Params(getFromRequestScope[Params]("params")(req)
           .map(_.underlying)
-          .getOrElse(params)
+          .getOrElse(params(req))
           .updated(name, value))
       }
-      set(RequestScopeFeature.ATTR_PARAMS -> updatedParams)
+      set(RequestScopeFeature.ATTR_PARAMS -> updatedParams)(req)
 
     } else {
-      val actual = requestScope(ATTR_PARAMS)
+      val actual = getFromRequestScope(ATTR_PARAMS)(req)
       throw new RequestScopeConflictException(
         s"""Skinny Framework expects that $${params} is a SkinnyParams value. (actual: "${actual}", class: ${actual.getClass.getName})""")
     }
   }
 
   /**
-   * Returns erorrMessages in the RequestScope.
+   * Returns errorMessages in the RequestScope.
    */
-  def errorMessages: Seq[String] = {
-    requestScope.get(RequestScopeFeature.ATTR_ERROR_MESSAGES)
+  def errorMessages(implicit req: HttpServletRequest = request): Seq[String] = {
+    requestScope(req).get(RequestScopeFeature.ATTR_ERROR_MESSAGES)
       .map(_.asInstanceOf[Seq[String]]).getOrElse(Nil)
   }
 
   /**
    * Returns keyAndErrorMessages in the RequestScope.
    */
-  def keyAndErrorMessages: Map[String, Seq[String]] = {
-    requestScope.get(RequestScopeFeature.ATTR_KEY_AND_ERROR_MESSAGES)
+  def keyAndErrorMessages(implicit req: HttpServletRequest = request): Map[String, Seq[String]] = {
+    requestScope(req).get(RequestScopeFeature.ATTR_KEY_AND_ERROR_MESSAGES)
       .map(_.asInstanceOf[KeyAndErrorMessages].underlying).getOrElse(Map())
   }
 

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -359,7 +359,7 @@ trait ScaffoldGenerator extends CodeGenerator {
       |        val controller = createMockController
       |        controller.showResource(${resource}.${primaryKeyName})
       |        controller.status should equal(200)
-      |        controller.requestScope[${toClassName(resource)}]("item") should equal(Some(${resource}))
+      |        controller.getFromRequestScope[${toClassName(resource)}]("item") should equal(Some(${resource}))
       |        controller.renderCall.map(_.path) should equal(Some("${viewTemplatesPath}/show"))
       |      }
       |    }

--- a/test/src/main/scala/skinny/test/MockControllerBase.scala
+++ b/test/src/main/scala/skinny/test/MockControllerBase.scala
@@ -21,13 +21,13 @@ trait MockControllerBase extends SkinnyControllerBase {
   override def contextPath = ""
   override def initParameter(name: String): Option[String] = None
 
-  override val request: HttpServletRequest = {
+  override implicit val request: HttpServletRequest = {
     val req = new MockHttpServletRequest
     req.setAttribute(RequestScopeFeature.REQUEST_SCOPE_KEY, _requestScope)
     req
   }
 
-  override val response: HttpServletResponse = {
+  override implicit val response: HttpServletResponse = {
     val res = new MockHttpServletResponse
     res
   }


### PR DESCRIPTION
These changes basically keep source code compatibility for framework users. If some users have extensions that depend on LocaleFeature, RequestScopeFeature or SkinnySessionFilter, they may need to rewrite them a little bit to accept implicit parameter.
- Add FutureOpsFeature trait
- Mixin FutureOpsFeature to SkinnyControllerBase by default
- Add HttpServletRequest implicit param to LocaleFeature, RequestScopeFeature and SkinnySessionFilter methods

Supporting fully asynchronous controller is out of the scope of this pull request. I just tried a little but there're some issues which prevent providing easy-to-use APIs.
