### PR TITLE
Enable code generator more customizable

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import scala.language.postfixOps
 
 object SkinnyFrameworkBuild extends Build {
 
-  lazy val currentVersion = "1.3.5"
+  lazy val currentVersion = "1.3.6-SNAPSHOT"
   lazy val scalatraVersion = "2.3.0"
   lazy val json4SVersion = "3.2.11"
   lazy val scalikeJDBCVersion = "2.2.0"
@@ -60,7 +60,7 @@ object SkinnyFrameworkBuild extends Build {
    settings = baseSettings ++ Seq(
       name := "skinny-http-client",
       libraryDependencies ++= Seq(
-        "org.specs2"         %% "specs2-core"        % "2.4.11"           % "test",
+        "org.specs2"         %% "specs2-core"        % "2.4.14"           % "test",
         "commons-fileupload" %  "commons-fileupload" % "1.3.1"            % "test",
         "commons-io"         %  "commons-io"         % "2.4"              % "test",
         "commons-httpclient" %  "commons-httpclient" % "3.1"              % "test",
@@ -311,7 +311,7 @@ object SkinnyFrameworkBuild extends Build {
     "org.scalikejdbc" %% "scalikejdbc-test"                 % scalikeJDBCVersion % "test"
   )
   lazy val jodaDependencies = Seq(
-    "joda-time" %  "joda-time"    % "2.5"   % "compile",
+    "joda-time" %  "joda-time"    % "2.6"   % "compile",
     "org.joda"  %  "joda-convert" % "1.7"   % "compile"
   )
   lazy val mailDependencies = slf4jApiDependencies ++ Seq(

--- a/task/src/main/scala/skinny/task/DefaultTaskLauncher.scala
+++ b/task/src/main/scala/skinny/task/DefaultTaskLauncher.scala
@@ -1,0 +1,36 @@
+package skinny.task
+
+import skinny.task.generator._
+import skinny.dbmigration.DBMigration
+import skinny.SkinnyEnv
+
+/**
+ * Task launcher.
+ */
+trait DefaultTaskLauncher extends SkinnyTaskLauncher {
+
+  // built-in tasks
+  register("generate:controller", (params) => ControllerGenerator.run(params))
+  register("generate:model", (params) => ModelGenerator.run(params))
+  register("generate:migration", (params) => DBMigrationFileGenerator.run(params))
+  register("generate:scaffold", (params) => ScaffoldSspGenerator.run(params))
+  register("generate:scaffold:ssp", (params) => ScaffoldSspGenerator.run(params))
+  register("generate:scaffold:scaml", (params) => ScaffoldScamlGenerator.run(params))
+  register("generate:scaffold:jade", (params) => ScaffoldJadeGenerator.run(params))
+  register("generate:reverse-model", (params) => ReverseModelGenerator.run(params))
+  register("generate:reverse-scaffold", (params) => ReverseScaffoldGenerator.run("ssp", params))
+  register("generate:reverse-scaffold:ssp", (params) => ReverseScaffoldGenerator.run("ssp", params))
+  register("generate:reverse-scaffold:scaml", (params) => ReverseScaffoldGenerator.run("scaml", params))
+  register("generate:reverse-scaffold:jade", (params) => ReverseScaffoldGenerator.run("jade", params))
+
+  register("db:migrate", {
+    case env :: dbName :: rest => DBMigration.migrate(env, dbName)
+    case params => DBMigration.migrate(params.headOption.getOrElse(SkinnyEnv.Development))
+  })
+  register("db:repair", {
+    case env :: dbName :: rest => DBMigration.repair(env, dbName)
+    case params => DBMigration.repair(params.headOption.getOrElse(SkinnyEnv.Development))
+  })
+
+}
+

--- a/task/src/main/scala/skinny/task/SkinnyTaskLauncher.scala
+++ b/task/src/main/scala/skinny/task/SkinnyTaskLauncher.scala
@@ -1,0 +1,30 @@
+package skinny.task
+
+trait SkinnyTaskLauncher {
+
+  /**
+   * Registered tasks.
+   */
+  private[this] val tasks = new scala.collection.mutable.HashMap[String, (List[String]) => Unit]
+
+  def register(name: String, runner: (List[String]) => Unit) = tasks.update(name, runner)
+
+  def showUsage = {
+    println(
+      s"""
+        | Usage: sbt "task/run [task] [options...]
+        |
+        |${tasks.map(t => "  " + t._1).mkString("\n")}
+        |
+        |""".stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    args.toList match {
+      case name :: parameters =>
+        tasks.get(name).map(_.apply(parameters)).getOrElse(println(s"Task for ${name} not found."))
+      case _ => showUsage
+    }
+  }
+
+}

--- a/task/src/main/scala/skinny/task/TaskLauncher.scala
+++ b/task/src/main/scala/skinny/task/TaskLauncher.scala
@@ -1,61 +1,9 @@
 package skinny.task
 
-import skinny.task.generator._
-import skinny.dbmigration.DBMigration
-import skinny.SkinnyEnv
-
 /**
- * Task launcher.
+ * Task launcher trait to keep backward compatibility.
  */
-trait TaskLauncher {
-
-  /**
-   * Registered tasks.
-   */
-  private[this] val tasks = new scala.collection.mutable.HashMap[String, (List[String]) => Unit]
-
-  // built-in tasks
-  register("generate:controller", (params) => ControllerGenerator.run(params))
-  register("generate:model", (params) => ModelGenerator.run(params))
-  register("generate:migration", (params) => DBMigrationFileGenerator.run(params))
-  register("generate:scaffold", (params) => ScaffoldSspGenerator.run(params))
-  register("generate:scaffold:ssp", (params) => ScaffoldSspGenerator.run(params))
-  register("generate:scaffold:scaml", (params) => ScaffoldScamlGenerator.run(params))
-  register("generate:scaffold:jade", (params) => ScaffoldJadeGenerator.run(params))
-  register("generate:reverse-model", (params) => ReverseModelGenerator.run(params))
-  register("generate:reverse-scaffold", (params) => ReverseScaffoldGenerator.run("ssp", params))
-  register("generate:reverse-scaffold:ssp", (params) => ReverseScaffoldGenerator.run("ssp", params))
-  register("generate:reverse-scaffold:scaml", (params) => ReverseScaffoldGenerator.run("scaml", params))
-  register("generate:reverse-scaffold:jade", (params) => ReverseScaffoldGenerator.run("jade", params))
-
-  register("db:migrate", {
-    case env :: dbName :: rest => DBMigration.migrate(env, dbName)
-    case params => DBMigration.migrate(params.headOption.getOrElse(SkinnyEnv.Development))
-  })
-  register("db:repair", {
-    case env :: dbName :: rest => DBMigration.repair(env, dbName)
-    case params => DBMigration.repair(params.headOption.getOrElse(SkinnyEnv.Development))
-  })
-
-  def register(name: String, runner: (List[String]) => Unit) = tasks.update(name, runner)
-
-  def showUsage = {
-    println(
-      s"""
-        | Usage: sbt "task/run [task] [options...]
-        |
-        |${tasks.map(t => "  " + t._1).mkString("\n")}
-        |
-        |""".stripMargin)
-  }
-
-  def main(args: Array[String]) {
-    args.toList match {
-      case name :: parameters =>
-        tasks.get(name).map(_.apply(parameters)).getOrElse(println(s"Task for ${name} not found."))
-      case _ => showUsage
-    }
-  }
+trait TaskLauncher extends DefaultTaskLauncher {
 
 }
 

--- a/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
@@ -17,6 +17,22 @@ import scala.io.Source
  */
 trait CodeGenerator {
 
+  def sourceDir = "src/main/scala"
+
+  def testSourceDir = "src/test/scala"
+
+  def resourceDir = "src/main/resources"
+
+  def testResourceDir = "src/test/resources"
+
+  def webInfDir = "src/main/webapp/WEB-INF"
+
+  // If you prefer Play Framework's style, override this and specify "controllers"
+  def controllerPackage: String = "controller"
+
+  // If you prefer Play Framework's style, override this and specify "models"
+  def modelPackage: String = "model"
+
   def toVariable(name: String) = name.head.toLower + name.tail
 
   def toClassName(name: String) = name.head.toUpper + name.tail
@@ -116,7 +132,7 @@ trait CodeGenerator {
 
   def appendToControllers(namespaces: Seq[String], name: String) {
     val controllerName = toControllerName(namespaces, name)
-    val controllerClassName = toNamespace("_root_.controller", namespaces) + "." + toControllerClassName(name)
+    val controllerClassName = toNamespace(s"_root_.${controllerPackage}", namespaces) + "." + toControllerClassName(name)
     val newMountCode =
       s"""def mount(ctx: ServletContext): Unit = {
         |    ${controllerName}.mount(ctx)""".stripMargin
@@ -128,7 +144,7 @@ trait CodeGenerator {
         |""".stripMargin
     }
 
-    val file = new File("src/main/scala/controller/Controllers.scala")
+    val file = new File(s"${sourceDir}/${controllerPackage}/Controllers.scala")
     if (file.exists()) {
       val code = Source.fromFile(file).mkString
         .replaceFirst("(def\\s+mount\\s*\\(ctx:\\s+ServletContext\\):\\s*Unit\\s*=\\s*\\{)", newMountCode)
@@ -136,9 +152,9 @@ trait CodeGenerator {
       forceWrite(file, code)
     } else {
       val fullNewCode =
-        s"""package controller
+        s"""package ${controllerPackage}
           |
-          |import _root_.controller._
+          |import _root_.${controllerPackage}._
           |import skinny._
           |import skinny.controller.AssetsController
           |

--- a/task/src/main/scala/skinny/task/generator/ControllerGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ControllerGenerator.scala
@@ -40,9 +40,9 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def code(namespaces: Seq[String], name: String): String = {
-    s"""package ${toNamespace("controller", namespaces)}
+    s"""package ${toNamespace(controllerPackage, namespaces)}
         |
-        |${if (!namespaces.isEmpty) "import _root_.controller._\n"}import skinny._
+        |${if (!namespaces.isEmpty) s"import _root_.${controllerPackage}._\n"}import skinny._
         |import skinny.validator._
         |
         |class ${toClassName(name)}Controller extends ApplicationController {
@@ -55,9 +55,9 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def generateApplicationControllerIfAbsent() {
-    val file = new File(s"src/main/scala/controller/ApplicationController.scala")
+    val file = new File(s"${sourceDir}/${controllerPackage}/ApplicationController.scala")
     writeIfAbsent(file,
-      """package controller
+      s"""package ${controllerPackage}
         |
         |import skinny._
         |import skinny.filter._
@@ -79,13 +79,13 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def generate(namespaces: Seq[String], name: String) {
-    val file = new File(s"src/main/scala/${toDirectoryPath("controller", namespaces)}/${toClassName(name)}Controller.scala")
+    val file = new File(s"${sourceDir}/${toDirectoryPath(controllerPackage, namespaces)}/${toClassName(name)}Controller.scala")
     writeIfAbsent(file, code(namespaces, name))
   }
 
   override def appendToControllers(namespaces: Seq[String], name: String) {
     val controllerName = toControllerName(namespaces, name)
-    val controllerClassName = toNamespace("_root_.controller", namespaces) + "." + toControllerClassName(name)
+    val controllerClassName = toNamespace(s"_root_.${controllerPackage}", namespaces) + "." + toControllerClassName(name)
     val newMountCode =
       s"""def mount(ctx: ServletContext): Unit = {
         |    ${controllerName}.mount(ctx)""".stripMargin
@@ -103,7 +103,7 @@ trait ControllerGenerator extends CodeGenerator {
       |""".stripMargin
     }
 
-    val file = new File("src/main/scala/controller/Controllers.scala")
+    val file = new File(s"${sourceDir}/${controllerPackage}/Controllers.scala")
     if (file.exists()) {
       val code = Source.fromFile(file).mkString
         .replaceFirst("(def\\s+mount\\s*\\(ctx:\\s+ServletContext\\):\\s*Unit\\s*=\\s*\\{)", newMountCode)
@@ -111,9 +111,9 @@ trait ControllerGenerator extends CodeGenerator {
       forceWrite(file, code)
     } else {
       val fullNewCode =
-        s"""package controller
+        s"""package ${controllerPackage}
           |
-          |import _root_.controller._
+          |import _root_.${controllerPackage}._
           |import skinny._
           |import skinny.controller.AssetsController
           |
@@ -130,7 +130,7 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def controllerSpec(namespaces: Seq[String], name: String): String = {
-    val namespace = toNamespace("controller", namespaces)
+    val namespace = toNamespace(controllerPackage, namespaces)
     val controllerClassName = toClassName(name) + "Controller"
     val viewTemplatesPath = s"${toResourcesBasePath(namespaces)}/${name}"
 
@@ -163,7 +163,7 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def generateControllerSpec(namespaces: Seq[String], name: String) {
-    val specFile = new File(s"src/test/scala/${toDirectoryPath("controller", namespaces)}/${toClassName(name)}ControllerSpec.scala")
+    val specFile = new File(s"${testSourceDir}/${toDirectoryPath(controllerPackage, namespaces)}/${toClassName(name)}ControllerSpec.scala")
     writeIfAbsent(specFile, controllerSpec(namespaces, name))
   }
 
@@ -181,7 +181,7 @@ trait ControllerGenerator extends CodeGenerator {
         |import skinny._
         |import skinny.test._
         |import org.joda.time._
-        |import _root_.controller.Controllers
+        |import _root_.${controllerPackage}.Controllers
         |
         |class ${toClassName(name)}Controller_IntegrationTestSpec extends ScalatraFlatSpec with SkinnyTestSupport {
         |  addFilter(Controllers.${toControllerName(namespaces, name)}, "/*")
@@ -198,7 +198,7 @@ trait ControllerGenerator extends CodeGenerator {
   }
 
   def generateIntegrationSpec(namespaces: Seq[String], name: String) {
-    val specFile = new File(s"src/test/scala/${toDirectoryPath("integrationtest", namespaces)}/${toClassName(name)}Controller_IntegrationTestSpec.scala")
+    val specFile = new File(s"${testSourceDir}/${toDirectoryPath("integrationtest", namespaces)}/${toClassName(name)}Controller_IntegrationTestSpec.scala")
     writeIfAbsent(specFile, integrationSpec(namespaces, name))
   }
 

--- a/task/src/main/scala/skinny/task/generator/DBMigrationFileGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/DBMigrationFileGenerator.scala
@@ -28,7 +28,7 @@ trait DBMigrationFileGenerator extends CodeGenerator {
 
   def generate(name: String, sql: String): Unit = {
     val version = DateTime.now.toString("yyyyMMddHHmmss")
-    val file = new File(s"src/main/resources/db/migration/V${version}__${name}.sql")
+    val file = new File(s"${resourceDir}/db/migration/V${version}__${name}.sql")
     writeIfAbsent(file, sql)
   }
 

--- a/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ModelGenerator.scala
@@ -10,6 +10,7 @@ import org.apache.commons.io.FileUtils
 object ModelGenerator extends ModelGenerator {
   override def withTimestamps: Boolean = true
 }
+
 object ModelWithoutTimestampsGenerator extends ModelGenerator {
   override def withTimestamps: Boolean = false
 }
@@ -57,7 +58,7 @@ trait ModelGenerator extends CodeGenerator {
   }
 
   def code(namespaces: Seq[String], name: String, tableName: Option[String], attributePairs: Seq[(String, String)]): String = {
-    val namespace = toNamespace("model", namespaces)
+    val namespace = toNamespace(modelPackage, namespaces)
     val modelClassName = toClassName(name)
     val alias = modelClassName.filter(_.isUpper).map(_.toLower).mkString
     val timestampPrefix = if (withId) ",\n" else { if (attributePairs.isEmpty) "" else ",\n" }
@@ -142,12 +143,12 @@ trait ModelGenerator extends CodeGenerator {
   }
 
   def generate(namespaces: Seq[String], name: String, tableName: Option[String], attributePairs: Seq[(String, String)]) {
-    val productionFile = new File(s"src/main/scala/${toDirectoryPath("model", namespaces)}/${toClassName(name)}.scala")
+    val productionFile = new File(s"${sourceDir}/${toDirectoryPath(modelPackage, namespaces)}/${toClassName(name)}.scala")
     writeIfAbsent(productionFile, code(namespaces, name, tableName, attributePairs))
   }
 
   def spec(namespaces: Seq[String], name: String): String = {
-    s"""package ${toNamespace("model", namespaces)}
+    s"""package ${toNamespace(modelPackage, namespaces)}
         |
         |import skinny.DBSettings
         |import skinny.test._
@@ -163,7 +164,7 @@ trait ModelGenerator extends CodeGenerator {
   }
 
   def generateSpec(namespaces: Seq[String], name: String, attributePairs: Seq[(String, String)]) {
-    val specFile = new File(s"src/test/scala/${toDirectoryPath("model", namespaces)}/${toClassName(name)}Spec.scala")
+    val specFile = new File(s"${testSourceDir}/${toDirectoryPath(modelPackage, namespaces)}/${toClassName(name)}Spec.scala")
     FileUtils.forceMkdir(specFile.getParentFile)
     writeIfAbsent(specFile, spec(namespaces, name))
   }

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGeneratorArg.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGeneratorArg.scala
@@ -1,3 +1,6 @@
 package skinny.task.generator
 
-case class ScaffoldGeneratorArg(name: String, typeName: String, columnName: Option[String] = None)
+case class ScaffoldGeneratorArg(
+  name: String,
+  typeName: String,
+  columnName: Option[String] = None)

--- a/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
@@ -16,7 +16,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
 
   val packageImportsWarning =
     s"""-# Be aware of package imports.
-       |-# 1. src/main/scala/templates/ScalatePackage.scala
+       |-# 1. ${sourceDir}/templates/ScalatePackage.scala
        |-# 2. scalateTemplateConfig in project/Build.scala""".stripMargin
 
   override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
@@ -148,7 +148,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
     s"""-@val s: skinny.Skinny
-        |-@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}]
+        |-@val items: Seq[${toNamespace(modelPackage, namespaces)}.${modelClassName}]
         |-@val totalPages: Int
         |-@val page: Int = s.params.page.map(_.toString.toInt).getOrElse(1)
         |
@@ -204,7 +204,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |""".stripMargin
     }.mkString
 
-    s"""-@val item: ${toNamespace("model", namespaces)}.${modelClassName}
+    s"""-@val item: ${toNamespace(modelPackage, namespaces)}.${modelClassName}
         |-@val s: skinny.Skinny
         |
         |${packageImportsWarning}

--- a/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
@@ -16,7 +16,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
 
   val packageImportsWarning =
     s"""-# Be aware of package imports.
-       |-# 1. src/main/scala/templates/ScalatePackage.scala
+       |-# 1. ${sourceDir}/templates/ScalatePackage.scala
        |-# 2. scalateTemplateConfig in project/Build.scala""".stripMargin
 
   override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
@@ -148,7 +148,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
     s"""-@val s: skinny.Skinny
-        |-@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}]
+        |-@val items: Seq[${toNamespace(modelPackage, namespaces)}.${modelClassName}]
         |-@val totalPages: Int
         |-@val page: Int = s.params.page.map(_.toString.toInt).getOrElse(1)
         |
@@ -205,7 +205,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |""".stripMargin
     }.mkString
 
-    s"""-@val item: ${toNamespace("model", namespaces)}.${modelClassName}
+    s"""-@val item: ${toNamespace(modelPackage, namespaces)}.${modelClassName}
         |-@val s: skinny.Skinny
         |
         |${packageImportsWarning}

--- a/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
@@ -14,7 +14,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
 
   val packageImportsWarning =
     s"""<%-- Be aware of package imports.
-        | 1. src/main/scala/templates/ScalatePackage.scala
+        | 1. ${sourceDir}/templates/ScalatePackage.scala
         | 2. scalateTemplateConfig in project/Build.scala
         |--%>""".stripMargin
 
@@ -201,7 +201,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
     s"""<%@val s: skinny.Skinny %>
-        |<%@val items: Seq[${toNamespace("model", namespaces)}.${modelClassName}] %>
+        |<%@val items: Seq[${toNamespace(modelPackage, namespaces)}.${modelClassName}] %>
         |<%@val totalPages: Int %>
         |<%@val page: Int = s.params.page.map(_.toString.toInt).getOrElse(1) %>
         |
@@ -267,7 +267,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
   override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, attributePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
-    val modelNamespace = toNamespace("model", namespaces)
+    val modelNamespace = toNamespace(modelPackage, namespaces)
     val attributesPart = ((primaryKeyName -> "Long") :: attributePairs.toList).map {
       case (name, _) =>
         s"""  <tr>

--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -16,7 +16,7 @@ object SkinnyAppBuild extends Build {
   val appName = "skinny-blank-app"
   val appVersion = "0.1.0-SNAPSHOT"
 
-  val skinnyVersion = "1.3.5"
+  val skinnyVersion = "1.3.6-SNAPSHOT"
   val scalatraVersion = "2.3.0"
   val theScalaVersion = "2.11.4"
   val jettyVersion = "9.2.1.v20140609" // latest: 9.2.5.v20141112
@@ -54,8 +54,6 @@ object SkinnyAppBuild extends Build {
     transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
     // the name-hashing algorithm for the incremental compiler.
     incOptions := incOptions.value.withNameHashing(true),
-    // https://github.com/sbt/sbt/blob/0.13/notes/0.13.7.markdown#cached-resolution-minigraph-caching
-    updateOptions := updateOptions.value.withCachedResolution(true),
     logBuffered in Test := false,
     javaOptions in Test ++= Seq("-Dskinny.env=test"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),


### PR DESCRIPTION
This PR enables customizing output directories and controller/model package names.

The following example shows how to integrate with Play Framework apps.
### build.sbt

``` scala
lazy val task = (project in file("task")).settings(
  scalaSource in Compile := baseDirectory.value,
  libraryDependencies += "org.skinny-framework" %% "skinny-task" % skinnyVersion,
  mainClass := Some("TaskRunnner")
)
```
### task/TaskRunner.scala

``` scala
import skinny.task._, generator._
object TaskRunner extends SkinnyTaskLauncher {

  lazy val modelGenerator = new ModelGenerator {
    override def sourceDir = "app"
    override def testSourceDir = "test"
    override def modelPackage = "models"
  }

  register("generate:model", (params) => {
    modelGenerator.run(params)
  })
}
```
### How to run

```
$ sbt "task/run generate:model Person name:String"
...
[info] Running TaskRunner generate:model Person name:String

 *** Skinny Generator Task ***

  "app/models/Person.scala" created.
  "test/models/PersonSpec.scala" created.

[success] Total time: 0 s, completed 2014/12/05 00:00:00
```
