### PR TITLE
ActiveSupport-ish implicit conversions

### DIFF
--- a/common/src/main/scala/skinny/activeimplicits/AllImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/AllImplicits.scala
@@ -1,0 +1,10 @@
+package skinny.activeimplicits
+
+/**
+ * ActiveSupport-ish implicit conversions.
+ */
+object AllImplicits extends AllImplicits
+
+trait AllImplicits
+  extends NumberImplicits
+  with StringImplicits

--- a/common/src/main/scala/skinny/activeimplicits/NumberImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/NumberImplicits.scala
@@ -1,0 +1,116 @@
+package skinny.activeimplicits
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+
+/**
+ * ActiveSupport-ish implicit conversions.
+ */
+object NumberImplicits extends NumberImplicits
+
+trait NumberImplicits {
+
+  val KILOBYTE: BigDecimal = 1024L
+  val MEGABYTE: BigDecimal = KILOBYTE * 1024L
+  val GIGABYTE: BigDecimal = MEGABYTE * 1024L
+  val TERABYTE: BigDecimal = GIGABYTE * 1024L
+  val PETABYTE: BigDecimal = TERABYTE * 1024L
+  val EXABYTE: BigDecimal = PETABYTE * 1024L
+
+  case class RichNumber(num: Number) extends DurationConversions {
+
+    override protected def durationIn(unit: TimeUnit) = {
+      Duration(num.doubleValue(), unit) match {
+        case f: FiniteDuration => f
+        case _ => throw new IllegalArgumentException("Duration DSL not applicable to " + num)
+      }
+    }
+
+    // byte()
+    // bytes()
+
+    def byte = bytes
+    def bytes = num
+
+    // kilobyte()
+    // kilobytes()
+
+    def kilobyte = kilobytes
+    def kilobytes = num.doubleValue() * KILOBYTE
+
+    // megabyte()
+    // megabytes()
+
+    def megabyte = megabytes
+    def megabytes = num.doubleValue() * MEGABYTE
+
+    // gigabyte()
+    // gigabytes()
+
+    def gigabyte = gigabytes
+    def gigabytes = num.doubleValue() * GIGABYTE
+
+    // terabyte()
+    // terabytes()
+
+    def terabyte = terabytes
+    def terabytes = num.doubleValue() * TERABYTE
+
+    // petabyte()
+    // petabytes()
+
+    def petabyte = petabytes
+    def petabytes = num.doubleValue() * PETABYTE
+
+    // exabyte()
+    // exabytes()
+
+    def exabyte = exabytes
+    def exabytes = num.doubleValue() * EXABYTE
+
+    // second()
+    // seconds()
+
+    // minute()
+    // minutes()
+
+    // hour()
+    // hours()
+
+    // day()
+    // days()
+
+    // duplicable?()
+
+    // fortnight()
+    // fortnights()
+
+    // html_safe?()
+
+    // in_milliseconds()
+
+    // to_formatted_s(format = :default, options = {})
+
+    // week()
+    // weeks()
+
+    def week: Duration = weeks
+
+    def weeks: Duration = Duration(num.doubleValue() * 7, TimeUnit.DAYS)
+
+  }
+
+  implicit def fromIntToRichNumber(num: Int): RichNumber = RichNumber(num)
+  implicit def fromLongToRichNumber(num: Long): RichNumber = RichNumber(num)
+  implicit def fromDoubleToRichNumber(num: Double): RichNumber = RichNumber(num)
+  implicit def fromBigDecimalToRichNumber(num: BigDecimal): RichNumber = RichNumber(num)
+
+  // Duration implicits from scala.concurrent.duration
+
+  implicit def pairIntToDuration(p: (Int, TimeUnit)): Duration = Duration(p._1.toLong, p._2)
+  implicit def pairLongToDuration(p: (Long, TimeUnit)): FiniteDuration = Duration(p._1, p._2)
+  implicit def durationToPair(d: Duration): (Long, TimeUnit) = (d.length, d.unit)
+
+}

--- a/common/src/main/scala/skinny/activeimplicits/StringImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/StringImplicits.scala
@@ -1,0 +1,245 @@
+package skinny.activeimplicits
+
+import java.util.Locale
+
+import org.joda.time._
+import skinny.util.{ DateTimeUtil, StringUtil }
+
+import scala.language.implicitConversions
+
+/**
+ * ActiveSupport-ish implicit conversions to String value.
+ */
+object StringImplicits extends StringImplicits
+
+trait StringImplicits {
+
+  /**
+   * http://api.rubyonrails.org/classes/String.html
+   */
+  case class RichString(str: String) {
+    private[this] def withString(op: (String) => String): String = Option(str).map(op).orNull[String]
+    private[this] def toBeginIndex(position: Int): Int = Option(str).map { s =>
+      if (position < 0) s.size - position.abs else position
+    }.getOrElse(position)
+
+    // acts_like_string?()
+    // won't be supported because this is a Ruby specific feature
+
+    // at(position)
+
+    def at(position: Int): String = withString { s =>
+      val pos = toBeginIndex(position)
+      if (pos + 1 > s.size) null
+      else s.substring(pos, pos + 1)
+    }
+
+    def at(range: Range): String = withString { s =>
+      range.headOption.map { head =>
+        val begin = toBeginIndex(head)
+        val end = if (head < 0) str.size - range.last.abs + 1 else range.last + 1
+
+        if (end > s.size) "" else s.substring(begin, end)
+      }.getOrElse("")
+    }
+
+    // blank?()
+
+    def blank: Boolean = Option(str).map(_.replaceAll("\\s+", "").length == 0).getOrElse(true)
+
+    // camelcase(first_letter = :upper)
+
+    def camelcase = camelize
+    def lowerCamelcase = lowerCamelize
+
+    def camelcaseAsRuby = camelizeAsRuby
+    def lowerCamelcaseAsRuby = lowerCamelizeAsRuby
+
+    def camelcaseAsScala = camelizeAsScala
+    def lowerCamelcaseAsScala = lowerCamelizeAsScala
+
+    // camelize(first_letter = :upper)
+
+    def camelize = camelizeAsScala
+    def lowerCamelize = lowerCamelizeAsScala
+
+    def camelizeAsRuby: String = StringUtil.toCamelCase(str).split("/").map { s => s.head.toUpper + s.tail }.mkString("::")
+    def lowerCamelizeAsRuby: String = {
+      val s = camelizeAsRuby
+      s.head.toLower + s.tail
+    }
+
+    def camelizeAsScala: String = withString { s =>
+      val elements = s.split("/")
+      elements.size match {
+        case 0 => null
+        case 1 => StringUtil.toUpperCamelCase(elements.head)
+        case _ => (elements.init :+ StringUtil.toUpperCamelCase(elements.last)).mkString(".")
+      }
+    }
+    def lowerCamelizeAsScala: String = withString { s =>
+      val elements = s.split("/")
+      elements.size match {
+        case 0 => null
+        case 1 => StringUtil.toCamelCase(elements.head)
+        case _ => (elements.init :+ StringUtil.toCamelCase(elements.last)).mkString(".")
+      }
+    }
+
+    // classify()
+    // TODO: inflection required
+
+    // constantize()
+    // won't be supported because this is a Ruby specific feature
+
+    // dasherize()
+
+    def dasherize: String = withString(_.replaceAll("_", "-"))
+
+    // deconstantize()
+
+    // demodulize()
+    // won't be supported because this is a Ruby specific feature
+
+    // exclude?(string)
+
+    def include(part: String): Boolean = Option(str).map(_.indexOf(part) != -1).getOrElse(false)
+    def exclude(part: String): Boolean = !include(part)
+
+    // first(limit = 1)
+
+    def first: String = withString(_.head.toString)
+    def first(length: Int): String = withString(_.take(length))
+
+    // foreign_key(separate_class_name_and_id_with_underscore = true)
+
+    // from(position)
+    // to(position)
+
+    def from(position: Int): String = withString(_.drop(toBeginIndex(position)))
+    def to(position: Int): String = withString(_.take(toBeginIndex(position) + 1))
+    def fromTo(from: Int, to: Int): String = withString(_.to(to).from(from))
+
+    // html_safe()
+    // humanize(options = {})
+    // TODO: inflection required
+
+    // in_time_zone(zone = ::Time.zone)
+
+    // indent(amount, indent_string=nil, indent_empty_lines=false)
+    // indent!(amount, indent_string=nil, indent_empty_lines=false)
+
+    // inquiry()
+
+    // is_utf8?()
+
+    // last(limit = 1)
+
+    // mb_chars()
+
+    // parameterize(sep = '-')
+
+    def parameterize: String = parameterize("-")
+
+    def parameterize(sep: String): String = {
+      withString(_
+        .replaceAll("\\s+", sep)
+        .replaceAll("\\.", "")
+        .toLowerCase(Locale.ENGLISH)
+      )
+    }
+
+    // pluralize(count = nil, locale = :en)
+    // TODO: inflection required
+
+    // remove(*patterns)
+    // remove!(*patterns)
+
+    def remove(regexp: String): String = withString(_.replaceAll(regexp, ""))
+
+    // safe_constantize()
+
+    // singularize(locale = :en)
+    // TODO: inflection required
+
+    // squish()
+    // squish!()
+
+    def squish: String = withString(_.replaceAll("\\s+", " ").trim)
+
+    // strip_heredoc()
+
+    // tableize()
+    // TODO: inflection required
+
+    // titlecase()
+
+    def titlecase = titleize
+
+    // titleize()
+
+    def titleize: String = withString { s =>
+      s.replaceAll("-", " ")
+        .split("\\s+")
+        .map { s => s.head.toUpper + s.tail }
+        .mkString(" ")
+    }
+
+    // to_date()
+
+    def toJodaLocalDate: LocalDate = DateTimeUtil.parseLocalDate(str)
+
+    // to_datetime()
+
+    def toJodaDateTime: DateTime = DateTimeUtil.parseDateTime(str)
+
+    // to_time(form = :local)
+
+    def toJodaLocalTime: LocalTime = DateTimeUtil.parseLocalTime(str)
+
+    // truncate(truncate_at, options = {})
+
+    def truncate(at: Int, separator: String = "", omission: String = "..."): String = {
+      val o = Option(omission).getOrElse("")
+      val sep = Option(separator).getOrElse("")
+      withString { s =>
+        val res = s.take(at - o.size)
+        if (sep.isEmpty) res + o
+        else res.replaceFirst(sep + res.split(sep).last + "$", "") + o
+      }
+    }
+
+    // truncate_words(words_count, options = {})
+
+    def truncateWords(count: Int, separator: String = "\\s+", omission: String = "..."): String = {
+      val o = Option(omission).getOrElse("")
+      val sep = Option(separator).getOrElse("")
+      withString { s =>
+        val regexpToRemove = s.split(separator).drop(count).foldLeft("") {
+          case (res, word) => res + separator + word
+        }
+        s.replaceFirst(regexpToRemove + "$", "") + o
+      }
+    }
+
+    // underscore()
+
+    def underscore: String = RichString(underscoreAsRuby).underscoreAsScala
+
+    def underscoreAsRuby: String = {
+      Option(StringUtil.toSnakeCase(str))
+        .map(_.split("::").map(_.replaceFirst("^_", "")).mkString("/"))
+        .orNull[String]
+    }
+
+    def underscoreAsScala: String = {
+      Option(StringUtil.toSnakeCase(str))
+        .map(_.split("\\.").map(_.replaceFirst("^_", "")).mkString("/"))
+        .orNull[String]
+    }
+
+  }
+
+  implicit def fromStringToRichString(str: String): RichString = RichString(str)
+
+}

--- a/common/src/main/scala/skinny/activeimplicits/StringImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/StringImplicits.scala
@@ -3,6 +3,7 @@ package skinny.activeimplicits
 import java.util.Locale
 
 import org.joda.time._
+import skinny.nlp.{ SkinnyJapaneseAnalyzerFactory, SkinnyJapaneseAnalyzer }
 import skinny.util.{ DateTimeUtil, StringUtil }
 
 import scala.language.implicitConversions
@@ -237,6 +238,54 @@ trait StringImplicits {
         .map(_.split("\\.").map(_.replaceFirst("^_", "")).mkString("/"))
         .orNull[String]
     }
+
+    // ----------------------------
+    // Japanese word conversions
+    // requires kuromoji analyzer - http://lucene.apache.org/
+
+    def katakanaReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): Seq[String] = {
+      Option(str).map { s =>
+        SkinnyJapaneseAnalyzerFactory.ensureKuromojiExistence
+        analyzer.toKatakanaReadings(s)
+      }.getOrElse(Nil)
+    }
+
+    def hiraganaReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): Seq[String] = {
+      Option(str).map { s =>
+        SkinnyJapaneseAnalyzerFactory.ensureKuromojiExistence
+        analyzer.toHiraganaReadings(s)
+      }.getOrElse(Nil)
+    }
+
+    def romajiReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): Seq[String] = {
+      Option(str).map { s =>
+        SkinnyJapaneseAnalyzerFactory.ensureKuromojiExistence
+        analyzer.toRomajiReadings(s)
+      }.getOrElse(Nil)
+
+    }
+
+    def toKatakanaReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = katakanaReadings
+    def toHiraganaReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = hiraganaReadings
+    def toRomajiReadings(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = romajiReadings
+
+    def katakana(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): String = withString { s =>
+      this.katakanaReadings.mkString
+    }
+
+    def hiragana(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): String = withString { s =>
+      this.hiraganaReadings.mkString
+    }
+
+    def romaji(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default): String = withString { s =>
+      this.romajiReadings.mkString
+    }
+
+    def toKatakana(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = katakana
+    def toHiragana(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = hiragana
+    def toRomaji(implicit analyzer: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzer.default) = romaji
+
+    // ----------------------------
 
   }
 

--- a/common/src/main/scala/skinny/nlp/KuromojiJapaneseAnalyzer.scala
+++ b/common/src/main/scala/skinny/nlp/KuromojiJapaneseAnalyzer.scala
@@ -1,0 +1,83 @@
+package skinny.nlp
+
+import org.apache.lucene.analysis.ja.JapaneseAnalyzer
+import org.apache.lucene.analysis.ja.tokenattributes.ReadingAttribute
+import org.apache.lucene.analysis.ja.util.ToStringUtil
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
+import skinny.logging.Logging
+import skinny.util.LoanPattern._
+
+import scala.collection.mutable.ListBuffer
+import scala.util.Try
+
+case class KuromojiJapaneseAnalyzer(kuromojiAnalyzer: JapaneseAnalyzer) extends SkinnyJapaneseAnalyzer with Logging {
+
+  private[this] val KATAKANA_CHARS_TO_BE_AS_IS = Seq('゠', '・', 'ー', 'ヽ', 'ヾ', 'ヿ')
+
+  def toKatakanaReadings(str: String): Seq[String] = toTokens(str).map(_.katakana).toSeq
+
+  def toHiraganaReadings(str: String): Seq[String] = {
+    toKatakanaReadings(str).map(katakanaToHiragana)
+  }
+
+  def toRomajiReadings(str: String): Seq[String] = {
+    toTokens(str).map(_.romaji).map(_.replaceAll("ō", "o")).toSeq
+  }
+
+  def toRomaji(str: String): String = toRomajiReadings(str).mkString
+
+  def toHiragana(str: String): String = katakanaToHiragana(toKatanaka(str))
+
+  def toKatanaka(str: String): String = toKatakanaReadings(str).mkString
+
+  private def isKatakanaToBeHiragana(c: Char): Boolean = {
+    Character.UnicodeBlock.of(c) == Character.UnicodeBlock.KATAKANA &&
+      !KATAKANA_CHARS_TO_BE_AS_IS.contains(c)
+  }
+
+  private def katakanaToHiragana(str: String): String = {
+    str.map { c => if (isKatakanaToBeHiragana(c)) (c + 'あ' - 'ア').toChar else c }.mkString
+  }
+
+  private case class KuromojiToken(term: String, katakana: String, romaji: String)
+
+  private def toTokens(str: String): Seq[KuromojiToken] = {
+    using(kuromojiAnalyzer.tokenStream("katakana-conversion", str)) { stream =>
+      val charTermAttr = stream.addAttribute(classOf[CharTermAttribute])
+      val readingAttr = stream.addAttribute(classOf[ReadingAttribute])
+
+      val tokens = new ListBuffer[KuromojiToken]
+      stream.reset()
+      while (Try(stream.incrementToken()).getOrElse(true)) {
+        val original = charTermAttr.toString
+        if (original != null) {
+          val katakana = if (readingAttr.getReading != null) readingAttr.getReading else original
+          val romaji = ToStringUtil.getRomanization(katakana)
+          val token = KuromojiToken(original, katakana, romaji)
+          tokens.append(token)
+        }
+      }
+      logger.debug(s"Tokenized results: ${tokens}")
+
+      var previous: KuromojiToken = null
+      val distinctTokens = new ListBuffer[KuromojiToken]
+      tokens.foreach { current =>
+        if (previous != null) {
+          if (current.term.contains(previous.term)) {
+            distinctTokens.remove(distinctTokens.size - 1)
+            distinctTokens.append(current)
+          } else if (previous.term.contains(current.term)) {
+            // NOOP
+          } else {
+            distinctTokens.append(current)
+          }
+        } else {
+          distinctTokens.append(current)
+        }
+        previous = current
+      }
+      distinctTokens.toSeq
+    }
+  }
+
+}

--- a/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzer.scala
+++ b/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzer.scala
@@ -1,0 +1,22 @@
+package skinny.nlp
+
+object SkinnyJapaneseAnalyzer {
+
+  lazy val default: SkinnyJapaneseAnalyzer = SkinnyJapaneseAnalyzerFactory.create()
+}
+
+trait SkinnyJapaneseAnalyzer {
+
+  def toKatakanaReadings(str: String): Seq[String]
+
+  def toHiraganaReadings(str: String): Seq[String]
+
+  def toRomajiReadings(str: String): Seq[String]
+
+  def toRomaji(str: String): String
+
+  def toHiragana(str: String): String
+
+  def toKatanaka(str: String): String
+
+}

--- a/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzerFactory.scala
+++ b/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzerFactory.scala
@@ -1,0 +1,57 @@
+package skinny.nlp
+
+import java.io.{ InputStreamReader, ByteArrayInputStream }
+import org.apache.lucene.analysis.ja.{ JapaneseTokenizer, JapaneseAnalyzer }
+import org.apache.lucene.analysis.ja.dict.UserDictionary
+import org.apache.lucene.analysis.util.CharArraySet
+import scala.collection.JavaConverters._
+import skinny.util.LoanPattern._
+
+object SkinnyJapaneseAnalyzerFactory {
+
+  def ensureKuromojiExistence: Unit = {
+    if (kuromojiNotFound) {
+      throw new IllegalStateException(
+        """Kuromoji Analyzer Required
+          |
+          |-------------------------------------------
+          |
+          | ***** Kuromoji Analyzer Required *****
+          |
+          | Japanese converters (katakana, hiragana, romaji) requires Kuromoji analyzer from Apache Lucene. http://lucene.apache.org/
+          |
+          | Add the following dependency to your build.sbt.
+          |
+          |   libraryDependencies += "org.apache.lucene" % "lucene-analyzers-kuromoji" % "<luceneLatestVersion>"
+          |
+          |-------------------------------------------
+          |""".stripMargin)
+    }
+  }
+
+  lazy val kuromojiNotFound: Boolean = {
+    try {
+      Class.forName("org.apache.lucene.analysis.ja.JapaneseAnalyzer")
+      false
+    } catch { case e: Exception => true }
+  }
+
+  def create(dictionaryText: String): SkinnyJapaneseAnalyzer = {
+    val dictionary: UserDictionary = using(new ByteArrayInputStream(dictionaryText.getBytes)) { stream =>
+      using(new InputStreamReader(stream)) { reader =>
+        new UserDictionary(reader)
+      }
+    }
+    create(dictionary)
+  }
+
+  def create(userDictionary: UserDictionary = null): SkinnyJapaneseAnalyzer = {
+    ensureKuromojiExistence
+    new KuromojiJapaneseAnalyzer(new JapaneseAnalyzer(
+      userDictionary,
+      JapaneseTokenizer.Mode.NORMAL,
+      new CharArraySet(0, true),
+      Set.empty[String].asJava))
+  }
+
+}

--- a/common/src/main/scala/skinny/util/StringUtil.scala
+++ b/common/src/main/scala/skinny/util/StringUtil.scala
@@ -47,14 +47,21 @@ object StringUtil {
    */
   def toCamelCase(str: String): String = {
     Option(str).map { s =>
+      val result = toUpperCamelCase(s)
+      if (result.headOption.exists(c => c.isUpper)) result.head.toLower + result.tail
+      else result
+    }.orNull[String]
+  }
+
+  def toUpperCamelCase(str: String): String = {
+    Option(str).map { s =>
       val result = s.foldLeft((ListBuffer[Char](), false)) {
         case ((cs, prevIs_), c) =>
           if (c == '_') (cs, true)
           else if (prevIs_) (cs += c.toUpper, false)
           else (cs += c, false)
       }._1.mkString
-
-      if (result.headOption.exists(c => c.isUpper)) result.head.toLower + result.tail
+      if (result.headOption.exists(c => c.isLower)) result.head.toUpper + result.tail
       else result
     }.orNull[String]
   }

--- a/common/src/test/scala/skinny/activeimplicits/AllImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/AllImplicitsSpec.scala
@@ -1,0 +1,20 @@
+package skinny.activeimplicits
+
+import org.scalatest._
+
+class AllImplicitsSpec extends FlatSpec with Matchers {
+
+  object Sample extends AllImplicits {
+    def duration = 100.seconds
+    def weeks = 4.weeks
+    def removeFoo(str: String) = str.remove("foo")
+  }
+
+  it should "be available" in {
+    import AllImplicits._
+    Sample.duration should equal(100.seconds)
+    Sample.weeks should equal(4.weeks)
+    Sample.removeFoo("foo bar") should equal(" bar")
+  }
+
+}

--- a/common/src/test/scala/skinny/activeimplicits/NumberImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/NumberImplicitsSpec.scala
@@ -1,0 +1,46 @@
+package skinny.activeimplicits
+
+import org.scalatest._
+
+class NumberImplicitsSpec extends FlatSpec with Matchers with NumberImplicits {
+
+  it should "have duration implicits" in {
+    1.second.toMillis should equal(1000L)
+    2000.millis should equal(2.seconds)
+
+    1.minute should equal(60.seconds)
+    1.hour should equal(60.minutes)
+    1.day should equal(24.hours)
+    1.week should equal(7.days)
+
+    2.minutes should equal(120.seconds)
+    2.hours should equal(120.minutes)
+    2.days should equal(48.hours)
+    2.weeks should equal(14.days)
+  }
+
+  it should "have #byte, #kilobytes ..." in {
+    1.byte should equal(1)
+    100.bytes should equal(100)
+
+    0.5D.kilobytes should equal(512.0)
+    1.kilobyte should equal(1024)
+    100.kilobytes should equal(100L * KILOBYTE)
+
+    1.megabyte should equal(MEGABYTE)
+    100.megabytes should equal(100L * MEGABYTE)
+
+    1.gigabyte should equal(GIGABYTE)
+    100.gigabytes should equal(100L * GIGABYTE)
+
+    1.terabyte should equal(TERABYTE)
+    100.terabytes should equal(100L * TERABYTE)
+
+    1.petabyte should equal(PETABYTE)
+    100.petabytes should equal(100L * PETABYTE)
+
+    1.exabyte should equal(EXABYTE)
+    100.exabytes should equal(100L * EXABYTE)
+  }
+
+}

--- a/common/src/test/scala/skinny/activeimplicits/StringImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/StringImplicitsSpec.scala
@@ -1,0 +1,128 @@
+package skinny.activeimplicits
+
+import org.scalatest._
+
+// http://api.rubyonrails.org/classes/String.html
+class StringImplicitsSpec extends FlatSpec with Matchers with StringImplicits {
+
+  it should "have #remove" in {
+    "Hello Hello HELLO World!".remove("Hello") should equal("  HELLO World!")
+  }
+
+  it should "have #squish" in {
+    " \n  foo\n\r \t bar \n".squish should equal("foo bar")
+  }
+
+  it should "have #at" in {
+    "hello".at(0) should equal("h")
+    "hello".at(1 to 3) should equal("ell")
+    "hello".at(-2) should equal("l")
+    "hello".at(-2 to -1) should equal("lo")
+    "hello".at(5) should equal(null)
+    "hello".at(5 to -1) should equal("")
+  }
+
+  it should "have #blank" in {
+    "".blank should equal(true)
+    "   ".blank should equal(true)
+    " \t \n \r".blank should equal(true)
+    " hello ".blank should equal(false)
+  }
+
+  it should "have #camelize / #lowerCamelize" in {
+    "active_record".camelize should equal("ActiveRecord")
+    "active_record/errors".camelize should equal("active_record.Errors")
+    "active_record".lowerCamelize should equal("activeRecord")
+    "active_record/errors".lowerCamelize should equal("active_record.errors")
+
+    "active_record".camelizeAsRuby should equal("ActiveRecord")
+    "active_record".lowerCamelizeAsRuby should equal("activeRecord")
+    "active_record/errors".camelizeAsRuby should equal("ActiveRecord::Errors")
+    "active_record/errors".lowerCamelizeAsRuby should equal("activeRecord::Errors")
+
+    "active_record".camelizeAsScala should equal("ActiveRecord")
+    "active_record/errors".camelizeAsScala should equal("active_record.Errors")
+    "active_record".lowerCamelizeAsScala should equal("activeRecord")
+    "active_record/errors".lowerCamelizeAsScala should equal("active_record.errors")
+  }
+
+  it should "have #dasherize" in {
+    // 'puni_puni'.dasherize # => "puni-puni"
+    "puni_puni".dasherize should equal("puni-puni")
+  }
+
+  it should "have #exclude" in {
+    "hello".exclude("lo") should equal(false)
+    "hello".exclude("ol") should equal(true)
+    "hello".exclude("h") should equal(false)
+  }
+
+  it should "have #first" in {
+    "hello".first should equal("h")
+    "hello".first(1) should equal("h")
+    "hello".first(2) should equal("he")
+    "hello".first(0) should equal("")
+    "hello".first(6) should equal("hello")
+  }
+
+  it should "have #from" in {
+    "hello".from(0) should equal("hello")
+    "hello".from(3) should equal("lo")
+    "hello".from(-2) should equal("lo")
+  }
+
+  it should "have #to" in {
+    "hello".to(0) should equal("h")
+    "hello".to(3) should equal("hell")
+    "hello".to(-2) should equal("hell")
+  }
+
+  it should "have #fromTo" in {
+    "hello".fromTo(0, -1) should equal("hello")
+    "hello".fromTo(1, -2) should equal("ell")
+  }
+
+  it should "have #parameterize" in {
+    "Donald E. Knuth".parameterize should equal("donald-e-knuth")
+  }
+
+  //  it should "have #tableize" in {
+  //    "RawScaledScorer".tableize should equal("raw_scaled_scorers")
+  //    "egg_and_ham".tableize should equal("egg_and_hams")
+  //    "fancyCategory".tableize should equal("fancy_categories")
+  //  }
+
+  it should "have #titleize" in {
+    "man from the boondocks".titleize should equal("Man From The Boondocks")
+    "x-men: the last stand".titleize should equal("X Men: The Last Stand")
+  }
+
+  it should "have #truncate" in {
+    "Once upon a time in a world far far away".truncate(27) should equal(
+      "Once upon a time in a wo...")
+    "Once upon a time in a world far far away".truncate(27, " ") should equal(
+      "Once upon a time in a...")
+    "And they found that many people were sleeping better.".truncate(25, omission = "... (continued)") should equal(
+      "And they f... (continued)")
+  }
+
+  it should "have #truncate_words" in {
+    "Once upon a time in a world far far away".truncateWords(4) should equal(
+      "Once upon a time...")
+    "Once<br>upon<br>a<br>time<br>in<br>a<br>world".truncateWords(5, separator = "<br>") should equal(
+      "Once<br>upon<br>a<br>time<br>in...")
+    "And they found that many people were sleeping better.".truncateWords(5, omission = "... (continued)") should equal(
+      "And they found that many... (continued)")
+  }
+
+  it should "hava #underscore" in {
+    "ActiveModel".underscore should equal("active_model")
+    "ActiveModel::Errors".underscore should equal("active_model/errors")
+
+    "ActiveModel".underscore should equal("active_model")
+    "activeModel.Errors".underscore should equal("active_model/errors")
+    "ActiveModel.Errors".underscore should equal("active_model/errors")
+    "active_model.Errors".underscore should equal("active_model/errors")
+  }
+
+}

--- a/common/src/test/scala/skinny/activeimplicits/StringImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/StringImplicitsSpec.scala
@@ -1,6 +1,7 @@
 package skinny.activeimplicits
 
 import org.scalatest._
+import skinny.nlp.SkinnyJapaneseAnalyzerFactory
 
 // http://api.rubyonrails.org/classes/String.html
 class StringImplicitsSpec extends FlatSpec with Matchers with StringImplicits {
@@ -115,7 +116,7 @@ class StringImplicitsSpec extends FlatSpec with Matchers with StringImplicits {
       "And they found that many... (continued)")
   }
 
-  it should "hava #underscore" in {
+  it should "have #underscore" in {
     "ActiveModel".underscore should equal("active_model")
     "ActiveModel::Errors".underscore should equal("active_model/errors")
 
@@ -123,6 +124,87 @@ class StringImplicitsSpec extends FlatSpec with Matchers with StringImplicits {
     "activeModel.Errors".underscore should equal("active_model/errors")
     "ActiveModel.Errors".underscore should equal("active_model/errors")
     "active_model.Errors".underscore should equal("active_model/errors")
+  }
+
+  it should "have #katakana" in {
+    "東京特許許可局".katakanaReadings should equal(Seq("トウキョウ", "トッキョ", "キョカ", "キョク"))
+    "東京特許許可局".katakana should equal("トウキョウトッキョキョカキョク")
+
+    "東京特許許可局".toKatakanaReadings should equal(Seq("トウキョウ", "トッキョ", "キョカ", "キョク"))
+    "東京特許許可局".toKatakana should equal("トウキョウトッキョキョカキョク")
+
+    "ようかい体操第一".katakana should equal("ヨウカイタイソウダイイチ")
+    "妖怪タイソウ第１".katakana should equal("ヨウカイタイソウダイイチ")
+    "ようかい体操第1".katakana should equal("ヨウカイタイソウダイ1")
+    "日本マイクロソフト株式会社".katakana should equal("ニッポンマイクロソフトカブシキガイシャ")
+    "型安全な Web フレームワーク".katakana should equal("カタアンゼンナwebフレームワーク")
+    "地獄のミサワ".katakana should equal("ジゴクノミサワ")
+    "椎名林檎".katakana should equal("シイナリンゴ")
+    "rpscala".katakana should equal("rpscala")
+    "区切り文字".katakana should equal("クギリモジ")
+    "毎日深夜0時更新！掘り出し物をチェック".katakana should equal("マイニチシンヤ0ジコウシンホリダシモノヲチェック")
+    "Skinny Framework はお好きなようにご利用ください".katakana should equal("skinnyframeworkハオスキナヨウニゴリヨウクダサイ")
+  }
+
+  it should "have #katakana with customized analyzer" in {
+    val dictionaryText =
+      """日本,日本,ニホン,カスタム名詞
+        |Skinny Framework,スキニーフレームワーク,スキニーフレームワーク,カスタム名詞""".stripMargin
+    implicit val analyzer = SkinnyJapaneseAnalyzerFactory.create(dictionaryText)
+
+    "日本マイクロソフト株式会社".katakana should equal("ニホンマイクロソフトカブシキガイシャ")
+    "Skinny Framework はお好きなようにご利用ください".katakana should equal("スキニーフレームワークハオスキナヨウニゴリヨウクダサイ")
+  }
+
+  it should "have #hiragana" in {
+    "東京特許許可局".hiraganaReadings should equal(Seq("とうきょう", "とっきょ", "きょか", "きょく"))
+    "東京特許許可局".hiragana should equal("とうきょうとっきょきょかきょく")
+
+    "東京特許許可局".toHiraganaReadings should equal(Seq("とうきょう", "とっきょ", "きょか", "きょく"))
+    "東京特許許可局".toHiragana should equal("とうきょうとっきょきょかきょく")
+
+    "ようかい体操第一".hiragana should equal("ようかいたいそうだいいち")
+    "妖怪タイソウ第１".hiragana should equal("ようかいたいそうだいいち")
+    "ようかい体操第1".hiragana should equal("ようかいたいそうだい1")
+    "日本マイクロソフト株式会社".hiragana should equal("にっぽんまいくろそふとかぶしきがいしゃ")
+    "型安全な Web フレームワーク".hiragana should equal("かたあんぜんなwebふれーむわーく")
+    "地獄のミサワ".hiragana should equal("じごくのみさわ")
+    "椎名林檎".hiragana should equal("しいなりんご")
+    "rpscala".hiragana should equal("rpscala")
+    "区切り文字".hiragana should equal("くぎりもじ")
+    "毎日深夜0時更新！掘り出し物をチェック".hiragana should equal("まいにちしんや0じこうしんほりだしものをちぇっく")
+    "Skinny Framework はお好きなようにご利用ください".hiragana should equal("skinnyframeworkはおすきなようにごりようください")
+  }
+
+  it should "have #romaji" in {
+    "東京特許許可局".romaji should equal("tokyotokkyokyokakyoku")
+    "ようかい体操第一".romaji should equal("yokaitaisodaiichi")
+    "妖怪タイソウ第１".romaji should equal("yokaitaisodaiichi")
+    "ようかい体操第1".romaji should equal("yokaitaisodai1")
+    "日本マイクロソフト株式会社".romaji should equal("nipponmaikurosofutokabushikigaisha")
+    "型安全な Web フレームワーク".romaji should equal("kataanzennawebfuremuwaku")
+    "地獄のミサワ".romaji should equal("jigokunomisawa")
+    "椎名林檎".romaji should equal("shiinaringo")
+    "rpscala".romaji should equal("rpscala")
+    "区切り文字".romaji should equal("kugirimoji")
+    "毎日深夜0時更新！掘り出し物をチェック".romaji should equal("mainichishin'ya0jikoshinhoridashimonoochekku")
+    "Skinny Framework はお好きなようにご利用ください".romaji should equal("skinnyframeworkhaosukinayonigoriyokudasai")
+
+    "東京特許許可局".toRomaji should equal("tokyotokkyokyokakyoku")
+  }
+
+  it should "have #romaji with custom analyzer" in {
+    val dictionaryText =
+      """日本,日本,nihon,カスタム名詞
+        |マイクロソフト,Microsoft,microsoft,カスタム名詞
+        |株式会社,K.K.,k.k.,カスタム名詞""".stripMargin
+    implicit val analyzer = SkinnyJapaneseAnalyzerFactory.create(dictionaryText)
+
+    "日本マイクロソフト株式会社".romajiReadings should equal(Seq("nihon", "microsoft", "k.k."))
+    "日本マイクロソフト株式会社".romaji should equal("nihonmicrosoftk.k.")
+
+    "日本マイクロソフト株式会社".toRomajiReadings should equal(Seq("nihon", "microsoft", "k.k."))
+    "日本マイクロソフト株式会社".toRomaji should equal("nihonmicrosoftk.k.")
   }
 
 }

--- a/common/src/test/scala/skinny/nlp/SkinnyJapaneseAnalyzerSpec.scala
+++ b/common/src/test/scala/skinny/nlp/SkinnyJapaneseAnalyzerSpec.scala
@@ -1,0 +1,14 @@
+package skinny.nlp
+
+import org.scalatest._
+
+class SkinnyJapaneseAnalyzerSpec extends FlatSpec with Matchers {
+
+  it should "be available" in {
+    val analyzer = SkinnyJapaneseAnalyzer.default
+    analyzer.toKatanaka("東京特許許可局") should equal("トウキョウトッキョキョカキョク")
+    analyzer.toHiragana("東京特許許可局") should equal("とうきょうとっきょきょかきょく")
+    analyzer.toRomaji("東京特許許可局") should equal("tokyotokkyokyokakyoku")
+  }
+
+}

--- a/common/src/test/scala/skinny/util/StringUtilSpec.scala
+++ b/common/src/test/scala/skinny/util/StringUtilSpec.scala
@@ -23,4 +23,13 @@ class StringUtilSpec extends FlatSpec with Matchers {
     toCamelCase("_first_name") should equal("firstName")
     toCamelCase("is_atm_working") should equal("isAtmWorking")
   }
+
+  it should "have #toUpperCamelCase" in {
+    toUpperCamelCase(null) should be(null)
+    toUpperCamelCase("FirstName") should equal("FirstName")
+    toUpperCamelCase("firstName") should equal("FirstName")
+    toUpperCamelCase("first_name") should equal("FirstName")
+    toUpperCamelCase("_first_name") should equal("FirstName")
+    toUpperCamelCase("is_atm_working") should equal("IsAtmWorking")
+  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,11 +5,12 @@ import scala.language.postfixOps
 
 object SkinnyFrameworkBuild extends Build {
 
-  lazy val currentVersion = "1.3.9"
+  lazy val currentVersion = "1.3.10-SNAPSHOT"
   lazy val scalatraVersion = "2.3.0"
   lazy val json4SVersion = "3.2.11"
   lazy val scalikeJDBCVersion = "2.2.1"
   lazy val h2Version = "1.4.184"
+  lazy val kuromojiVersion = "4.10.3"
   lazy val mockitoVersion = "1.10.19"
   lazy val jettyVersion = "9.2.1.v20140609" // latest: "9.2.6.v20141205"
 
@@ -48,7 +49,12 @@ object SkinnyFrameworkBuild extends Build {
     settings = baseSettings ++ Seq(
       name := "skinny-common",
       libraryDependencies  <++= (scalaVersion) { scalaVersion => 
-        Seq("com.typesafe" %  "config" % "1.2.1" % "compile")  ++
+        Seq(
+          "com.typesafe"      % "config"                    % "1.2.1"         % "compile",
+          "org.apache.lucene" % "lucene-core"               % kuromojiVersion % "provided",
+          "org.apache.lucene" % "lucene-analyzers-common"   % kuromojiVersion % "provided",
+          "org.apache.lucene" % "lucene-analyzers-kuromoji" % kuromojiVersion % "provided"
+        ) ++
         jodaDependencies ++ slf4jApiDependencies ++ testDependencies ++ (scalaVersion match {
           case v if v.startsWith("2.11.") => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3" % "compile")
           case _ => Nil

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
 sbt.version=0.13.7
-


### PR DESCRIPTION
Here is an ActiveSupport-ish implicit conversions module. 

http://guides.rubyonrails.org/active_support_core_extensions.html

Currently following classes are extended. Features which require inflections are not supported yet.

- String
- Int/Long/Double/BigDecimal

```scala
import skinny.activeimplicits.NumberImplicits._

100.kilobytes should equal(102400.bytes)
3.weeks should equal(21.days)

import skinny.activeimplicits.StringImplicits._

"Donald E. Knuth".parameterize should equal("donald-e-knuth")
"x-men: the last stand".titleize should equal("X Men: The Last Stand")

// prerequisite: Apache Lucene Kuromoji Analyzer

"東京特許許可局".hiragana should equal("とうきょうとっきょきょかきょく")
"ようかい体操第一".katakana should equal("ヨウカイタイソウダイイチ")
"地獄のミサワ".romaji should equal("jigokunomisawa")
```

