### PR TITLE
Add joda-time String interpolation

### DIFF
--- a/common/src/main/scala/skinny/time/DateTimeInterpolationString.scala
+++ b/common/src/main/scala/skinny/time/DateTimeInterpolationString.scala
@@ -1,0 +1,40 @@
+package skinny.time
+
+import org.joda.time._
+import skinny.util.DateTimeUtil
+
+private[time] object LastParam
+
+/**
+ * String interpolation as a factory of joda-time values.
+ */
+class DateTimeInterpolationString(val s: StringContext) extends AnyVal {
+
+  // DateTime
+
+  def joda(params: Any*): DateTime = jodaDateTime(params: _*)
+  def jodaDateTime(params: Any*): DateTime = DateTimeUtil.parseDateTime(buildInterpolatedString(params: _*))
+
+  // LocalDate
+
+  def jodaLocalDate(params: Any*): LocalDate = DateTimeUtil.parseLocalDate(buildInterpolatedString(params: _*))
+  def jodaDate(params: Any*): LocalDate = jodaLocalDate(params: _*)
+
+  // LocalTime
+
+  def jodaLocalTime(params: Any*): LocalTime = DateTimeUtil.parseLocalTime(buildInterpolatedString(params: _*))
+  def jodaTime(params: Any*): LocalTime = jodaLocalTime(params: _*)
+
+  private def buildInterpolatedString(params: Any*): String = {
+    s.parts.zipAll(params, "", LastParam).foldLeft(new StringBuilder) {
+      case (sb, (previousQueryPart, LastParam)) => sb ++= previousQueryPart
+      case (sb, (previousQueryPart, param)) => sb ++= previousQueryPart ++=
+        Option(param).map {
+          case s: String => s
+          case n: Number => n.toString
+          case v => throw new IllegalArgumentException(s"${v} (type: ${v.getClass.getCanonicalName}) is not allowed. Use String or number value instead.")
+        }.getOrElse("")
+    }.toString
+  }
+
+}

--- a/common/src/main/scala/skinny/time/Implicits.scala
+++ b/common/src/main/scala/skinny/time/Implicits.scala
@@ -1,0 +1,13 @@
+package skinny.time
+
+import scala.language.implicitConversions
+
+object Implicits extends Implicits
+
+trait Implicits {
+
+  @inline implicit def skinnyDateTimeInterpolationImplicitDef(s: StringContext) = {
+    new skinny.time.DateTimeInterpolationString(s)
+  }
+
+}

--- a/common/src/test/scala/skinny/time/DateTimeInterpolationStringSpec.scala
+++ b/common/src/test/scala/skinny/time/DateTimeInterpolationStringSpec.scala
@@ -1,0 +1,71 @@
+package skinny.time
+
+import org.joda.time._
+import org.scalatest._
+
+class DateTimeInterpolationStringSpec extends FlatSpec with Matchers
+    with skinny.time.Implicits {
+
+  behavior of "DateTimeInterpolationString"
+
+  it should "work with DateTime" in {
+    {
+      joda"2014-01-02".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      joda"2014-1-2".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      joda"2014-01-02 03:04:05".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+
+      joda"2014/01/02".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      joda"2014/1/2".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      joda"2014/01/02 03:04:05".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+
+      val input1 = "2014/01/02"
+      val input2 = "2014/01/02 03:04:05"
+      joda"$input1".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      joda"$input2".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+      joda"${2014}/${1}/${2} ${3}:${4}:${5}".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+    }
+
+    {
+      jodaDateTime"2014/01/02".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      jodaDateTime"2014/01/02 03:04:05".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+
+      val input1 = "2014/01/02"
+      val input2 = "2014/01/02 03:04:05"
+      jodaDateTime"$input1".toString should equal(new DateTime(2014, 1, 2, 0, 0, 0).toString)
+      jodaDateTime"$input2".toString should equal(new DateTime(2014, 1, 2, 3, 4, 5).toString)
+    }
+  }
+
+  it should "reject unexpected params" in {
+    intercept[IllegalArgumentException] {
+      joda"${true}"
+    }
+    intercept[IllegalArgumentException] {
+      joda"${Some(123)}"
+    }
+    try {
+      joda"${Some(123)}"
+    } catch {
+      case e: IllegalArgumentException =>
+        e.getMessage should equal("Some(123) (type: scala.Some) is not allowed. Use String or number value instead.")
+    }
+  }
+
+  it should "work with LocalDate" in {
+    jodaLocalDate"2014/01/02".toString should equal(new LocalDate(2014, 1, 2).toString)
+    jodaDate"2014/01/02 03:04:05".toString should equal(new LocalDate(2014, 1, 2).toString)
+
+    val input = "2014/01/02 03:04:05"
+    jodaLocalDate"${input}".toString should equal(new LocalDate(2014, 1, 2).toString)
+    jodaDate"${input}".toString should equal(new LocalDate(2014, 1, 2).toString)
+  }
+
+  it should "work with LocalTime" in {
+    jodaLocalTime"03:04:05" should equal(new LocalTime(3, 4, 5))
+    jodaTime"2014/01/02 03:04:05" should equal(new LocalTime(3, 4, 5))
+
+    val input = "03:04:05"
+    jodaTime"${input}" should equal(new LocalTime(3, 4, 5))
+  }
+
+}


### PR DESCRIPTION
maybe useful when testing?

``` scala
scala> import skinny.time.Implicits._
import skinny.time.Implicits._

scala> joda"2014-01-02 03:04:05"
res0: org.joda.time.DateTime = 2014-01-02T03:04:05.000+09:00
```
