### PR TITLE
Fix env handling.

### DIFF
--- a/framework/src/main/scala/skinny/controller/feature/EnvFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/EnvFeature.scala
@@ -9,11 +9,12 @@ import org.scalatra.ScalatraBase
 trait EnvFeature extends ScalatraBase {
 
   /**
-   * Env string value from "skinny.env" or "org.scalatra.environment".
+   * Env string value from "skinny.env", "org.scalatra.environment" or default value "development".
    *
    * @return env string such as "production"
    */
-  def skinnyEnv: Option[String] = SkinnyEnv.get().orElse(Option(environment))
+  // Skinny is unified lower case. Therefore, convert to lower case.
+  def skinnyEnv: Option[String] = SkinnyEnv.get().orElse(Option(environment.toLowerCase))
 
   /**
    * Predicates current env is "development" or "dev".

--- a/framework/src/main/scala/skinny/controller/feature/EnvFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/EnvFeature.scala
@@ -9,13 +9,14 @@ import org.scalatra.ScalatraBase
 trait EnvFeature extends ScalatraBase {
 
   /**
-   * Env string value from "skinny.env", "org.scalatra.environment" or default value "development".
+   * Env string value from "skinny.env" or "org.scalatra.environment".
    *
    * @return env string such as "production"
    */
-  // Skinny is unified lower case. Therefore, convert to lower case.
-  def skinnyEnv: Option[String] = SkinnyEnv.get().orElse(Option(environment.toLowerCase))
-
+  def skinnyEnv: Option[String] = SkinnyEnv.get().orElse {
+    // convert upper cased "org.scalatra.environment" (e.g. DEVELOPMENT) to skinny's style here
+    Option(environment).map(_.toLowerCase(java.util.Locale.ENGLISH))
+  }
   /**
    * Predicates current env is "development" or "dev".
    *

--- a/framework/src/test/scala/skinny/controller/feature/EnvFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/EnvFeatureSpec.scala
@@ -16,4 +16,10 @@ class EnvFeatureSpec extends FlatSpec with Matchers {
     }
   }
 
+  it should "Scalatra default value should be converted to lower case" in {
+    class Controller extends SkinnyApiController {
+      skinnyEnv should equal(Option("development"))
+    }
+  }
+
 }

--- a/framework/src/test/scala/skinny/controller/feature/EnvFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/EnvFeatureSpec.scala
@@ -16,9 +16,9 @@ class EnvFeatureSpec extends FlatSpec with Matchers {
     }
   }
 
-  it should "Scalatra default value should be converted to lower case" in {
+  it should "convert the default value of Scalatra's environment to lower cased one" in {
     class Controller extends SkinnyApiController {
-      skinnyEnv should equal(Option("development"))
+      skinnyEnv should equal(Some("development"))
     }
   }
 


### PR DESCRIPTION
Scalatra default is upper case. But Skinny is expect lower case.
Therefore add the convert process.