### PR TITLE
Add query(Multi)Params and form(Multi)Params

### DIFF
--- a/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
@@ -23,6 +23,8 @@ trait SkinnyControllerBase
     extends org.scalatra.SkinnyScalatraBase
     with ApiFormats
     with EnvFeature
+    with QueryParamsFeature
+    with FormParamsFeature
     with RichRouteFeature
     with UrlGeneratorSupport
     with ExplicitRedirectFeature

--- a/framework/src/main/scala/skinny/controller/feature/FormParamsFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/FormParamsFeature.scala
@@ -1,0 +1,30 @@
+package skinny.controller.feature
+
+import javax.servlet.http.HttpServletRequest
+
+import org.scalatra._
+
+/**
+ * Provides formParams/formMultiParams.
+ */
+trait FormParamsFeature extends ScalatraBase with QueryParamsFeature {
+
+  /**
+   * Returns query string multi parameters as a Map value.
+   */
+  def formMultiParams(implicit request: HttpServletRequest): MultiParams = {
+    multiParams.map {
+      case (k, vs) =>
+        queryMultiParams.find(_._1 == k) match {
+          case Some((k, queryValues)) => k -> vs.diff(queryValues)
+          case _ => k -> vs
+        }
+    }
+  }
+
+  /**
+   * Returns query string parameters as a Map value.
+   */
+  def formParams(implicit request: HttpServletRequest): Params = new ScalatraParams(formMultiParams)
+
+}

--- a/framework/src/main/scala/skinny/controller/feature/QueryParamsFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/QueryParamsFeature.scala
@@ -1,0 +1,24 @@
+package skinny.controller.feature
+
+import javax.servlet.http.HttpServletRequest
+
+import org.scalatra._
+
+/**
+ * Provides queryParams/queryMultiParams.
+ */
+trait QueryParamsFeature extends ScalatraBase {
+
+  /**
+   * Returns query string multi parameters as a Map value.
+   */
+  def queryMultiParams(implicit request: HttpServletRequest): MultiParams = {
+    new MultiParams(rl.MapQueryString.parseString(request.queryString))
+  }
+
+  /**
+   * Returns query string parameters as a Map value.
+   */
+  def queryParams(implicit request: HttpServletRequest): Params = new ScalatraParams(queryMultiParams)
+
+}

--- a/framework/src/test/scala/skinny/controller/feature/FormParamsFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/FormParamsFeatureSpec.scala
@@ -1,0 +1,52 @@
+package skinny.controller.feature
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny._
+import skinny.controller.SkinnyController
+
+class FormParamsFeatureSpec extends ScalatraFlatSpec {
+  behavior of "FormParamsFeature"
+
+  class Controller extends SkinnyController {
+    def single = formParams.getAs[String]("foo").getOrElse("<empty>")
+    def multi = formMultiParams.getAs[String]("foo").map(_.mkString(",")).getOrElse("<empty>")
+  }
+  object ctrl extends Controller with Routes {
+    get("/get")(single).as('get)
+    post("/post")(single).as('post)
+    get("/multi/get")(multi).as('multiGet)
+    post("/multi/post")(multi).as('multiPost)
+  }
+  addFilter(ctrl, "/*")
+
+  "formMultiParams" should "be available" in {
+    get("/multi/get?foo=bar&foo=baz") {
+      status should equal(200)
+      body should equal("")
+    }
+    post("/multi/post", "foo" -> "bar", "foo" -> "baz") {
+      status should equal(200)
+      body should equal("bar,baz")
+    }
+    post("/multi/post?foo=bar&foo=baz&foo=xxx", "foo" -> "xxx", "foo" -> "yyy") {
+      status should equal(200)
+      body should equal("xxx,yyy")
+    }
+  }
+
+  "formParams" should "be available" in {
+    get("/get", "foo" -> "bar") {
+      status should equal(200)
+      body should equal("<empty>")
+    }
+    post("/post", "foo" -> "bar") {
+      status should equal(200)
+      body should equal("bar")
+    }
+    post("/post?foo=bar", "foo" -> "baz") {
+      status should equal(200)
+      body should equal("baz")
+    }
+  }
+
+}

--- a/framework/src/test/scala/skinny/controller/feature/QueryParamsFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/QueryParamsFeatureSpec.scala
@@ -1,0 +1,52 @@
+package skinny.controller.feature
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny._
+import skinny.controller.SkinnyController
+
+class QueryParamsFeatureSpec extends ScalatraFlatSpec {
+  behavior of "QueryParamsFeature"
+
+  class Controller extends SkinnyController {
+    def single = queryParams.getAs[String]("foo").getOrElse("<empty>")
+    def multi = queryMultiParams.getAs[String]("foo").map(_.mkString(",")).getOrElse("<empty>")
+  }
+  object ctrl extends Controller with Routes {
+    get("/get")(single).as('get)
+    post("/post")(single).as('post)
+    get("/multi/get")(multi).as('multiGet)
+    post("/multi/post")(multi).as('multiPost)
+  }
+  addFilter(ctrl, "/*")
+
+  "queryMultiParams" should "be available" in {
+    get("/multi/get?foo=bar&foo=baz") {
+      status should equal(200)
+      body should equal("bar,baz")
+    }
+    post("/multi/post", "foo" -> "bar", "foo" -> "baz") {
+      status should equal(200)
+      body should equal("<empty>")
+    }
+    post("/multi/post?foo=bar&foo=baz", "foo" -> "xxx", "foo" -> "yyy") {
+      status should equal(200)
+      body should equal("bar,baz")
+    }
+  }
+
+  "queryParams" should "be available" in {
+    get("/get", "foo" -> "bar") {
+      status should equal(200)
+      body should equal("bar")
+    }
+    post("/post", "foo" -> "bar") {
+      status should equal(200)
+      body should equal("<empty>")
+    }
+    post("/post?foo=bar", "foo" -> "baz") {
+      status should equal(200)
+      body should equal("bar")
+    }
+  }
+
+}


### PR DESCRIPTION
This pull request newly enables following four APIs.

- queryParams
- queryMultiParams
- formParams
- formMultiParams

Although some people may wonder why Scalatra doesn't support these APIs, I think that's reasonable because sinatra doesn't have them.
