### PR TITLE
Add TwitterLoginFeature (OAuth 1.0a)

### DIFF
--- a/example/src/main/scala/controller/Controllers.scala
+++ b/example/src/main/scala/controller/Controllers.scala
@@ -34,6 +34,7 @@ object Controllers {
     facebook.mount(ctx)
     github.mount(ctx)
     google.mount(ctx)
+    twitter.mount(ctx)
 
     AssetsController.mount(ctx)
   }
@@ -121,6 +122,12 @@ object Controllers {
     val loginUrl = get("/google")(loginRedirect).as('login)
     val callbackUrl = get("/google/callback")(callback).as('callback)
     val okUrl = get("/google/ok")(ok).as('ok)
+  }
+
+  object twitter extends TwitterController with Routes {
+    val loginUrl = get("/twitter")(loginRedirect).as('login)
+    val callbackUrl = get("/twitter/callback")(callback).as('callback)
+    val okUrl = get("/twitter/ok")(ok).as('ok)
   }
 
 }

--- a/example/src/main/scala/controller/TwitterController.scala
+++ b/example/src/main/scala/controller/TwitterController.scala
@@ -1,0 +1,31 @@
+package controller
+
+import skinny.controller.feature.{ SkinnySessionTwitterLoginFeature, TwitterLoginFeature }
+import skinny.filter.SkinnySessionFilter
+import twitter4j.User
+import twitter4j.auth.AccessToken
+
+class TwitterController extends ApplicationController
+    with TwitterLoginFeature {
+  //with SkinnySessionTwitterLoginFeature with SkinnySessionFilter {
+
+  override protected def isLocalDebug = true
+
+  override protected def saveAuthorizedUser(user: User): Unit = {
+    session.setAttribute("user", user)
+    //skinnySession.setAttribute("user", user)
+  }
+
+  override protected def handleWhenLoginSucceeded(): Any = {
+    redirect302(url(Controllers.twitter.okUrl))
+  }
+
+  def ok = {
+    logger.info("accessToken: " + currentAccessToken())
+    logger.info("twitter4j: " + twitter)
+    set("user", session.getAs[User]("user"))
+    //set("user", skinnySession.getAs[User]("user"))
+    render("/twitter/ok")
+  }
+
+}

--- a/example/src/main/webapp/WEB-INF/views/twitter/ok.html.ssp
+++ b/example/src/main/webapp/WEB-INF/views/twitter/ok.html.ssp
@@ -1,0 +1,4 @@
+<%@val user: Option[twitter4j.User] %>
+<h3>Twitter OAuth</h3>
+<hr/>
+<pre><%= user %></pre>

--- a/oauth2-controller/src/main/scala/skinny/controller/feature/OAuth2LoginFeature.scala
+++ b/oauth2-controller/src/main/scala/skinny/controller/feature/OAuth2LoginFeature.scala
@@ -12,7 +12,7 @@ object OAuth2LoginFeature {
 
   val DEFAULT_CLIENT_SECRET_ENV_NAME_PREFIX = "SKINNY_OAUTH2_CLIENT_SECRET"
 
-  val SESSION_OAUTH2_STATE_NAME = "SKINNY_OAUTH2_STATE"
+  val DEFAULT_SESSION_OAUTH2_STATE_NAME = "SKINNY_OAUTH2_STATE"
 
 }
 
@@ -30,6 +30,8 @@ trait OAuth2LoginFeature[U <: OAuth2User] extends SkinnyControllerBase {
   protected def clientSecretEnvName: String =
     OAuth2LoginFeature.DEFAULT_CLIENT_SECRET_ENV_NAME_PREFIX + "_" + provider.providerName.toUpperCase(Locale.ENGLISH)
 
+  protected def sessionOAuth2StateName: String = OAuth2LoginFeature.DEFAULT_SESSION_OAUTH2_STATE_NAME
+
   protected def clientId: String = sys.env(clientIdEnvName)
 
   protected def clientSecret: String = sys.env(clientSecretEnvName)
@@ -40,9 +42,9 @@ trait OAuth2LoginFeature[U <: OAuth2User] extends SkinnyControllerBase {
     digestedBytes.map("%02x".format(_)).mkString
   }
 
-  protected def state: String = session.get(OAuth2LoginFeature.SESSION_OAUTH2_STATE_NAME).map(_.toString).getOrElse {
+  protected def state: String = session.get(sessionOAuth2StateName).map(_.toString).getOrElse {
     val state: String = generateStateValue()
-    session.setAttribute(OAuth2LoginFeature.SESSION_OAUTH2_STATE_NAME, state)
+    session.setAttribute(sessionOAuth2StateName, state)
     state
   }
 

--- a/oauth2-controller/src/main/scala/skinny/controller/feature/SkinnySessionOAuth2LoginFeature.scala
+++ b/oauth2-controller/src/main/scala/skinny/controller/feature/SkinnySessionOAuth2LoginFeature.scala
@@ -3,11 +3,14 @@ package skinny.controller.feature
 import skinny.filter.SkinnySessionFilter
 import skinny.oauth2.client._
 
+/**
+ * SkinnySession wired OAuth2LoginFeature.
+ */
 trait SkinnySessionOAuth2LoginFeature[U <: OAuth2User] { self: OAuth2LoginFeature[U] with SkinnySessionFilter =>
 
-  override protected def state: String = skinnySession.getAs[String](OAuth2LoginFeature.SESSION_OAUTH2_STATE_NAME).getOrElse {
+  override protected def state: String = skinnySession.getAs[String](sessionOAuth2StateName).getOrElse {
     val state: String = generateStateValue()
-    skinnySession.setAttribute(OAuth2LoginFeature.SESSION_OAUTH2_STATE_NAME, state)
+    skinnySession.setAttribute(sessionOAuth2StateName, state)
     state
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -191,6 +191,15 @@ object SkinnyFrameworkBuild extends Build {
     )
   ) dependsOn(framework, oauth2)
 
+  lazy val twitterController = Project (id = "twitterController", base = file("twitter-controller"),
+    settings = baseSettings ++ Seq(
+      name := "skinny-twitter-controller",
+      libraryDependencies ++= Seq(
+        "org.twitter4j" % "twitter4j-core" % "4.0.2" % "compile"
+      ) ++ servletApiDependencies
+    )
+  ) dependsOn(framework)
+
   lazy val validator = Project (id = "validator", base = file("validator"),
     settings = baseSettings ++ Seq(
       name := "skinny-validator",
@@ -238,7 +247,18 @@ object SkinnyFrameworkBuild extends Build {
       parallelExecution in Test := false,
       unmanagedClasspath in Test <+= (baseDirectory) map { bd =>  Attributed.blank(bd / "src/main/webapp") } 
     ) 
-  ) dependsOn(framework, assets, thymeleaf, freemarker, factoryGirl, test, task, scaldi, oauth2Controller)
+  ) dependsOn(
+    framework, 
+    assets, 
+    thymeleaf, 
+    freemarker, 
+    factoryGirl, 
+    test, 
+    task, 
+    scaldi, 
+    oauth2Controller, 
+    twitterController
+  )
 
   // -----------------------------
   // common dependencies

--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,7 @@ sbt ++2.11.2 \
   json/publishSigned \
   oauth2/publishSigned \
   oauth2Controller/publishSigned \
+  twitterController/publishSigned \
   orm/publishSigned \
   factoryGirl/publishSigned \
   validator/publishSigned \
@@ -27,6 +28,7 @@ sbt ++2.11.2 \
   json/publishSigned \
   oauth2/publishSigned \
   oauth2Controller/publishSigned \
+  twitterController/publishSigned \
   orm/publishSigned \
   factoryGirl/publishSigned \
   validator/publishSigned \

--- a/publish_local.sh
+++ b/publish_local.sh
@@ -8,6 +8,7 @@ sbt clean \
   json/publishLocal \
   oauth2/publishLocal \
   oauth2Controller/publishLocal \
+  twitterController/publishLocal \
   orm/publishLocal \
   factoryGirl/publishLocal \
   validator/publishLocal \
@@ -26,6 +27,7 @@ sbt clean \
   json/publishLocal \
   oauth2/publishLocal \
   oauth2Controller/publishLocal \
+  twitterController/publishLocal \
   orm/publishLocal \
   factoryGirl/publishLocal \
   validator/publishLocal \

--- a/twitter-controller/src/main/scala/skinny/controller/feature/SkinnySessionTwitterLoginFeature.scala
+++ b/twitter-controller/src/main/scala/skinny/controller/feature/SkinnySessionTwitterLoginFeature.scala
@@ -1,0 +1,55 @@
+package skinny.controller.feature
+
+import skinny.filter.SkinnySessionFilter
+import twitter4j.auth.{AccessToken, RequestToken}
+
+/**
+ * SkinnySession wired TwitterLoginFeature.
+ */
+trait SkinnySessionTwitterLoginFeature extends TwitterLoginFeature { self: SkinnySessionFilter =>
+
+  // ----------------------------------------
+  // Request Token
+
+  override protected def saveRequestToken(requestToken: RequestToken): Unit = {
+    skinnySession.setAttribute(sessionRequestTokenName, requestToken.getToken)
+    skinnySession.setAttribute(sessionRequestTokenSecretName, requestToken.getTokenSecret)
+  }
+
+  override protected def currentRequestToken(): Option[RequestToken] = {
+    for {
+      token <- skinnySession.getAttribute(sessionRequestTokenName).map(_.toString)
+      tokenSecret <- skinnySession.getAttribute(sessionRequestTokenSecretName).map(_.toString)
+    } yield {
+      new RequestToken(token, tokenSecret)
+    }
+  }
+
+  override protected def deleteSavedRequestToken(): Unit = {
+    skinnySession.removeAttribute(sessionRequestTokenName)
+    skinnySession.removeAttribute(sessionRequestTokenSecretName)
+  }
+
+  // ----------------------------------------
+  // Access Token
+
+  override protected def saveAccessToken(accessToken: AccessToken): Unit = {
+    skinnySession.setAttribute(sessionAccessTokenName, accessToken.getToken)
+    skinnySession.setAttribute(sessionAccessTokenSecretName, accessToken.getTokenSecret)
+  }
+
+  override protected def currentAccessToken(): Option[AccessToken] = {
+    for {
+      token <- skinnySession.getAttribute(sessionAccessTokenName).map(_.toString)
+      tokenSecret <- skinnySession.getAttribute(sessionAccessTokenSecretName).map(_.toString)
+    } yield {
+      new AccessToken(token, tokenSecret)
+    }
+  }
+
+  override protected def deleteSavedAccessToken(): Unit = {
+    skinnySession.removeAttribute(sessionAccessTokenName)
+    skinnySession.removeAttribute(sessionAccessTokenSecretName)
+  }
+
+}

--- a/twitter-controller/src/main/scala/skinny/controller/feature/TwitterLoginFeature.scala
+++ b/twitter-controller/src/main/scala/skinny/controller/feature/TwitterLoginFeature.scala
@@ -1,0 +1,179 @@
+package skinny.controller.feature
+
+import skinny.controller.SkinnyControllerBase
+import twitter4j._
+import twitter4j.auth._
+import twitter4j.conf._
+
+/**
+ * Twitter OAuth 1.0a Login Feature.
+ */
+trait TwitterLoginFeature extends SkinnyControllerBase {
+
+  protected def isLocalDebug: Boolean = false
+
+  protected def isTwitter4jDebug: Boolean = true
+
+  // ----------------------------------------
+  // Env names
+
+  protected def consumerKeyEnvName: String = "SKINNY_OAUTH1_CONSUMER_KEY_TWITTER"
+
+  protected def consumerSecretEnvName: String = "SKINNY_OAUTH1_CONSUMER_SECRET_TWITTER"
+
+  // ----------------------------------------
+  // Session keys
+
+  protected def sessionRequestTokenName: String = "SKINNY_OAUTH1_REQUEST_TOKEN_TWITTER"
+
+  protected def sessionRequestTokenSecretName: String = "SKINNY_OAUTH1_REQUEST_TOKEN_SECRET_TWITTER"
+
+  protected def sessionAccessTokenName: String = "SKINNY_OAUTH1_ACCESS_TOKEN_TWITTER"
+
+  protected def sessionAccessTokenSecretName: String = "SKINNY_OAUTH1_ACCESS_TOKEN_SECRET_TWITTER"
+
+  // ----------------------------------------
+  // OAuth 1.0a consumer key/secret
+
+  protected def consumerKey: String = sys.env(consumerKeyEnvName)
+
+  protected def consumerSecret: String = sys.env(consumerSecretEnvName)
+
+  // ----------------------------------------
+  // Request Token
+
+  protected def saveRequestToken(requestToken: RequestToken): Unit = {
+    session.setAttribute(sessionRequestTokenName, requestToken.getToken)
+    session.setAttribute(sessionRequestTokenSecretName, requestToken.getTokenSecret)
+  }
+
+  protected def currentRequestToken(): Option[RequestToken] = {
+    for {
+      token <- Option(session.getAttribute(sessionRequestTokenName)).map(_.toString)
+      tokenSecret <- Option(session.getAttribute(sessionRequestTokenSecretName)).map(_.toString)
+    } yield {
+      new RequestToken(token, tokenSecret)
+    }
+  }
+
+  protected def deleteSavedRequestToken(): Unit = {
+    session.removeAttribute(sessionRequestTokenName)
+    session.removeAttribute(sessionRequestTokenSecretName)
+  }
+
+  // ----------------------------------------
+  // Access Token
+
+  protected def saveAccessToken(accessToken: AccessToken): Unit = {
+    println("SSS"+ accessToken.getToken)
+    session.setAttribute(sessionAccessTokenName, accessToken.getToken)
+    session.setAttribute(sessionAccessTokenSecretName, accessToken.getTokenSecret)
+  }
+
+  protected def currentAccessToken(): Option[AccessToken] = {
+    for {
+      token <- Option(session.getAttribute(sessionAccessTokenName)).map(_.toString)
+      tokenSecret <- Option(session.getAttribute(sessionAccessTokenSecretName)).map(_.toString)
+    } yield {
+      new AccessToken(token, tokenSecret)
+    }
+  }
+
+  protected def deleteSavedAccessToken(): Unit = {
+    session.removeAttribute(sessionAccessTokenName)
+    session.removeAttribute(sessionAccessTokenSecretName)
+  }
+
+  // ----------------------------------------
+  // event handlers
+
+  protected def saveAuthorizedUser(user: User): Unit
+
+  protected def handleWhenLoginFailed(): Any = haltWithBody(401)
+
+  protected def handleWhenLoginSucceeded(): Any
+
+  // ----------------------------------------
+  // Twitter4j
+
+  protected lazy val twitter4jConfiguration: Configuration = {
+    new ConfigurationBuilder()
+      .setDebugEnabled(isTwitter4jDebug)
+      .setOAuthConsumerKey(consumerKey)
+      .setOAuthConsumerSecret(consumerSecret)
+      .build()
+  }
+
+  protected lazy val twitterFactory: TwitterFactory = {
+    new TwitterFactory(twitter4jConfiguration)
+  }
+
+  protected def twitter: Option[Twitter] = currentAccessToken.map(t => twitter(t)) 
+
+  protected def twitter(accessToken: AccessToken): Twitter = twitterFactory.getInstance(accessToken)
+
+  // ----------------------------------------
+  // Actions
+
+  /**
+   * Redirects users to OAuth provider's authentication endpoint.
+   */
+  def loginRedirect: Any = {
+    val twitter: Twitter = twitterFactory.getInstance
+    val requestToken: RequestToken = twitter.getOAuthRequestToken
+    logger.debug(s"request token when redirecting: ${requestToken}")
+    saveRequestToken(requestToken)
+    redirect(requestToken.getAuthorizationURL)
+  }
+
+  /**
+   * Accepts callback response from OAuth provider.
+   */
+  def callback: Any = {
+    logger.debug(s"request token in session: ${currentRequestToken}")
+    logger.debug(s"oauth_token: ${params.get("oauth_token")}, oauth_verifier: ${params.get("oauth_verifier")}")
+
+    try {
+      (for {
+        requestToken <- currentRequestToken
+        token <- params.getAs[String]("oauth_token") if token == requestToken.getToken
+        verifier <- params.getAs[String]("oauth_verifier")
+      } yield {
+
+        val twitter: Twitter = twitterFactory.getInstance
+        // access token retrieval
+        val accessToken: AccessToken = try {
+          twitter.getOAuthAccessToken(requestToken, verifier)
+        } catch { case e: TwitterException =>
+          logger.error(s"Failed to retrieve access token because ${e.getMessage}", e)
+          handleWhenLoginFailed()
+          haltWithBody(401) // will be dead code
+        }
+        saveAccessToken(accessToken)
+        twitter.setOAuthAccessToken(accessToken)
+
+        // retrieve current user information
+        val user: User = try {
+          twitter.showUser(twitter.getId)
+        } catch { case e: TwitterException =>
+          logger.error(s"Failed to retrieve user information because ${e.getMessage}", e)
+          handleWhenLoginFailed()
+          haltWithBody(401) // will be dead code
+        }
+        saveAuthorizedUser(user)
+
+        // login succeeded
+        handleWhenLoginSucceeded()
+
+      }).getOrElse {
+        handleWhenLoginFailed()
+      }
+
+    } finally {
+      if (!isLocalDebug) {
+        deleteSavedRequestToken()
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Although it's possible to support general OAuth 1.0a implementation, lots of developers just need Twitter OAuth. So that's reasonable to support only Twitter with convenient twitter4j.

refs #8
