### PR TITLE
findBy method should not throw exception for multiple results

### DIFF
--- a/orm/src/main/scala/skinny/orm/feature/FinderFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/FinderFeature.scala
@@ -114,7 +114,9 @@ trait FinderFeatureWithId[Id, Entity]
   override def findBy(where: SQLSyntax)(implicit s: DBSession = autoSession): Option[Entity] = {
     implicit val repository = IncludesQueryRepository[Entity]()
     appendIncludedAttributes(extract(withSQL {
-      selectQueryWithAssociations.where(sqls.toAndConditionOpt(Some(where), defaultScopeWithDefaultAlias))
+      selectQueryWithAssociations
+        .where(sqls.toAndConditionOpt(Some(where), defaultScopeWithDefaultAlias))
+        .limit(1)
     }).single.apply())
   }
 

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -106,6 +106,37 @@ class SkinnyORMSpec extends fixture.FunSpec with Matchers
       none.isDefined should be(false)
     }
 
+    // It should behave like `ActiveRecord::Base.find_by(...)`
+    it("should have #findBy(where)") { implicit session =>
+      val m = Member.defaultAlias
+      val mentor = Member.findAll().head
+      val now = DateTime.now
+
+      val member1Id = Member.createWithAttributes(
+        'countryId -> mentor.countryId,
+        'companyId -> mentor.companyId,
+        'mentorId -> mentor.id,
+        'createdAt -> now
+      )
+      val member2Id = Member.createWithAttributes(
+        'countryId -> mentor.countryId,
+        'companyId -> mentor.companyId,
+        'mentorId -> mentor.id,
+        'createdAt -> now
+      )
+
+      val member = Member.findBy(
+        sqls.eq(m.countryId, mentor.countryId)
+          .and.eq(m.companyId, mentor.companyId)
+          .and.eq(m.mentorId, mentor.id))
+
+      // depends on default ordering
+      member.get.id should (
+        equal(member1Id) or
+        equal(member2Id)
+      )
+    }
+
     it("returns nested belongsTo relations") { implicit session =>
       val m = Member.defaultAlias
 


### PR DESCRIPTION
<code>FinderFeatureWithId#findBy</code> throws <code>scalikejdbc.TooManyRowsException</code> when <code>select \* from table_name where ...</code> returns 2 rows.

```
val m = Member.defaultAlias
val member = Member.findBy(
  sqls.eq(m.countryId, 1)
  .and.eq(m.companyId, 2)
  .and.eq(m.mentorId, 3))

[info] - should have #findBy(where) *** FAILED ***
[info]   scalikejdbc.TooManyRowsException:
[info]   at scalikejdbc.RelationalSQLResultSetOperations$class.toSingle(RelationalSQL.scala:29)
[info]   at scalikejdbc.OneToManies2SQLToOption.toSingle(OneToManies2SQL.scala:120)
[info]   at scalikejdbc.OneToManies2SQLToOption$$anonfun$apply$14.apply(OneToManies2SQL.scala:132)
[info]   at scalikejdbc.OneToManies2SQLToOption$$anonfun$apply$14.apply(OneToManies2SQL.scala:132)
[info]   at scalikejdbc.RelationalSQLResultSetOperations$class.executeQuery(RelationalSQL.scala:38)
[info]   at scalikejdbc.OneToManies2SQLToOption.executeQuery(OneToManies2SQL.scala:120)
[info]   at scalikejdbc.OneToManies2SQLToOption.apply(OneToManies2SQL.scala:132)
[info]   at skinny.orm.feature.FinderFeatureWithId$class.findBy(FinderFeature.scala:118)
[info]   at skinny.orm.Member$.findBy(models.scala:22)
[info]   at skinny.orm.SkinnyORMSpec$$anonfun$5$$anonfun$apply$mcV$sp$6.apply(SkinnyORMSpec.scala:128)
[info]   ...
```

It may be bad where clause condition, but the behavior is too strict... I expect ActiveRecord::Base.find_by like behavior. It selects 1 record only (loosely a little bit).

```
Member.find_by(country_id: 1, company_id: 2, mentor_id: 3)
#  Member Load (8.3ms)  SELECT  `members`.* FROM `members`  WHERE `members`.`country_id` = 1 AND `members`.`company_id` = 2 AND `members`.`mentor_id` = 3 LIMIT 1
#=> #<Member id: 1, country_id: 1, company_id: 2, mentor_id: 3, created_at: "2014-12-17 16:05:44", updated_at: "2014-12-17 16:05:44">
```
