### PR TITLE
Add Typetalk OAuth2 support

### DIFF
--- a/example/src/main/scala/controller/Controllers.scala
+++ b/example/src/main/scala/controller/Controllers.scala
@@ -37,6 +37,7 @@ object Controllers {
     github.mount(ctx)
     google.mount(ctx)
     twitter.mount(ctx)
+    typetalk.mount(ctx)
 
     AssetsController.mount(ctx)
   }
@@ -139,6 +140,12 @@ object Controllers {
     val loginUrl = get("/twitter")(loginRedirect).as('login)
     val callbackUrl = get("/twitter/callback")(callback).as('callback)
     val okUrl = get("/twitter/ok")(ok).as('ok)
+  }
+
+  object typetalk extends TypetalkController with Routes {
+    val loginUrl = get("/typetalk")(loginRedirect).as('login)
+    val callbackUrl = get("/typetalk/callback")(callback).as('callback)
+    val okUrl = get("/typetalk/ok")(ok).as('ok)
   }
 
 }

--- a/example/src/main/scala/controller/TypetalkController.scala
+++ b/example/src/main/scala/controller/TypetalkController.scala
@@ -1,0 +1,27 @@
+package controller
+
+import skinny.controller.feature.TypetalkLoginFeature
+import skinny.oauth2.client.OAuth2User
+import skinny.oauth2.client.typetalk.TypetalkUser
+
+class TypetalkController extends ApplicationController
+    with TypetalkLoginFeature {
+
+  override def redirectURI = "http://127.0.0.1:8080/example/typetalk/callback"
+
+  override protected def saveAuthorizedUser(user: TypetalkUser): Unit = {
+    session.setAttribute("user", user)
+  }
+
+  override protected def handleWhenLoginSucceeded(): Any = {
+    redirect302(url(Controllers.typetalk.okUrl))
+  }
+
+  def ok = {
+    set("user", session.getAs[OAuth2User]("user"))
+    set("typetalk", session.getAs[TypetalkUser]("user"))
+    render("/typetalk/ok")
+  }
+
+}
+

--- a/example/src/main/webapp/WEB-INF/views/typetalk/ok.html.ssp
+++ b/example/src/main/webapp/WEB-INF/views/typetalk/ok.html.ssp
@@ -1,0 +1,8 @@
+<%@val user: Option[skinny.oauth2.client.OAuth2User] %>
+<%@val typetalk: Option[skinny.oauth2.client.typetalk.TypetalkUser] %>
+<% import skinny.util.JSONStringOps %>
+<h3>Typetalk OAuth</h3>
+<hr/>
+<pre><%= user.map(u => JSONStringOps.toPrettyJSONString(u)) %></pre>
+<pre><%= typetalk.map(u => JSONStringOps.toPrettyJSONString(u)) %></pre>
+

--- a/oauth2-controller/src/main/scala/skinny/controller/feature/TypetalkLoginFeature.scala
+++ b/oauth2-controller/src/main/scala/skinny/controller/feature/TypetalkLoginFeature.scala
@@ -1,0 +1,36 @@
+package skinny.controller.feature
+
+import skinny.oauth2.client._
+import skinny.oauth2.client.typetalk.{ TypetalkAPI, TypetalkUser }
+
+/**
+ * Typetalk OAuth2 Login Controller.
+ *
+ * {{{
+ * export SKINNY_OAUTH2_CLIENT_ID_TYPETALK=xxx
+ * export SKINNY_OAUTH2_CLIENT_SECRET_TYPETALK=yyy
+ * }}}
+ */
+trait TypetalkLoginFeature extends OAuth2LoginFeature[TypetalkUser] {
+
+  override protected def provider = OAuth2Provider.Typetalk
+
+  override protected def createAuthenticationRequest(): AuthenticationRequest = {
+    val req = AuthenticationRequest(provider)
+      .clientId(clientId)
+      .responseType(ResponseType.Code)
+      .state(state)
+      .scope("my")
+      .redirectURI(redirectURI)
+    if (scope != null) req.scope(scope) else req
+  }
+
+  override protected def retrieveAuthorizedUser(token: OAuth2Token): TypetalkUser = {
+    TypetalkAPI.profile(token).getOrElse {
+      handleWhenLoginFailed()
+      haltWithBody(401)
+    }
+  }
+
+}
+

--- a/oauth2/src/main/scala/skinny/oauth2/client/OAuth2Provider.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/OAuth2Provider.scala
@@ -79,6 +79,14 @@ object OAuth2Provider {
     "https://auth.login.yahoo.co.jp/yconnect/v1/token"
   )
 
+  // Typetalk
+  // https://typetalk.in/
+  val Typetalk = OAuth2Provider(
+    "typetalk",
+    "https://typetalk.in/oauth2/authorize",
+    "https://typetalk.in/oauth2/access_token"
+  )
+
   // *** IMPORTANT ***
   // Waiting for your pull request here!
   /*

--- a/oauth2/src/main/scala/skinny/oauth2/client/typetalk/MyProfileResponse.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/typetalk/MyProfileResponse.scala
@@ -1,0 +1,4 @@
+package skinny.oauth2.client.typetalk
+
+private[skinny] case class MyProfileResponse(
+  account: TypetalkUser)

--- a/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkAPI.scala
@@ -1,0 +1,28 @@
+package skinny.oauth2.client.typetalk
+
+import skinny.logging.Logging
+import skinny.oauth2.client.{ BearerRequest, OAuth2Client, OAuth2Token }
+import skinny.util.JSONStringOps
+
+import scala.util.control.NonFatal
+
+trait TypetalkAPI extends Logging {
+
+  def profile(token: OAuth2Token): Option[TypetalkUser] = {
+    try {
+      val response = OAuth2Client.resource {
+        BearerRequest("https://typetalk.in/api/v1/profile").accessToken(token.accessToken)
+      }
+      logger.debug(s"Typetalk authorized user: ${response.body}")
+      JSONStringOps.fromJSONString[MyProfileResponse](response.body).map(_.account)
+    } catch {
+      case NonFatal(e) =>
+        logger.error(s"Failed to get current Typetalk user information because ${e.getMessage}", e)
+        None
+    }
+  }
+
+}
+
+object TypetalkAPI extends TypetalkAPI
+

--- a/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkUser.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkUser.scala
@@ -1,0 +1,14 @@
+package skinny.oauth2.client.typetalk
+
+import org.joda.time.DateTime
+import skinny.oauth2.client.OAuth2User
+
+case class TypetalkUser(
+  override val id: String,
+  name: String,
+  fullName: String,
+  suggestion: String,
+  imageUrl: String,
+  createdAt: DateTime,
+  updatedAt: DateTime) extends OAuth2User
+


### PR DESCRIPTION
In my opinion, skinny's OAuth2 module should have lots of out-of-the-box OAuth provider support.

Typetalk is a realtime instant messaging service from @nulab. http://www.typetalk.in/
Thanks to Nulabbers, I just tried to create OAuth 2 integration feature with Typetalk API yesterday. http://www.zusaar.com/event/8747007
