### PR TITLE
Fix #229 [orm] where('col_name -> Nil) condition is removed

### DIFF
--- a/orm/src/main/scala/skinny/orm/feature/QueryingFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/QueryingFeature.scala
@@ -34,7 +34,7 @@ trait QueryingFeatureWithId[Id, Entity]
       case (key, value) =>
         value match {
           case None => Some(sqls.isNull(defaultAlias.field(key.name)))
-          case Nil => None
+          case Nil => Some(sqls" FALSE") // for scalikejdbc 2.0.0 - 2.0.6 compatibility
           case values: Seq[_] => Some(sqls.in(defaultAlias.field(key.name), values))
           case value => Some(sqls.eq(defaultAlias.field(key.name), value))
         }

--- a/orm/src/test/scala/issue229/Issue229Spec.scala
+++ b/orm/src/test/scala/issue229/Issue229Spec.scala
@@ -1,0 +1,90 @@
+package issue229
+
+import org.scalatest._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+import skinny.dbmigration.DBSeeds
+import skinny.orm._
+
+trait Connection {
+  Class.forName("org.h2.Driver")
+  ConnectionPool.add('issue229, "jdbc:h2:mem:issue229;MODE=PostgreSQL", "sa", "sa")
+}
+
+trait CreateTables extends DBSeeds { self: Connection =>
+
+  override val dbSeedsAutoSession = NamedAutoSession('issue229)
+
+  addSeedSQL(
+    sql"""
+create table user (
+  id bigserial not null,
+  name varchar(100) not null)
+""")
+  addSeedSQL(
+    sql"""
+create table article (
+  id bigserial not null,
+  title varchar(100) not null,
+  user_id bigint references user(id))
+""")
+  runIfFailed(sql"select count(1) from article")
+}
+
+class Issue229Spec extends fixture.FunSpec with Matchers
+    with Connection
+    with CreateTables
+    with AutoRollback {
+
+  case class User(id: Long, name: String)
+  case class Article(id: Long, title: String, userId: Option[Long], user: Option[User] = None)
+
+  object User extends SkinnyCRUDMapper[User] {
+    override val connectionPoolName = 'issue229
+    override def defaultAlias = createAlias("u")
+
+    override def extract(rs: WrappedResultSet, rn: ResultName[User]) = autoConstruct(rs, rn)
+  }
+  object Article extends SkinnyCRUDMapper[Article] {
+    override val connectionPoolName = 'issue229
+    override def defaultAlias = createAlias("a")
+    override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user")
+
+    lazy val userRef = {
+      belongsTo[User](
+        right = User,
+        merge = (a, u) => a.copy(user = u)
+      ).includes[User]((as, us) => as.map { a =>
+          us.find(u => a.user.exists(_.id == u.id))
+            .map(u => a.copy(user = Some(u)))
+            .getOrElse(a)
+        })
+    }
+  }
+
+  override def db(): DB = NamedDB('issue229).toDB()
+
+  override def fixture(implicit session: DBSession): Unit = {
+    val aliceId = User.createWithAttributes('name -> "Alice")
+    val bobId = User.createWithAttributes('name -> "Bob")
+    Seq(
+      ("Hello World", Some(aliceId)),
+      ("Getting Started with Scala", Some(bobId)),
+      ("Functional Programming", None),
+      ("How to user sbt", Some(aliceId))
+    ).foreach {
+        case (title, userId) => Article.createWithAttributes('title -> title, 'userId -> userId)
+      }
+  }
+
+  def id(implicit session: DBSession): Long = {
+    Article.where('title -> "Functional Programming").apply().head.id
+  }
+
+  describe("find empty with empty ids") {
+    it("should return no results") { implicit session =>
+      Article.where('id -> Nil).apply().size should equal(0)
+    }
+  }
+
+}

--- a/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
+++ b/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
@@ -6,8 +6,9 @@ import javax.servlet.http._
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
+import skinny.{ DBSettings, DBSettingsInitializer }
 
-class TxPerRequestFilterSpec extends FunSpec with Matchers with MockitoSugar {
+class TxPerRequestFilterSpec extends FunSpec with Matchers with MockitoSugar with DBSettings with DBSettingsInitializer {
 
   val filter = new TxPerRequestFilter {
   }


### PR DESCRIPTION
This pull request fixes #229 [orm] where('col_name -> Nil) condition is removed.