### PR TITLE
URL field should be optional

### DIFF
--- a/oauth2/src/main/scala/skinny/oauth2/client/google/GoogleUser.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/google/GoogleUser.scala
@@ -9,7 +9,7 @@ case class GoogleUser(
   override val id: String,
   displayName: String,
   name: Name,
-  url: String,
+  url: Option[String],
   image: Option[Image],
   emails: Seq[Email]) extends OAuth2User
 


### PR DESCRIPTION
I was testing the GoogleLoginFeature with a Google user with no URL and I was getting the following error:

```
2015-02-04 03:15:32.628 ERROR   --- [tp1815007640-68] s.oauth2.client.google.GooglePlusAPI$    : Failed to get current Google user information because No usable value for url
Did not find value which can be converted into java.lang.String

org.json4s.package$MappingException: No usable value for url
Did not find value which can be converted into java.lang.String
```

This should fix it.