### PR TITLE
Add response headers for security improvements

### DIFF
--- a/example/src/test/scala/integrationtest/AssetsSpec.scala
+++ b/example/src/test/scala/integrationtest/AssetsSpec.scala
@@ -13,6 +13,9 @@ class AssetsSpec extends ScalatraFlatSpec with SkinnyTestSupport {
     get("/assets/js/hello-react.js") {
       status should equal(200)
       header("Content-Type") should equal("application/javascript; charset=UTF-8")
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
+
       body.replaceFirst("\n$", "") should equal(
         """/** @jsx React.DOM */
          |React.renderComponent(

--- a/example/src/test/scala/integrationtest/CompaniesControllerSpec.scala
+++ b/example/src/test/scala/integrationtest/CompaniesControllerSpec.scala
@@ -17,6 +17,8 @@ class CompaniesControllerSpec extends ScalatraFlatSpec with unit.SkinnyTesting {
   it should "show companies" in {
     get("/companies") {
       status should equal(200)
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
     }
     get("/companies/") {
       status should equal(200)

--- a/example/src/test/scala/integrationtest/RootControllerSpec.scala
+++ b/example/src/test/scala/integrationtest/RootControllerSpec.scala
@@ -22,6 +22,9 @@ class RootControllerSpec extends ScalatraFlatSpec with unit.SkinnyTesting {
     get("/?echo=abcdEFG") {
       status should equal(200)
       body should include("abcdEFG")
+
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
     }
     get("/mock/?echo=abcdEFG") {
       status should equal(200)

--- a/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
@@ -35,6 +35,7 @@ trait SkinnyControllerBase
     with TimeLoggingFeature
     with ThreadLocalRequestFeature
     with SnakeCasedParamKeysFeature
+    with XContentTypeOptionsNosniffHeaderFeature
     with RoutesAsImplicits
     with ParametersGetAsImplicits
     with ParamsPermitImplicits

--- a/framework/src/main/scala/skinny/controller/SkinnyWebPageControllerFeatures.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyWebPageControllerFeatures.scala
@@ -1,6 +1,6 @@
 package skinny.controller
 
-import skinny.controller.feature.{ CSRFProtectionFeature, ScalateTemplateEngineFeature, TemplateEngineFeature, FlashFeature }
+import skinny.controller.feature._
 
 /**
  * Additional web pages specific features for SkinnyControllers.
@@ -10,7 +10,8 @@ trait SkinnyWebPageControllerFeatures
     with FlashFeature
     with TemplateEngineFeature
     with ScalateTemplateEngineFeature
-    with CSRFProtectionFeature {
+    with CSRFProtectionFeature
+    with XXSSProtectionHeaderFeature {
 
   override def handleForgeryIfDetected() = haltWithBody(403)
 

--- a/framework/src/main/scala/skinny/controller/feature/XContentTypeOptionsNosniffHeaderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/XContentTypeOptionsNosniffHeaderFeature.scala
@@ -1,0 +1,21 @@
+package skinny.controller.feature
+
+import org.scalatra.SkinnyScalatraBase
+
+/**
+ * X-Content-Type-Options header support.
+ *
+ * - https://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx?Redirected=true
+ * - http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
+ * - https://github.com/blog/1482-heads-up-nosniff-header-support-coming-to-chrome-and-firefox
+ * - https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+ */
+trait XContentTypeOptionsNosniffHeaderFeature { self: SkinnyScalatraBase with BeforeAfterActionFeature =>
+
+  // NOTE: To force this header to all responses
+  //beforeAction() {
+  before() {
+    response.setHeader("X-Content-Type-Options", "nosniff")
+  }
+
+}

--- a/framework/src/main/scala/skinny/controller/feature/XXSSProtectionHeaderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/XXSSProtectionHeaderFeature.scala
@@ -1,0 +1,17 @@
+package skinny.controller.feature
+
+import org.scalatra.SkinnyScalatraBase
+
+/**
+ * X-XSS-Protection header support
+ *
+ * - https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+ */
+trait XXSSProtectionHeaderFeature { self: SkinnyScalatraBase with BeforeAfterActionFeature =>
+
+  // NOTE: for all HTML responses defined as Skinny routes
+  beforeAction() {
+    response.setHeader("X-XSS-Protection", "1; mode=block")
+  }
+
+}

--- a/framework/src/test/scala/skinny/controller/ScalateTemplateEngineFeaturespec.scala
+++ b/framework/src/test/scala/skinny/controller/ScalateTemplateEngineFeaturespec.scala
@@ -1,11 +1,10 @@
 package skinny.controller
 
 import org.scalatra.test.scalatest.ScalatraFlatSpec
-import javax.servlet.ServletContext
-import javax.servlet.http.HttpServletRequest
-import skinny.Format
 import org.scalatest.BeforeAndAfter
 import java.io.File
+
+import skinny.Routes
 
 class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAfter {
 
@@ -27,13 +26,13 @@ class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAf
     get("/default/xyz")(xyz)
   }
 
-  object SspOnlyController extends SkinnyController {
+  object SspOnlyController extends SkinnyController with Routes {
     override def scalateExtensions = List("ssp")
     def a = render("foo/a")
     def c = render("foo/c")
     def xyz = render("foo/xyz")
 
-    get("/ssp/a")(a)
+    get("/ssp/a")(a).as('a)
     get("/ssp/c")(c)
     get("/ssp/xyz")(xyz)
   }
@@ -94,6 +93,8 @@ class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAf
     get("/ssp/a") {
       status should be(200)
       body should include("<p>This is SSP template A")
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
     }
   }
 

--- a/framework/src/test/scala/skinny/controller/SkinnyApiControllerSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiControllerSpec.scala
@@ -48,6 +48,7 @@ class SkinnyApiControllerSpec extends ScalatraFlatSpec {
 
   it should "have creation API" in {
     post("/companies", "name" -> "CompanyName", "url" -> "http://www.example.com/") {
+      header("X-Content-Type-Options") should equal("nosniff")
       status should equal(201)
     }
   }

--- a/framework/src/test/scala/skinny/controller/SkinnyApiResourceSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiResourceSpec.scala
@@ -48,6 +48,7 @@ class SkinnyApiResourceSpec extends ScalatraFlatSpec {
   it should "have list APIs" in {
     get("/bar/apis.json") {
       status should equal(200)
+      header("X-Content-Type-Options") should equal("nosniff")
       header("Content-Type") should equal("application/json; charset=utf-8")
     }
     get("/bar/apis.xml") {

--- a/framework/src/test/scala/skinny/controller/SkinnyApiServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiServletSpec.scala
@@ -44,6 +44,7 @@ class SkinnyApiServletSpec extends ScalatraFlatSpec {
 
   it should "have creation API" in {
     post("/companies", "name" -> "CompanyName", "url" -> "http://www.example.com/") {
+      header("X-Content-Type-Options") should equal("nosniff")
       status should equal(201)
     }
   }

--- a/framework/src/test/scala/skinny/controller/SkinnyResourceServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyResourceServletSpec.scala
@@ -53,6 +53,8 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
   it should "have list APIs" in {
     post("/foo/apis.json", "name" -> "Twitter API", "url" -> "https://dev.twitter.com/") {
       status should equal(201)
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
       header("Content-Type") should equal("application/json; charset=utf-8")
     }
     get("/foo/apis.json") {

--- a/framework/src/test/scala/skinny/controller/SkinnyResourceSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyResourceSpec.scala
@@ -53,6 +53,8 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
   it should "have list APIs" in {
     post("/foo/apis.json", "name" -> "Twitter API", "url" -> "https://dev.twitter.com/") {
       status should equal(201)
+      header("X-Content-Type-Options") should equal("nosniff")
+      header("X-XSS-Protection") should equal("1; mode=block")
       header("Content-Type") should equal("application/json; charset=utf-8")
     }
     get("/foo/apis.json") {


### PR DESCRIPTION
- "X-Content-Type-Options: nosniff" for all responses
- "X-XSS-Protection: 1; mode=block" for HTML responses
