### PR TITLE
Fix memory leak at SkinnyFilterActivation

### DIFF
--- a/framework/src/main/scala/skinny/filter/SkinnyFilterActivation.scala
+++ b/framework/src/main/scala/skinny/filter/SkinnyFilterActivation.scala
@@ -6,7 +6,7 @@ import org.scalatra._
 /**
  * Activates skinny filters.
  */
-trait SkinnyFilterActivation { self: SkinnyControllerBase =>
+trait SkinnyFilterActivation extends SkinnyScalatraBase { self: SkinnyControllerBase =>
 
   sealed trait RenderingRequired
   case object WithRendering extends RenderingRequired
@@ -27,48 +27,55 @@ trait SkinnyFilterActivation { self: SkinnyControllerBase =>
     skinnyErrorFilters.update(WithoutRendering, mergedHandlers)
   }
 
+  // mark as already initialized
+  private[this] var isFiltersTraverseAtSkinnyFilterActivationAlreadyLoaded: Boolean = false
+
+  // combined error filters
+  private[this] lazy val filtersTraverseAtSkinnyFilterActivation: PartialFunction[Throwable, Any] = {
+    case (t: Throwable) =>
+
+      skinnyErrorFilters.get(WithoutRendering).foreach { handlers =>
+        handlers.foreach { handler =>
+          // just apply this filter and return the existing body.
+          try handler.apply(t)
+          catch { case e: Exception => logger.error(s"Failed to apply SkinnyFilter (error: ${e.getMessage})", e) }
+        }
+      }
+
+      var rendered = false
+
+      // rendering body
+      val body: Any = skinnyErrorFilters.get(WithRendering).map { handlers =>
+        handlers.foldLeft(null.asInstanceOf[Any]) {
+          case (body, handler) =>
+            // just apply this filter and return the existing body.
+            if (rendered) {
+              logger.error("This response is marked as rendered because other RenderingFilter already did the stuff.")
+              body
+            } else {
+              rendered = true
+              try handler.apply(t)
+              catch {
+                case e: Exception =>
+                  logger.error(s"Failed to apply SkinnyFilter (error: ${e.getMessage})", e)
+                  body
+              }
+            }
+        }
+      }.getOrElse(null)
+
+      if (rendered) body else throw t
+  }
+
   /**
    * Start applying all the filters
    */
   beforeAction() {
-    // combine error filters
-    val filtersTraverse: PartialFunction[Throwable, Any] = {
-      case (t: Throwable) =>
-
-        skinnyErrorFilters.get(WithoutRendering).foreach { handlers =>
-          handlers.foreach { handler =>
-            // just apply this filter and return the existing body.
-            try handler.apply(t)
-            catch { case e: Exception => logger.error(s"Failed to apply SkinnyFilter (error: ${e.getMessage})", e) }
-          }
-        }
-
-        var rendered = false
-
-        // rendering body
-        val body: Any = skinnyErrorFilters.get(WithRendering).map { handlers =>
-          handlers.foldLeft(null.asInstanceOf[Any]) {
-            case (body, handler) =>
-              // just apply this filter and return the existing body.
-              if (rendered) {
-                logger.error("This response is marked as rendered because other RenderingFilter already did the stuff.")
-                body
-              } else {
-                rendered = true
-                try handler.apply(t)
-                catch {
-                  case e: Exception =>
-                    logger.error(s"Failed to apply SkinnyFilter (error: ${e.getMessage})", e)
-                    body
-                }
-              }
-          }
-        }.getOrElse(null)
-
-        if (rendered) body else throw t
+    if (!isFiltersTraverseAtSkinnyFilterActivationAlreadyLoaded) {
+      // register combined error filters
+      error(filtersTraverseAtSkinnyFilterActivation)
+      isFiltersTraverseAtSkinnyFilterActivationAlreadyLoaded = true
     }
-    // register combined error filters
-    error(filtersTraverse)
   }
 
 }

--- a/framework/src/test/scala/skinny/filter/SkinnyFilterActivationSpec.scala
+++ b/framework/src/test/scala/skinny/filter/SkinnyFilterActivationSpec.scala
@@ -1,0 +1,24 @@
+package skinny.filter
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import skinny.SkinnyApiController
+import skinny.routing.Routes
+
+class SkinnyFilterActivationSpec extends ScalatraFlatSpec with skinny.Logging {
+
+  object Controller extends SkinnyApiController with SkinnyFilterActivation with Routes {
+    override def detectTooManyErrorFilterRegistrationnAsAnErrorAtSkinnyScalatraBase = true
+    def index = "ok"
+    get("/")(index).as('index)
+  }
+  addFilter(Controller, "/*")
+
+  it should "not waste memory" in {
+    (1 to 500).foreach { _ =>
+      get("/") { status should equal(200) }
+    }
+    // if possible leak detected, this status will be 500
+    get("/") { status should equal(200) }
+  }
+
+}


### PR DESCRIPTION
Possible memory leak issue has been found by @rinoguchi. Due to current implementation which calls the following method lots of times, 
https://github.com/scalatra/scalatra/blob/v2.3.1/core/src/main/scala/org/scalatra/ScalatraBase.scala#L333-L335
`errorHandler` in ScalatraBase unnecessarily becomes enlarged.
https://github.com/scalatra/scalatra/blob/v2.3.1/core/src/main/scala/org/scalatra/ScalatraBase.scala#L329-L331

This pull request fixes the issue. Next version including this fix should be out soon.