### PR TITLE
Create Ivy cache before copy

### DIFF
--- a/yeoman-generator-skinny/app/templates/skinny
+++ b/yeoman-generator-skinny/app/templates/skinny
@@ -10,6 +10,7 @@ chmod +x ${sbt_debug_path}
 
 # prepared deps
 if [ -d "${current_dir}/ivy2" ]; then
+  mkdir -p $HOME/.ivy2/cache/
   cp -prn ${current_dir}/ivy2/cache/* $HOME/.ivy2/cache/.
   rm -rf ${current_dir}/ivy2
 fi


### PR DESCRIPTION
If a user doesn't have ~/.ivy2/cache/ then subsequent cp will fail.
