### PR TITLE
Fix Play2 friendly tasks #213

### DIFF
--- a/common/src/main/scala/skinny/util/TypesafeConfigReader.scala
+++ b/common/src/main/scala/skinny/util/TypesafeConfigReader.scala
@@ -12,6 +12,14 @@ object TypesafeConfigReader {
   /**
    * Loads a configuration file.
    *
+   * @param file file
+   * @return config
+   */
+  def load(file: File): Config = ConfigFactory.parseFile(file)
+
+  /**
+   * Loads a configuration file.
+   *
    * @param resource file resource
    * @return config
    */

--- a/orm/src/main/scala/skinny/DBSettings.scala
+++ b/orm/src/main/scala/skinny/DBSettings.scala
@@ -1,83 +1,17 @@
 package skinny
 
-import scalikejdbc.config._
-import skinny.exception._
-import skinny.util.{ TypesafeConfigReader => sConfigReader }
-
-trait DBSettings {
-  DBSettings.initialize()
-}
-
 /**
  * Skinny ORM Database settings initializer.
  *
  * @see https://github.com/seratch/scalikejdbc
  */
-object DBSettings {
-
-  private[this] case class State(var alreadyInitialized: Boolean = false)
-  private[this] val state: State = State()
-
-  lazy val dbs = SkinnyDBsWithEnv(SkinnyEnv.getOrElse(SkinnyEnv.Development))
-
-  /**
-   * Initializes DB settings.
-   */
-  def initialize(force: Boolean = false): Unit = {
-    state.synchronized {
-      if (force || !state.alreadyInitialized) {
-        if (!dbs.dbNames.isEmpty) {
-          dbs.setupAll()
-        } else {
-          throw new DBSettingsException(s"""
-        | ---------------------------------------------
-        |
-        |  !!! Skinny Configuration Error !!!
-        |
-        |  DB settings was not found. Add some db settings to src/main/resources/application.conf like this:
-        |
-        |   development {
-        |     db {
-        |       default {
-        |         driver="org.h2.Driver"
-        |         url="jdbc:h2:mem:example"
-        |         user="sa"
-        |         password="sa"
-        |         poolInitialSize=2
-        |         poolMaxSize=10
-        |       }
-        |     }
-        |   }
-        |
-        |
-        |  "development" is the default env value. If you don't need env prefix it also works.
-        |  You can pass env value from environment variables "export skinny.env=qa" or via JVM option like "-Dskinny.env=qa".
-        |  Though you're not forced to use these values, recommended env values are "development", "test", "qa" and "production".
-        |
-        | ---------------------------------------------
-        |""".stripMargin)
-        }
-        state.alreadyInitialized = true
-      }
-    }
-  }
-
-  /**
-   * Wipes out all DB settings.
-   */
-  def destroy() = dbs.closeAll()
-
-}
+object DBSettings extends DBSettingsInitializer
 
 /**
- * DB setup executor with default settings
+ * Database settings initializer mixin.
  */
-case class SkinnyDBsWithEnv(envValue: String) extends DBs
-    with TypesafeConfigReader
-    with TypesafeConfig
-    with NoEnvPrefix {
+trait DBSettings {
 
-  // Replacing Config because (at least) ScalikeJDBC 2.0.4 or lower versions doesn't support default values
-  override val config = sConfigReader.config(envValue)
+  DBSettings.initialize()
 
 }

--- a/orm/src/main/scala/skinny/DBSettingsInitializer.scala
+++ b/orm/src/main/scala/skinny/DBSettingsInitializer.scala
@@ -1,0 +1,65 @@
+package skinny
+
+import skinny.exception.DBSettingsException
+
+/**
+ * Skinny ORM Database settings initializer.
+ *
+ * @see https://github.com/seratch/scalikejdbc
+ */
+trait DBSettingsInitializer {
+
+  private[this] case class State(var alreadyInitialized: Boolean = false)
+
+  private[this] val state: State = State()
+
+  lazy val dbs = SkinnyDBsWithEnv(SkinnyEnv.getOrElse(SkinnyEnv.Development))
+
+  /**
+   * Initializes DB settings.
+   */
+  def initialize(force: Boolean = false): Unit = {
+    state.synchronized {
+      if (force || !state.alreadyInitialized) {
+        if (!dbs.dbNames.isEmpty) {
+          dbs.setupAll()
+        } else {
+          throw new DBSettingsException(s"""
+        | ---------------------------------------------
+        |
+        |  !!! Skinny Configuration Error !!!
+        |
+        |  DB settings was not found. Add some db settings to src/main/resources/application.conf like this:
+        |
+        |   development {
+        |     db {
+        |       default {
+        |         driver="org.h2.Driver"
+        |         url="jdbc:h2:mem:example"
+        |         user="sa"
+        |         password="sa"
+        |         poolInitialSize=2
+        |         poolMaxSize=10
+        |       }
+        |     }
+        |   }
+        |
+        |
+        |  "development" is the default env value. If you don't need env prefix it also works.
+        |  You can pass env value from environment variables "export skinny.env=qa" or via JVM option like "-Dskinny.env=qa".
+        |  Though you're not forced to use these values, recommended env values are "development", "test", "qa" and "production".
+        |
+        | ---------------------------------------------
+        |""".stripMargin)
+        }
+        state.alreadyInitialized = true
+      }
+    }
+  }
+
+  /**
+   * Wipes out all DB settings.
+   */
+  def destroy() = dbs.closeAll()
+
+}

--- a/orm/src/main/scala/skinny/SkinnyDBsWithEnv.scala
+++ b/orm/src/main/scala/skinny/SkinnyDBsWithEnv.scala
@@ -1,0 +1,17 @@
+package skinny
+
+import scalikejdbc.config._
+import skinny.util.{ TypesafeConfigReader => sConfigReader }
+
+/**
+ * DB setup executor with default settings
+ */
+case class SkinnyDBsWithEnv(envValue: String) extends DBs
+    with TypesafeConfigReader
+    with TypesafeConfig
+    with NoEnvPrefix {
+
+  // Replacing Config because (at least) ScalikeJDBC 2.0.4 or lower versions doesn't support default values
+  override val config = sConfigReader.config(envValue)
+
+}

--- a/task/src/main/scala/skinny/task/generator/PlayConfiguration.scala
+++ b/task/src/main/scala/skinny/task/generator/PlayConfiguration.scala
@@ -1,0 +1,18 @@
+package skinny.task.generator
+
+import java.io.File
+
+import com.typesafe.config.Config
+import scalikejdbc.config._
+
+trait PlayConfiguration {
+
+  trait PlayDBs extends DBs with TypesafeConfigReader with TypesafeConfig with NoEnvPrefix
+
+  def defaultPlayConfig: Config = skinny.util.TypesafeConfigReader.load(new File("conf/application.conf"))
+
+  lazy val playDBs = new PlayDBs {
+    override val config = defaultPlayConfig
+  }
+
+}

--- a/task/src/main/scala/skinny/task/generator/PlayModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/PlayModelGenerator.scala
@@ -1,0 +1,13 @@
+package skinny.task.generator
+
+/**
+ * Model generator for Play Framework users.
+ */
+trait PlayModelGenerator extends ModelGenerator {
+  override def useAutoConstruct = true
+  override def sourceDir = "app"
+  override def testSourceDir = "test"
+  override def modelPackage = "models"
+}
+
+object PlayModelGenerator extends PlayModelGenerator

--- a/task/src/main/scala/skinny/task/generator/PlayReverseModelAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/PlayReverseModelAllGenerator.scala
@@ -1,0 +1,13 @@
+package skinny.task.generator
+
+/**
+ * Reverse model all generator for Play Framework users.
+ */
+trait PlayReverseModelAllGenerator extends ReverseModelAllGenerator with PlayConfiguration {
+  override def sourceDir = "app"
+  override def testSourceDir = "test"
+  override def modelPackage = "models"
+  override def initializeDB(skinnyEnv: Option[String]) = playDBs.setupAll()
+}
+
+object PlayReverseModelAllGenerator extends PlayReverseModelAllGenerator

--- a/task/src/main/scala/skinny/task/generator/PlayReverseModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/PlayReverseModelGenerator.scala
@@ -1,0 +1,14 @@
+package skinny.task.generator
+
+/**
+ * Reverse model generator for Play Framework users.
+ */
+trait PlayReverseModelGenerator extends ReverseModelGenerator with PlayConfiguration {
+  override def useAutoConstruct = true
+  override def sourceDir = "app"
+  override def testSourceDir = "test"
+  override def modelPackage = "models"
+  override def initializeDB(skinnyEnv: Option[String]) = playDBs.setupAll()
+}
+
+object PlayReverseModelGenerator extends PlayReverseModelGenerator

--- a/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
@@ -12,17 +12,21 @@ object ReverseModelAllGenerator extends ReverseModelAllGenerator {
 
 trait ReverseModelAllGenerator extends CodeGenerator {
 
-  private[this] def showUsage = {
+  protected def showUsage = {
     showSkinnyGenerator()
-    println("""  Usage: sbt "task/run generate:reverse-model-all [skinnyEnv]""")
+    println("""  Usage: sbt "task/run generate:reverse-model-all [env]""")
     println("")
+  }
+
+  protected def initializeDB(skinnyEnv: Option[String]): Unit = {
+    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
+    DBSettings.initialize()
   }
 
   def run(args: List[String]) {
     val skinnyEnv: Option[String] = args.headOption
 
-    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
-    DBSettings.initialize()
+    initializeDB(skinnyEnv)
 
     val tables: Seq[Table] = DB.getAllTableNames.filter(_.toLowerCase != "schema_version").flatMap { tableName =>
       DB.getTable(tableName)

--- a/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
@@ -24,10 +24,15 @@ trait ReverseModelGenerator extends CodeGenerator with ReverseGenerator {
 
   def createAssociationsForForeignKeys: Boolean = false
 
-  private[this] def showUsage = {
+  protected def showUsage = {
     showSkinnyGenerator()
-    println("""  Usage: sbt "task/run generate:reverse-model table_name [className] [skinnyEnv]""")
+    println("""  Usage: sbt "task/run generate:reverse-model table_name [className] [env]""")
     println("")
+  }
+
+  protected def initializeDB(skinnyEnv: Option[String]): Unit = {
+    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
+    DBSettings.initialize()
   }
 
   def run(args: List[String]) {
@@ -40,8 +45,7 @@ trait ReverseModelGenerator extends CodeGenerator with ReverseGenerator {
         return
     }
 
-    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
-    DBSettings.initialize()
+    initializeDB(skinnyEnv)
 
     val columns: List[Column] = extractColumns(tableName)
 

--- a/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
@@ -12,16 +12,20 @@ object ReverseScaffoldAllGenerator extends ReverseScaffoldAllGenerator {
 
 trait ReverseScaffoldAllGenerator extends CodeGenerator {
 
-  private[this] def showUsage = {
+  protected def showUsage = {
     showSkinnyGenerator()
-    println("""  Usage: sbt "task/run generate:reverse-model-all [skinnyEnv]""")
+    println("""  Usage: sbt "task/run generate:reverse-model-all [env]""")
     println("")
+  }
+
+  protected def initializeDB(skinnyEnv: Option[String]): Unit = {
+    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
+    DBSettings.initialize()
   }
 
   def run(templateType: String, args: List[String], skinnyEnv: Option[String]) {
 
-    System.setProperty(SkinnyEnv.PropertyKey, skinnyEnv.getOrElse(SkinnyEnv.Development))
-    DBSettings.initialize()
+    initializeDB(skinnyEnv)
 
     val tables: Seq[Table] = DB.getAllTableNames.filter(_.toLowerCase != "schema_version").flatMap { tableName =>
       DB.getTable(tableName)


### PR DESCRIPTION
skinny-task for Play Framework users.
### build.sbt

``` scala
lazy val task = (project in file("task")).settings(
  scalaSource in Compile := baseDirectory.value,
  libraryDependencies ++= Seq(
    "org.skinny-framework" %% "skinny-task" % skinnyVersion,
    "org.skinny-framework" %% "skinny-orm"  % skinnyVersion,
    "com.h2database"       %  "h2"          % "1.4.183"
  ),
  mainClass := Some("TaskRunnner")
)
```
### task/TaskRunner.scala

``` scala
import skinny.task._, generator._
object TaskRunner extends SkinnyTaskLauncher {
  register("model", (params) => PlayModelGenerator.run(params))
  register("reverse-model", (params) => PlayReverseModelGenerator.run(params))
  register("reverse-model-all", (params) => PlayReverseModelAllGenerator.run(params))
}
```
### usage

```
sbt "task/run model Account name:String"
sbt "task/run reverse-model Account"
sbt "task/run reverse-model-all"
```
