### PR TITLE
Specify a different directory from archiving one

### DIFF
--- a/create_homebrew_formula.sh
+++ b/create_homebrew_formula.sh
@@ -13,8 +13,7 @@ cp -pr ${TEMPLATE_PATH}/bin ${WORK_DIR}/.
 VERSION=`grep "val _version =" project/Build.scala | awk -F'"' '{print $2}'`
 
 cd ${WORK_DIR}
-tar cvfzp skinny-${VERSION}.tar.gz .
-mv skinny-${VERSION}.tar.gz ../.
+tar cvfzp ../skinny-${VERSION}.tar.gz .
 cd -
 rm -rf ${WORK_DIR}
 openssl sha1 skinny-${VERSION}.tar.gz


### PR DESCRIPTION
It warns as `Can't add archive to itself` before this change.

```
$ bash -x ./create_homebrew_formula.sh 
+ WORK_DIR=brew_work
+ mkdir -p brew_work
+ TEMPLATE_PATH=yeoman-generator-skinny/app/templates
+ cp -p yeoman-generator-skinny/app/templates/skinny brew_work/.
+ cp -p yeoman-generator-skinny/app/templates/sbt brew_work/.
+ cp -p yeoman-generator-skinny/app/templates/sbt-debug brew_work/.
+ chmod +x brew_work/sbt brew_work/sbt-debug brew_work/skinny
+ cp -pr yeoman-generator-skinny/app/templates/bin brew_work/.
++ grep 'val _version =' project/Build.scala
++ awk '-F"' '{print $2}'
+ VERSION=1.2.8
+ cd brew_work
+ tar cvfzp skinny-1.2.8.tar.gz .
a .
a ./bin
a ./sbt
a ./sbt-debug
a ./skinny
a ./skinny-1.2.8.tar.gz: Can't add archive to itself
a ./bin/sbt-launch.jar
+ mv skinny-1.2.8.tar.gz ../.
+ cd -
/Users/kawachi/.ghq/github.com/skinny-framework/skinny-framework
+ rm -rf brew_work
+ openssl sha1 skinny-1.2.8.tar.gz
SHA1(skinny-1.2.8.tar.gz)= 73bd2e74471fb0d9a080c8a3cf80b90562abfefc
```
