### PR TITLE
Switch xsbt-scalate-generator to sbt-scalate-precompiler

### DIFF
--- a/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
+++ b/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
@@ -6,9 +6,9 @@ import javax.servlet.http._
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-import skinny.{ DBSettings, DBSettingsInitializer }
+import skinny.DBSettings
 
-class TxPerRequestFilterSpec extends FunSpec with Matchers with MockitoSugar with DBSettings with DBSettingsInitializer {
+class TxPerRequestFilterSpec extends FunSpec with Matchers with MockitoSugar with DBSettings {
 
   val filter = new TxPerRequestFilter {
   }

--- a/orm/src/test/scala/test006/Spec.scala
+++ b/orm/src/test/scala/test006/Spec.scala
@@ -75,20 +75,20 @@ class Spec extends fixture.FunSpec with Matchers
       _afterDeleteBy += 1
     })
 
-    @deprecated("will be removed someday")
+    @deprecated("will be removed someday", "1.3.12")
     override protected def beforeCreate(namedValues: Seq[(SQLSyntax, Any)])(implicit s: DBSession): Unit = {
       _beforeCreateDeprecated += 1
     }
-    @deprecated("will be removed someday")
+    @deprecated("will be removed someday", "1.3.12")
     override protected def afterCreate(namedValues: Seq[(SQLSyntax, Any)], generatedId: Option[Long])(implicit s: DBSession): Unit = {
       _afterCreateDeprecated += 1
     }
 
-    @deprecated("will be removed someday")
+    @deprecated("will be removed someday", "1.3.12")
     override protected def beforeDeleteBy(where: SQLSyntax)(implicit s: DBSession): Unit = {
       _beforeDeleteByDeprecated += 1
     }
-    @deprecated("will be removed someday")
+    @deprecated("will be removed someday", "1.3.12")
     override protected def afterDeleteBy(where: SQLSyntax, deletedCount: Int)(implicit s: DBSession): Int = {
       _afterDeleteByDeprecated += 1
       1

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,6 @@
 import sbt._, Keys._
 import org.scalatra.sbt._, PluginKeys._
-import com.mojolly.scalate.ScalatePlugin._, ScalateKeys._
+import skinny.scalate.ScalatePlugin._, ScalateKeys._
 import scala.language.postfixOps
 
 object SkinnyFrameworkBuild extends Build {
@@ -19,7 +19,7 @@ object SkinnyFrameworkBuild extends Build {
     version := currentVersion,
     resolvers ++= Seq(
       "sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases"
-      //, "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+      //,"sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
     publishTo <<= version { (v: String) => _publishTo(v) },
     publishMavenStyle := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,10 @@
 resolvers += Classpaths.sbtPluginReleases
+
 // TODO: https://github.com/jrudolph/sbt-dependency-graph/issues/67
 //addMavenResolverPlugin
 
-addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")
+addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.7.1.0")
+
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5" excludeAll(
   ExclusionRule(organization = "org.mortbay.jetty"),
   ExclusionRule(organization = "org.eclipse.jetty"),

--- a/travis_after.sh
+++ b/travis_after.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 if [[ "$TEST_TYPE" == "framework" ]]; then
-  sbt coveralls
+  if [[ "$TRAVIS_SCALA_VERSION" == 2.11* ]]; then
+    sbt coveralls
+  fi
 fi
 

--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -1,6 +1,6 @@
 import sbt._, Keys._
 import org.scalatra.sbt._, PluginKeys._
-import com.mojolly.scalate.ScalatePlugin._, ScalateKeys._
+import skinny.scalate.ScalatePlugin._, ScalateKeys._
 import com.earldouglas.xsbtwebplugin.WebPlugin._
 import com.earldouglas.xsbtwebplugin.PluginKeys._
 import org.sbtidea.SbtIdeaPlugin._

--- a/yeoman-generator-skinny/app/templates/project/plugins.sbt
+++ b/yeoman-generator-skinny/app/templates/project/plugins.sbt
@@ -27,8 +27,9 @@ addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.1" excludeAll(
   ExclusionRule(organization = "org.eclipse.jetty"),
   ExclusionRule(organization = "org.apache.tomcat.embed")
 ))
+
 // Scalate template files precompilation
-addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")
+addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.7.1.0")
 
 // --------
 // format Scala source code automatically
@@ -49,4 +50,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 // addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.8")
 
 // visualize this project's dependencies
+// TODO: sbt 0.13.8 support - https://github.com/jrudolph/sbt-dependency-graph/issues/67
 // addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")


### PR DESCRIPTION
Unfortunately, xsbt-scalate-generate is no longer actively maintained. 

Compiling Scalate templates is a very important part of Skinny apps development. So I just decided to fork the project and keep maintaining it. 

This forked project aims to achieve the following benefits.

- Control of release management
- Smooth upgrade corresponded to the lastest Scalate libs
- Reduce the number of dependencies when bootstrapping new Skinny projects

Forked project is already available on sonatype snapshots repository. Please try it out and give us your feedback.

https://github.com/skinny-framework/sbt-scalate-precompiler
