### PR TITLE
Fix #222 java.lang.InternalError when using doubly nested class name (SI-2034) since 1.3.6

### DIFF
--- a/framework/src/main/scala/org/scalatra/SkinnyScalatraBase.scala
+++ b/framework/src/main/scala/org/scalatra/SkinnyScalatraBase.scala
@@ -29,7 +29,7 @@ trait SkinnyScalatraBase extends ScalatraBase {
         val (rq, rs) = (request, response)
         onCompleted { _ =>
           withRequestResponse(rq, rs) {
-            var className = this.getClass.getCanonicalName
+            val className = this.getClass.toString
             this match {
               // **** PATCHED ****
               case f: Filter if !rq.contains(s"org.scalatra.ScalatraFilter.afterFilters.Run (${className})") =>


### PR DESCRIPTION
refs #222