### PR TITLE
Fix #217 SkinnyRecord#save() with TimestampsFeature doesn't update updatedAtField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ ivy2
 
 skinny-*.tar.gz
 tmp
-
+.sbtconfig

--- a/orm/src/main/scala/skinny/orm/SkinnyRecordBaseWithId.scala
+++ b/orm/src/main/scala/skinny/orm/SkinnyRecordBaseWithId.scala
@@ -62,12 +62,22 @@ trait SkinnyRecordBaseWithId[Id, Entity] {
   }
 
   /**
+   * Returns attribute names to be excluded when persistence.
+   *
+   * @return names
+   */
+  protected def excludedFieldNamesWhenSaving: Seq[String] = Nil
+
+  /**
    * Returns attributes to persist.
    *
    * @return attributes
    */
-  protected def attributesToPersist(): Seq[(SQLSyntax, Any)] = JavaReflectAPI.getterNames(this)
-    .filter { name => skinnyCRUDMapper.isValidFieldName(name) }
-    .map { name => skinnyCRUDMapper.column.field(name) -> JavaReflectAPI.getter(this, name) }
+  protected def attributesToPersist(): Seq[(SQLSyntax, Any)] = {
+    JavaReflectAPI.getterNames(this)
+      .filter { name => skinnyCRUDMapper.isValidFieldName(name) }
+      .filterNot { name => excludedFieldNamesWhenSaving.exists(_ == name) }
+      .map { name => skinnyCRUDMapper.column.field(name) -> JavaReflectAPI.getter(this, name) }
+  }
 
 }

--- a/orm/src/test/scala/test004/Connection.scala
+++ b/orm/src/test/scala/test004/Connection.scala
@@ -1,0 +1,8 @@
+package test004
+
+import scalikejdbc.ConnectionPool
+
+trait Connection {
+  Class.forName("org.h2.Driver")
+  ConnectionPool.add('test004, "jdbc:h2:mem:test004;MODE=PostgreSQL", "sa", "sa")
+}

--- a/orm/src/test/scala/test004/CreateTables.scala
+++ b/orm/src/test/scala/test004/CreateTables.scala
@@ -1,0 +1,26 @@
+package test004
+
+import scalikejdbc._
+import skinny.dbmigration.DBSeeds
+
+trait CreateTables extends DBSeeds { self: Connection =>
+
+  override val dbSeedsAutoSession = NamedAutoSession('test004)
+
+  addSeedSQL(
+    sql"""
+create table ability_type (
+  id serial not null,
+  name varchar(100) not null)
+""")
+  addSeedSQL(
+    sql"""
+create table ability (
+  id serial not null,
+  name varchar(100) not null,
+  ability_type_id int references ability_type(id),
+  created_at timestamp not null,
+  updated_at timestamp)
+""")
+  runIfFailed(sql"select count(1) from ability_type")
+}

--- a/orm/src/test/scala/test004/Test004Spec.scala
+++ b/orm/src/test/scala/test004/Test004Spec.scala
@@ -1,0 +1,62 @@
+package test004
+
+import org.joda.time.DateTime
+import org.scalatest._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+import skinny.orm._
+import skinny.orm.feature.TimestampsFeature
+
+class Test004Spec extends fixture.FunSpec with Matchers
+    with Connection
+    with CreateTables
+    with AutoRollback {
+
+  override def db(): DB = NamedDB('test004).toDB()
+
+  // entities
+  case class Ability(
+      id: Long,
+      name: String,
+      abilityTypeId: Option[Long],
+      createdAt: DateTime,
+      updatedAt: Option[DateTime],
+      abilityType: Option[AbilityType] = None) extends SkinnyRecord[Ability] {
+
+    override def skinnyCRUDMapper = Ability
+    override def excludedFieldNamesWhenSaving = Seq(Ability.createdAtFieldName, Ability.updatedAtFieldName)
+  }
+  case class AbilityType(
+    id: Long,
+    name: String)
+
+  // mappers
+  object Ability extends SkinnyCRUDMapper[Ability] with TimestampsFeature[Ability] {
+    override val connectionPoolName = 'test004
+    override lazy val defaultAlias = createAlias("a")
+    lazy val abilityTypeRef = belongsTo[AbilityType](AbilityType, (a, at) => a.copy(abilityType = at))
+    override def extract(rs: WrappedResultSet, rn: ResultName[Ability]) = autoConstruct(rs, rn, "abilityType")
+  }
+
+  object AbilityType extends SkinnyCRUDMapper[AbilityType] {
+    override val connectionPoolName = 'test004
+    override lazy val defaultAlias = createAlias("at")
+    override def extract(rs: WrappedResultSet, rn: ResultName[AbilityType]) = autoConstruct(rs, rn)
+  }
+
+  override def fixture(implicit session: DBSession) {
+  }
+
+  describe("SkinnyRecord") {
+    it("should update timestamps") { implicit session =>
+      val id = Ability.createWithAttributes('name -> "SCALA")
+      val before: Ability = Ability.findById(id).get
+      before.copy(name = "Scala").save()
+      val after = Ability.findById(id).get
+      after.createdAt should equal(before.createdAt)
+      after.updatedAt should not equal (before.updatedAt)
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is a general solution for #217. 

If skinny detects `#skinnyCRUDMapper` is a `TimestampsFeature` wired one (via Java reflection API) and automatically filters timestamps for library users, it may be handy.

However, I'm not willing to do that because of the following reasons:
- the implementation won't be type-safe
- the mechanism is a little bit black magic
