### PR TITLE
Add reverse-scaffold-all/reverse-model-all command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ standalone-build
 ivy2
 
 skinny-*.tar.gz
+tmp
 

--- a/task/src/main/scala/skinny/task/DefaultTaskLauncher.scala
+++ b/task/src/main/scala/skinny/task/DefaultTaskLauncher.scala
@@ -13,15 +13,23 @@ trait DefaultTaskLauncher extends SkinnyTaskLauncher {
   register("generate:controller", (params) => ControllerGenerator.run(params))
   register("generate:model", (params) => ModelGenerator.run(params))
   register("generate:migration", (params) => DBMigrationFileGenerator.run(params))
+
   register("generate:scaffold", (params) => ScaffoldSspGenerator.run(params))
   register("generate:scaffold:ssp", (params) => ScaffoldSspGenerator.run(params))
   register("generate:scaffold:scaml", (params) => ScaffoldScamlGenerator.run(params))
   register("generate:scaffold:jade", (params) => ScaffoldJadeGenerator.run(params))
+
   register("generate:reverse-model", (params) => ReverseModelGenerator.run(params))
-  register("generate:reverse-scaffold", (params) => ReverseScaffoldGenerator.run("ssp", params))
-  register("generate:reverse-scaffold:ssp", (params) => ReverseScaffoldGenerator.run("ssp", params))
-  register("generate:reverse-scaffold:scaml", (params) => ReverseScaffoldGenerator.run("scaml", params))
-  register("generate:reverse-scaffold:jade", (params) => ReverseScaffoldGenerator.run("jade", params))
+  register("generate:reverse-model-all", (params) => ReverseModelAllGenerator.run(params))
+
+  register("generate:reverse-scaffold", (params) => ReverseScaffoldGenerator.run("ssp", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold:ssp", (params) => ReverseScaffoldGenerator.run("ssp", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold:scaml", (params) => ReverseScaffoldGenerator.run("scaml", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold:jade", (params) => ReverseScaffoldGenerator.run("jade", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold-all", (params) => ReverseScaffoldAllGenerator.run("ssp", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold-all:ssp", (params) => ReverseScaffoldAllGenerator.run("ssp", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold-all:scaml", (params) => ReverseScaffoldAllGenerator.run("scaml", params, SkinnyEnv.get()))
+  register("generate:reverse-scaffold-all:jade", (params) => ReverseScaffoldAllGenerator.run("jade", params, SkinnyEnv.get()))
 
   register("db:migrate", {
     case env :: dbName :: rest => DBMigration.migrate(env, dbName)

--- a/task/src/main/scala/skinny/task/generator/ReverseGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseGenerator.scala
@@ -1,0 +1,43 @@
+package skinny.task.generator
+
+import scalikejdbc.DB
+import scalikejdbc.metadata.{ Table, ForeignKey }
+
+trait ReverseGenerator extends CodeGenerator {
+
+  def extractAssociationParams(tableName: String, pkName: Option[String], cachedTables: Seq[Table]): Seq[String] = {
+
+    // belongsTo associations
+    val foreignKeys: Seq[ForeignKey] = {
+      val table: Option[Table] = {
+        cachedTables.find((t) => t.name.toLowerCase == tableName.toLowerCase).orElse(DB.getTable(tableName))
+      }
+      table.map(_.foreignKeys.toSeq).getOrElse(Nil)
+    }
+    val belongsToAssociations: Seq[String] = foreignKeys.map { fk =>
+      val name = toCamelCase(fk.name.toLowerCase).replace(toFirstCharUpper(fk.foreignColumnName.toLowerCase), "")
+      s"${name}:Option[${toFirstCharUpper(name)}]"
+    }
+
+    // hasMany associations
+    val hasManyAssociations: Seq[String] = {
+      if (cachedTables.isEmpty) Nil
+      else {
+        val expectedFkName = s"${toFirstCharLower(toCamelCase(tableName))}${pkName.map(toFirstCharUpper).getOrElse("Id")}"
+        val hasManyTables: Seq[Table] = cachedTables.filter { table =>
+          table.foreignKeys.exists { (fk) =>
+            fk.foreignTableName.toLowerCase == tableName.toLowerCase &&
+              toCamelCase(fk.name.toLowerCase) == expectedFkName
+          }
+        }
+        hasManyTables.map { table =>
+          val name = toCamelCase(table.name.toLowerCase)
+          s"${name}s:Seq[${toClassName(name)}]"
+        }
+      }
+    }
+
+    belongsToAssociations ++ hasManyAssociations
+  }
+
+}

--- a/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
@@ -1,0 +1,50 @@
+package skinny.task.generator
+
+import skinny.{ DBSettings, SkinnyEnv }
+import scalikejdbc._
+import scalikejdbc.metadata.Table
+
+/**
+ * Reverse Model All generator.
+ */
+object ReverseModelAllGenerator extends ReverseModelAllGenerator {
+}
+
+trait ReverseModelAllGenerator extends CodeGenerator {
+
+  private[this] def showUsage = {
+    showSkinnyGenerator()
+    println("""  Usage: sbt "task/run generate:reverse-model-all [skinnyEnv]""")
+    println("")
+  }
+
+  def run(args: List[String]) {
+    val skinnyEnv: Option[String] = args.headOption
+
+    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
+    DBSettings.initialize()
+
+    val tables: Seq[Table] = DB.getAllTableNames.flatMap { tableName =>
+      DB.getTable(tableName)
+    }
+    val self = this
+    val generator = new ReverseModelGenerator {
+      override def cachedTables = tables
+      override def useAutoConstruct = true
+      override def createAssociationsForForeignKeys = true
+
+      override def sourceDir = self.sourceDir
+      override def testSourceDir = self.testSourceDir
+      override def resourceDir = self.resourceDir
+      override def testResourceDir = self.testResourceDir
+      override def modelPackage = self.modelPackage
+      override def modelPackageDir = self.modelPackageDir
+    }
+    tables.map { table =>
+      val tableName = table.name.toLowerCase
+      val args: List[String] = Seq(Some(tableName), Some(toCamelCase(tableName)), skinnyEnv).flatten.toList
+      generator.run(args)
+    }
+  }
+
+}

--- a/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
@@ -2,7 +2,7 @@ package skinny.task.generator
 
 import java.util.Locale
 import skinny.{ DBSettings, SkinnyEnv, ParamType }
-import scalikejdbc.metadata.Column
+import scalikejdbc.metadata.{ Table, Column }
 
 /**
  * Reverse Model generator.
@@ -10,13 +10,19 @@ import scalikejdbc.metadata.Column
 object ReverseModelGenerator extends ReverseModelGenerator {
 }
 
-trait ReverseModelGenerator extends CodeGenerator {
+trait ReverseModelGenerator extends CodeGenerator with ReverseGenerator {
 
   def withId: Boolean = true
 
   def primaryKeyName: String = "id"
 
   def primaryKeyType: ParamType = ParamType.Long
+
+  def cachedTables: Seq[Table] = Nil
+
+  def useAutoConstruct: Boolean = false
+
+  def createAssociationsForForeignKeys: Boolean = false
 
   private[this] def showUsage = {
     showSkinnyGenerator()
@@ -42,16 +48,23 @@ trait ReverseModelGenerator extends CodeGenerator {
     val hasId: Boolean = columns.filter(_.isPrimaryKey).size == 1
     val pkName: Option[String] = if (hasId) columns.find(_.isPrimaryKey).map(_.name.toLowerCase(Locale.ENGLISH)).map(toCamelCase) else None
     val pkType: Option[ParamType] = if (hasId) columns.find(_.isPrimaryKey).map(_.typeCode).map(convertJdbcSqlTypeToParamType) else None
-    val fields: List[String] = if (hasId) {
-      columns
-        .map(column => toScaffoldFieldDef(column))
-        .filter(param => param != "id:Long" && param != "id:Option[Long]")
-        .filter(param => !param.startsWith(pkName.get + ":"))
-        .map(param => toCamelCase(param))
-    } else {
-      columns
-        .map(column => toScaffoldFieldDef(column))
-        .map(param => toCamelCase(param))
+    val fields: Seq[String] = {
+      val fields = if (hasId) {
+        columns
+          .map(column => toScaffoldFieldDef(column))
+          .filter(param => param != "id:Long" && param != "id:Option[Long]")
+          .filter(param => !param.startsWith(pkName.get + ":"))
+          .map(param => toCamelCase(param))
+      } else {
+        columns
+          .map(column => toScaffoldFieldDef(column))
+          .map(param => toCamelCase(param))
+      }
+      if (createAssociationsForForeignKeys) {
+        fields ++ extractAssociationParams(tableName, pkName, cachedTables)
+      } else {
+        fields
+      }
     }
 
     println(if (hasId) {
@@ -79,10 +92,21 @@ trait ReverseModelGenerator extends CodeGenerator {
       override def primaryKeyName = pkName.getOrElse(self.primaryKeyName)
       override def primaryKeyType = pkType.getOrElse(self.primaryKeyType)
       override def withTimestamps: Boolean = false
+      override def useAutoConstruct = self.useAutoConstruct
       override def tableName = Some(_tableName)
+
+      override def sourceDir = self.sourceDir
+      override def testSourceDir = self.testSourceDir
+      override def resourceDir = self.resourceDir
+      override def testResourceDir = self.testResourceDir
+      override def webInfDir = self.webInfDir
+      override def controllerPackage = self.controllerPackage
+      override def controllerPackageDir = self.controllerPackageDir
+      override def modelPackage = self.modelPackage
+      override def modelPackageDir = self.modelPackageDir
     }
 
-    generator.run(nameWithPackage.getOrElse(toClassName(tableName)).split("\\.") ++ fields)
+    generator.run(nameWithPackage.getOrElse(toClassName(tableName.toLowerCase)).split("\\.") ++ fields)
 
   }
 

--- a/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
@@ -1,0 +1,52 @@
+package skinny.task.generator
+
+import skinny.{ DBSettings, SkinnyEnv }
+import scalikejdbc._
+import scalikejdbc.metadata.Table
+
+/**
+ * Reverse Model All generator.
+ */
+object ReverseScaffoldAllGenerator extends ReverseScaffoldAllGenerator {
+}
+
+trait ReverseScaffoldAllGenerator extends CodeGenerator {
+
+  private[this] def showUsage = {
+    showSkinnyGenerator()
+    println("""  Usage: sbt "task/run generate:reverse-model-all [skinnyEnv]""")
+    println("")
+  }
+
+  def run(templateType: String, args: List[String], skinnyEnv: Option[String]) {
+
+    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
+    DBSettings.initialize()
+
+    val tables: Seq[Table] = DB.getAllTableNames.flatMap { tableName =>
+      DB.getTable(tableName)
+    }
+    val self = this
+    val generator = new ReverseScaffoldGenerator {
+      override def cachedTables = tables
+      override def useAutoConstruct = true
+      override def createAssociationsForForeignKeys = true
+
+      override def sourceDir = self.sourceDir
+      override def testSourceDir = self.testSourceDir
+      override def resourceDir = self.resourceDir
+      override def testResourceDir = self.testResourceDir
+      override def webInfDir = self.webInfDir
+      override def controllerPackage = self.controllerPackage
+      override def controllerPackageDir = self.controllerPackageDir
+      override def modelPackage = self.modelPackage
+      override def modelPackageDir = self.modelPackageDir
+    }
+    tables.map { table =>
+      val tableName = table.name.toLowerCase
+      val args: List[String] = List(tableName, toCamelCase(tableName) + "s", toCamelCase(tableName))
+      generator.run(templateType, args, SkinnyEnv.get())
+    }
+  }
+
+}

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -30,6 +30,8 @@ trait ScaffoldGenerator extends CodeGenerator {
 
   protected def customPrimaryKeyName: Option[String] = if (primaryKeyName == "id") None else Option(primaryKeyName)
 
+  protected def useAutoConstruct: Boolean = false
+
   private def showUsage = {
     showSkinnyGenerator()
     println("""  Usage: sbt "task/run generate:scaffold members member name:String birthday:Option[LocalDate]" """)
@@ -92,14 +94,22 @@ trait ScaffoldGenerator extends CodeGenerator {
           // Model
           val self = this
           val modelGenerator = new ModelGenerator {
-            override def modelPackage = self.modelPackage
             override def primaryKeyName = self.primaryKeyName
             override def primaryKeyType = self.primaryKeyType
             override def withId = self.withId
             override def withTimestamps = self.withTimestamps
+            override def useAutoConstruct = self.useAutoConstruct
+
+            override def sourceDir = self.sourceDir
+            override def testSourceDir = self.testSourceDir
+            override def resourceDir = self.resourceDir
+            override def testResourceDir = self.testResourceDir
+            override def modelPackage = self.modelPackage
+            override def modelPackageDir = self.modelPackageDir
           }
-          modelGenerator.generate(namespaces, resource, tableName.orElse(Some(toSnakeCase(resources))), nameAndTypeNamePairs)
-          modelGenerator.generateSpec(namespaces, resource, nameAndTypeNamePairs)
+          val nameAndTypeNamePairsForModel = generatorArgs.map(a => (a.name, a.typeName))
+          modelGenerator.generate(namespaces, resource, tableName.orElse(Some(toSnakeCase(resources))), nameAndTypeNamePairsForModel)
+          modelGenerator.generateSpec(namespaces, resource, nameAndTypeNamePairsForModel)
 
           if (withId) {
             // Views

--- a/task/src/test/resources/application.conf
+++ b/task/src/test/resources/application.conf
@@ -1,0 +1,12 @@
+test {
+  db {
+    default {
+      driver="org.h2.Driver"
+      url="jdbc:h2:mem:skinny-task-test;MODE=PostgreSQL"
+      user="sa"
+      password="sa"
+      poolInitialSize=2
+      poolMaxSize=10
+    }
+  }
+}

--- a/task/src/test/scala/skinny/task/generator/ReverseModelAllGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ReverseModelAllGeneratorSpec.scala
@@ -1,0 +1,146 @@
+package skinny.task.generator
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.scalatest._
+import scalikejdbc._
+import skinny.{ SkinnyEnv, DBSettings }
+
+class ReverseModelAllGeneratorSpec extends FunSpec with Matchers {
+
+  val generator = new ReverseModelAllGenerator {
+    override def sourceDir = "tmp/ReverseModelAllGeneratorSpec/src/main/scala"
+    override def resourceDir = "tmp/ReverseModelAllGeneratorSpec/src/main/resources"
+    override def testSourceDir = "tmp/ReverseModelAllGeneratorSpec/src/test/scala"
+    override def testResourceDir = "tmp/ReverseModelAllGeneratorSpec/src/test/resources"
+  }
+
+  describe("ReverseModelAllGenerator") {
+    it("should be created as expected") {
+      System.setProperty(SkinnyEnv.PropertyKey, "test")
+      DBSettings.initialize()
+      DB.localTx { implicit s =>
+        sql"""
+create table company (
+  id bigserial not null primary key,
+  name varchar(100) not null,
+  url varchar(512),
+  created_at timestamp not null default current_timestamp
+);
+
+create table member (
+  id bigserial not null primary key,
+  name varchar(512) not null,
+  nickname varchar(32),
+  company_id bigint references company(id),
+  joined_at timestamp not null,
+  leave_at timestamp
+);
+""".execute.apply()
+      }
+
+      FileUtils.deleteDirectory(new File("tmp/ReverseModelAllGeneratorSpec"))
+      generator.run(List(SkinnyEnv.getOrDevelopment()))
+
+      val company = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Company.scala"))
+      company should equal(
+        s"""package model
+
+import skinny.orm._, feature._
+import scalikejdbc._
+import org.joda.time._
+
+// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+case class Company(
+  id: Long,
+  name: String,
+  url: Option[String] = None,
+  createdAt: DateTime,
+  members: Seq[Member] = Nil
+)
+
+object Company extends SkinnyCRUDMapper[Company] {
+  override lazy val tableName = "company"
+  override lazy val defaultAlias = createAlias("c")
+
+  lazy val membersRef = hasMany[Member](
+    many = Member -> Member.defaultAlias,
+    on = (c, m) => sqls.eq(c.id, m.companyId),
+    merge = (c, ms) => c.copy(members = ms)
+  )
+
+  override def extract(rs: WrappedResultSet, rn: ResultName[Company]): Company = {
+    autoConstruct(rs, rn, "members")
+  }
+}
+""".stripMargin)
+
+      val member = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Member.scala"))
+      member should equal(
+        s"""package model
+
+import skinny.orm._, feature._
+import scalikejdbc._
+import org.joda.time._
+
+// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
+case class Member(
+  id: Long,
+  name: String,
+  nickname: Option[String] = None,
+  companyId: Option[Long] = None,
+  joinedAt: DateTime,
+  leaveAt: Option[DateTime] = None,
+  company: Option[Company] = None
+)
+
+object Member extends SkinnyCRUDMapper[Member] {
+  override lazy val tableName = "member"
+  override lazy val defaultAlias = createAlias("m")
+
+  lazy val companyRef = belongsTo[Company](Company, (m, c) => m.copy(company = c))
+
+  override def extract(rs: WrappedResultSet, rn: ResultName[Member]): Member = {
+    autoConstruct(rs, rn, "company")
+  }
+}
+""".stripMargin)
+
+      val companySpec = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/CompanySpec.scala"))
+      companySpec should equal(
+        s"""package model
+
+import skinny.DBSettings
+import skinny.test._
+import org.scalatest.fixture.FlatSpec
+import org.scalatest._
+import scalikejdbc._
+import scalikejdbc.scalatest._
+import org.joda.time._
+
+class CompanySpec extends FlatSpec with Matchers with DBSettings with AutoRollback {
+}
+"""
+      )
+
+      val memberSpec = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/MemberSpec.scala"))
+      memberSpec should equal(
+        s"""package model
+
+import skinny.DBSettings
+import skinny.test._
+import org.scalatest.fixture.FlatSpec
+import org.scalatest._
+import scalikejdbc._
+import scalikejdbc.scalatest._
+import org.joda.time._
+
+class MemberSpec extends FlatSpec with Matchers with DBSettings with AutoRollback {
+}
+"""
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
Powerful reverse engineering commands.
## reverse-model-all
### DDL

``` sql
create table company (
  id bigserial not null primary key,
  name varchar(100) not null,
  url varchar(512),
  created_at timestamp not null default current_timestamp
);

create table member (
  id bigserial not null primary key,
  name varchar(512) not null,
  nickname varchar(32),
  company_id bigint references company(id),
  joined_at timestamp not null,
  leave_at timestamp
);
```
### Output

```
 *** Skinny Reverse Engineering Task ***

  Table     : company
  ID        : id:Long

  Columns:
   - name:String:varchar(100)
   - url:Option[String]:varchar(512)
   - createdAt:DateTime
   - members:Seq[Member]

 *** Skinny Generator Task ***

  "tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Company.scala" created.
  "tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/CompanySpec.scala" created.


 *** Skinny Reverse Engineering Task ***

  Table     : member
  ID        : id:Long

  Columns:
   - name:String:varchar(512)
   - nickname:Option[String]:varchar(32)
   - companyId:Option[Long]
   - joinedAt:DateTime
   - leaveAt:Option[DateTime]
   - company:Option[Company]

 *** Skinny Generator Task ***

  "tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Member.scala" created.
  "tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/MemberSpec.scala" created.
```
### Generated Files

``` scala
package model

import skinny.orm._, feature._
import scalikejdbc._
import org.joda.time._

// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
case class Company(
  id: Long,
  name: String,
  url: Option[String] = None,
  createdAt: DateTime,
  members: Seq[Member] = Nil
)

object Company extends SkinnyCRUDMapper[Company] {
  override lazy val tableName = "company"
  override lazy val defaultAlias = createAlias("c")

  lazy val membersRef = hasMany[Member](
    many = Member -> Member.defaultAlias,
    on = (c, m) => sqls.eq(c.id, m.companyId),
    merge = (c, ms) => c.copy(members = ms)
  )

  override def extract(rs: WrappedResultSet, rn: ResultName[Company]): Company = {
    autoConstruct(rs, rn, "members")
  }
}
```

``` scala
package model

import skinny.orm._, feature._
import scalikejdbc._
import org.joda.time._

// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
case class Member(
  id: Long,
  name: String,
  nickname: Option[String] = None,
  companyId: Option[Long] = None,
  joinedAt: DateTime,
  leaveAt: Option[DateTime] = None,
  company: Option[Company] = None
)

object Member extends SkinnyCRUDMapper[Member] {
  override lazy val tableName = "member"
  override lazy val defaultAlias = createAlias("m")

  lazy val companyRef = belongsTo[Company](Company, (m, c) => m.copy(company = c))

  override def extract(rs: WrappedResultSet, rn: ResultName[Member]): Member = {
    autoConstruct(rs, rn, "company")
  }
}
```
## reverse-scaffold-all
### DDL

``` sql
create table user_group (
  id bigserial not null primary key,
  name varchar(100) not null,
  url varchar(512)
);
create table organization (
  id bigserial not null primary key,
  name varchar(100) not null,
  url varchar(512) not null
);
create table developer (
  id bigserial not null primary key,
  name varchar(512) not null,
  nickname varchar(32),
  user_group_id bigint references user_group(id)
);
create table organization_developer (
  organization_id bigint not null references organization(id),
  developer_id bigint not null references developer(id)
);
```
### Output

```
 *** Skinny Reverse Engineering Task ***

  Table     : developer
  ID        : id:Long
  Resources : developers
  Resource  : developer

  Columns:
   - name:String:varchar(512)
   - nickname:Option[String]:varchar(32)
   - userGroupId:Option[Long]
   - userGroup:Option[UserGroup]
   - organizationDevelopers:Seq[OrganizationDeveloper]

 *** Skinny Generator Task ***

  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/ApplicationController.scala" skipped.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/DevelopersController.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/Controllers.scala" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/controller/DevelopersControllerSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/integrationtest/DevelopersController_IntegrationTestSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/resources/factories.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/model/Developer.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/model/DeveloperSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/developers/_form.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/developers/new.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/developers/edit.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/developers/index.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/developers/show.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/messages.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/db/migration/V20141207024947__Create_developers_table.sql" created.


 *** Skinny Reverse Engineering Task ***

  Table     : organization
  ID        : id:Long
  Resources : organizations
  Resource  : organization

  Columns:
   - name:String:varchar(100)
   - url:String:varchar(512)
   - organizationDevelopers:Seq[OrganizationDeveloper]

 *** Skinny Generator Task ***

  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/ApplicationController.scala" skipped.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/OrganizationsController.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/Controllers.scala" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/controller/OrganizationsControllerSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/integrationtest/OrganizationsController_IntegrationTestSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/resources/factories.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/model/Organization.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/model/OrganizationSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/organizations/_form.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/organizations/new.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/organizations/edit.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/organizations/index.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/organizations/show.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/messages.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/db/migration/V20141207024947__Create_organizations_table.sql" created.


Since this table (organization_developer) has no primary key, generator created only NoIdCRUDMapper file and skipped creating controller and view files.

 *** Skinny Reverse Engineering Task ***

  Table  : organization_developer

  Columns:
   - organizationId:Long
   - developerId:Long
   - developer:Option[Developer]
   - organization:Option[Organization]

 *** Skinny Generator Task ***

  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/model/OrganizationDeveloper.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/model/OrganizationDeveloperSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/db/migration/V20141207024947__Create_organizationDevelopers_table.sql" created.


 *** Skinny Reverse Engineering Task ***

  Table     : user_group
  ID        : id:Long
  Resources : userGroups
  Resource  : userGroup

  Columns:
   - name:String:varchar(100)
   - url:Option[String]:varchar(512)
   - developers:Seq[Developer]

 *** Skinny Generator Task ***

  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/ApplicationController.scala" skipped.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/UserGroupsController.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/controller/Controllers.scala" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/controller/UserGroupsControllerSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/integrationtest/UserGroupsController_IntegrationTestSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/resources/factories.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala/model/UserGroup.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/test/scala/model/UserGroupSpec.scala" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/userGroups/_form.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/userGroups/new.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/userGroups/edit.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/userGroups/index.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/webapp/WEB-INF/views/userGroups/show.html.ssp" created.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/messages.conf" modified.
  "tmp/ReverseScaffoldAllGeneratorSpec/src/main/resources/db/migration/V20141207024947__Create_userGroups_table.sql" created.
```
### Generated Files

``` scala
package model

import skinny.orm._, feature._
import scalikejdbc._
import org.joda.time._

// If your model has +23 fields, switch this to normal class and mixin scalikejdbc.EntityEquality.
case class Developer(
  id: Long,
  name: String,
  nickname: Option[String] = None,
  userGroupId: Option[Long] = None,
  userGroup: Option[UserGroup] = None,
  organizations: Seq[Organization] = Nil
)

object Developer extends SkinnyCRUDMapper[Developer] {
  override lazy val tableName = "developer"
  override lazy val defaultAlias = createAlias("d")

  lazy val userGroupRef = belongsTo[UserGroup](UserGroup, (d, ug) => d.copy(userGroup = ug))

  lazy val organizationsRef = hasManyThrough[Organization](
    through = OrganizationDeveloper,
    many = Organization,
    merge = (d, os) => d.copy(organizations = os)
  )

  override def extract(rs: WrappedResultSet, rn: ResultName[Developer]): Developer = {
    autoConstruct(rs, rn, "userGroup", "organizations")
  }
}
```

``` scala
package controller

import skinny._
import skinny.validator._
import _root_.controller._
import model.Developer

class DevelopersController extends SkinnyResource with ApplicationController {
  protectFromForgery()

  override def model = Developer
  override def resourcesName = "developers"
  override def resourceName = "developer"

  override def resourcesBasePath = s"/${toSnakeCase(resourcesName)}"
  override def useSnakeCasedParamKeys = true

  override def viewsDirectoryPath = s"/${resourcesName}"

  override def createParams = Params(params)
  override def createForm = validation(createParams,
    paramKey("name") is required & maxLength(512),
    paramKey("nickname") is maxLength(32),
    paramKey("user_group_id") is numeric & longValue
  )
  override def createFormStrongParameters = Seq(
    "name" -> ParamType.String,
    "nickname" -> ParamType.String,
    "user_group_id" -> ParamType.Long
  )

  override def updateParams = Params(params)
  override def updateForm = validation(updateParams,
    paramKey("name") is required & maxLength(512),
    paramKey("nickname") is maxLength(32),
    paramKey("user_group_id") is numeric & longValue
  )
  override def updateFormStrongParameters = Seq(
    "name" -> ParamType.String,
    "nickname" -> ParamType.String,
    "user_group_id" -> ParamType.Long
  )

}
```
