### PR TITLE
Scala.js 0.6.0

### DIFF
--- a/run_skinny-blank-app_test.sh
+++ b/run_skinny-blank-app_test.sh
@@ -23,6 +23,7 @@ grunt compile
 ./skinny g reverse-model members1 rev2.member1 test && \
 ./skinny g reverse-scaffold members2 rev2.members2 member2 && \
 ./skinny test && \
+./skinny scalajs:package && \
 ./skinny package && \
 ./skinny package:standalone
 

--- a/yeoman-generator-skinny/app/templates/skinny
+++ b/yeoman-generator-skinny/app/templates/skinny
@@ -57,20 +57,20 @@ function copy_resources_to_task() {
 function setup_scalajs() {
   setting_file="${current_dir}/project/_skinny_scalajs.sbt"
   if [ ! -f "${setting_file}" ]; then
-    echo "addSbtPlugin(\"org.scala-lang.modules.scalajs\" % \"scalajs-sbt-plugin\" % \"0.5.4\")" > ${setting_file}
+    echo "resolvers += \"scala-js-release\" at \"http://dl.bintray.com/scala-js/scala-js-releases\"
+addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"0.6.0\")" > ${setting_file}
 
-    echo "lazy val scalaJS = Project(id = \"scalajs\", base = file(\"src/main/webapp/WEB-INF/assets\"),
-  settings = Seq(
-    name := \"application\", // JavaScript file name
-    unmanagedSourceDirectories in Compile <+= baseDirectory(_ / \"scala\"),
-    libraryDependencies ++= Seq(
-      \"org.scala-lang.modules.scalajs\" %%% \"scalajs-dom\"                    % \"0.6\",
-      \"org.scala-lang.modules.scalajs\" %%% \"scalajs-jquery\"                 % \"0.6\",
-      \"org.scala-lang.modules.scalajs\" %%  \"scalajs-jasmine-test-framework\" % \"0.5.4\" % \"test\"
-    ),
-    crossTarget in Compile <<= baseDirectory(_ / \"..\" / \"..\" / \"assets\" / \"js\")
-  )
-)" > ${current_dir}/_skinny_scalajs_settings.sbt
+echo "lazy val scalajs = (project in file(\"src/main/webapp/WEB-INF/assets\")).settings(
+  name := \"application\", // JavaScript file name
+  scalaVersion := \"2.11.5\",
+  unmanagedSourceDirectories in Compile <+= baseDirectory(_ / \"scala\"),
+  libraryDependencies ++= Seq(
+    \"org.scala-js\" %%% \"scalajs-dom\"    % \"0.8.0\",
+    \"be.doeraene\"  %%% \"scalajs-jquery\" % \"0.8.0\",
+    \"org.monifu\"   %%  \"minitest\"       % \"0.11\" % \"test\"
+  ),
+  crossTarget in Compile <<= baseDirectory(_ / \"..\" / \"..\" / \"assets\" / \"js\")
+).enablePlugins(ScalaJSPlugin)" > ${current_dir}/_skinny_scalajs_settings.sbt
   fi
 }
 

--- a/yeoman-generator-skinny/app/templates/skinny.bat
+++ b/yeoman-generator-skinny/app/templates/skinny.bat
@@ -372,20 +372,20 @@ GOTO script_eof
 
 :scalajs_task
 IF NOT EXIST "project\_skinny_scalajs.sbt" (
-  ECHO addSbtPlugin^("org.scala-lang.modules.scalajs" %% "scalajs-sbt-plugin" %% "0.5.4"^) > "project\_skinny_scalajs.sbt"
+  ECHO resolvers += "scala-js-release" at "http://dl.bintray.com/scala-js/scala-js-releases" > "project\_skinny_scalajs.sbt"
+  ECHO addSbtPlugin^("org.scala-js" %% "sbt-scalajs" %% "0.6.0"^) >> "project\_skinny_scalajs.sbt"
 
-  ECHO lazy val scalaJS = Project^(id = "scalajs", base = file^("src/main/webapp/WEB-INF/assets"^),  > "_skinny_scalajs_settings.sbt"
-  ECHO   settings = Seq^(                                  >> "_skinny_scalajs_settings.sbt"
-  ECHO     name := "application", // JavaScript file name  >> "_skinny_scalajs_settings.sbt"
-  ECHO     unmanagedSourceDirectories in Compile ^<+= baseDirectory^(_ / "scala"^), >> "_skinny_scalajs_settings.sbt"
-  ECHO     libraryDependencies ++= Seq^(                   >> "_skinny_scalajs_settings.sbt"
-  ECHO       "org.scala-lang.modules.scalajs" %%%%%% "scalajs-dom"                    %% "0.6", >> "_skinny_scalajs_settings.sbt"
-  ECHO       "org.scala-lang.modules.scalajs" %%%%%% "scalajs-jquery"                 %% "0.6", >> "_skinny_scalajs_settings.sbt"
-  ECHO       "org.scala-lang.modules.scalajs" %%%%  "scalajs-jasmine-test-framework" %% "0.5.4" %% "test" >> "_skinny_scalajs_settings.sbt"
-  ECHO     ^), >> "_skinny_scalajs_settings.sbt"
-  ECHO     crossTarget in Compile ^<^<= baseDirectory^(_ / ".." / ".." / "assets" / "js"^) >> "_skinny_scalajs_settings.sbt"
-  ECHO   ^) >> "_skinny_scalajs_settings.sbt"
-  ECHO ^) >> "_skinny_scalajs_settings.sbt"
+  ECHO lazy val scalajs = ^(project in file^("src/main/webapp/WEB-INF/assets"^)^).settings^( > "_skinny_scalajs_settings.sbt"
+  ECHO   name := "application", // JavaScript file name  >> "_skinny_scalajs_settings.sbt"
+  ECHO   scalaVersion := "2.11.5", >> "_skinny_scalajs_settings.sbt"
+  ECHO   unmanagedSourceDirectories in Compile ^<+= baseDirectory^(_ / "scala"^), >> "_skinny_scalajs_settings.sbt"
+  ECHO   libraryDependencies ++= Seq^(                   >> "_skinny_scalajs_settings.sbt"
+  ECHO     "org.scala-js" %%%%%% "scalajs-dom"     %% "0.8.0", >> "_skinny_scalajs_settings.sbt"
+  ECHO     "be.doeraene"  %%%%%% "scalajs-jquery"  %% "0.8.0", >> "_skinny_scalajs_settings.sbt"
+  ECHO     "org.monifu"   %%%%  "minitest"        %% "0.11" %% "test" >> "_skinny_scalajs_settings.sbt"
+  ECHO   ^), >> "_skinny_scalajs_settings.sbt"
+  ECHO   crossTarget in Compile ^<^<= baseDirectory^(_ / ".." / ".." / "assets" / "js"^) >> "_skinny_scalajs_settings.sbt"
+  ECHO ^).enablePlugins^(ScalaJSPlugin^) >> "_skinny_scalajs_settings.sbt"
 )
 sbt "project scalajs" %SUB_COMMAND%
 GOTO script_eof

--- a/yeoman-generator-skinny/app/templates/src/main/webapp/WEB-INF/assets/build.sbt
+++ b/yeoman-generator-skinny/app/templates/src/main/webapp/WEB-INF/assets/build.sbt
@@ -1,4 +1,1 @@
-scalaJSSettings
-
 scalacOptions += s"-P:scalajs:relSourceMap:${dev.base.toURI}/src/main/webapp/WEB-INF/assets/scala/"
-


### PR DESCRIPTION
refs #231
Scala.js 0.6.0 will be out on Feb. 5th.  https://github.com/scala-js/scala-js-website/pull/114
scalajs-dom and scalajs-jquery are re-organized. scalajs-jasmine-test-framework has been removed.

