### PR TITLE
Associations: generalize right/many argument to AssociationsFeature

### DIFF
--- a/orm/src/main/scala/skinny/orm/SkinnyNoIdMapper.scala
+++ b/orm/src/main/scala/skinny/orm/SkinnyNoIdMapper.scala
@@ -19,7 +19,7 @@ trait SkinnyNoIdMapper[Entity]
     with StrongParametersFeature {
 
   override def hasOne[A](
-    right: AssociationsWithIdFeature[_, A],
+    right: AssociationsFeature[A],
     merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
 
     throw new IllegalAssociationException(

--- a/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
@@ -283,14 +283,14 @@ trait AssociationsFeature[Entity]
     defaultOneToManyExtractors.add(extractor)
   }
 
-  def hasMany[M](many: (AssociationsWithIdFeature[_, M], Alias[M]), on: (Alias[Entity], Alias[M]) => SQLSyntax, merge: (Entity, Seq[M]) => Entity): HasManyAssociation[Entity] = {
+  def hasMany[M](many: (AssociationsFeature[M], Alias[M]), on: (Alias[Entity], Alias[M]) => SQLSyntax, merge: (Entity, Seq[M]) => Entity): HasManyAssociation[Entity] = {
     val joinDef = leftJoin(this -> this.defaultAlias, many, on.asInstanceOf[(Alias[_], Alias[_]) => SQLSyntax])
     val extractor = extractOneToMany[M](many._1, many._2, merge)
     val definitions = new mutable.LinkedHashSet().+=(joinDef).++(many._1.defaultJoinDefinitions)
     new HasManyAssociation[Entity](this, definitions, extractor)
   }
 
-  def hasManyThrough[M2](through: AssociationsFeature[_], many: AssociationsWithIdFeature[_, M2], merge: (Entity, Seq[M2]) => Entity): HasManyAssociation[Entity] = {
+  def hasManyThrough[M2](through: AssociationsFeature[_], many: AssociationsFeature[M2], merge: (Entity, Seq[M2]) => Entity): HasManyAssociation[Entity] = {
     val throughFk = toDefaultForeignKeyName[Entity](this)
     val manyFk = toDefaultForeignKeyName[M2](many)
     hasManyThrough(
@@ -301,7 +301,7 @@ trait AssociationsFeature[Entity]
       merge = merge)
   }
 
-  def hasManyThroughWithFk[M2](through: AssociationsFeature[_], many: AssociationsWithIdFeature[_, M2], throughFk: String, manyFk: String, merge: (Entity, Seq[M2]) => Entity): HasManyAssociation[Entity] = {
+  def hasManyThroughWithFk[M2](through: AssociationsFeature[_], many: AssociationsFeature[M2], throughFk: String, manyFk: String, merge: (Entity, Seq[M2]) => Entity): HasManyAssociation[Entity] = {
     hasManyThrough(
       through = through.asInstanceOf[AssociationsFeature[Any]] -> through.defaultAlias.asInstanceOf[Alias[Any]],
       throughOn = (entity, m1: Alias[_]) => sqls.eq(entity.field(primaryKeyFieldName), m1.field(throughFk)),
@@ -313,7 +313,7 @@ trait AssociationsFeature[Entity]
   def hasManyThrough[M1, M2](
     through: (AssociationsFeature[M1], Alias[M1]),
     throughOn: (Alias[Entity], Alias[M1]) => SQLSyntax,
-    many: (AssociationsWithIdFeature[_, M2], Alias[M2]),
+    many: (AssociationsFeature[M2], Alias[M2]),
     on: (Alias[M1], Alias[M2]) => SQLSyntax,
     merge: (Entity, Seq[M2]) => Entity): HasManyAssociation[Entity] = {
 

--- a/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
@@ -185,18 +185,18 @@ trait AssociationsFeature[Entity]
     defaultBelongsToExtractors.add(extractor)
   }
 
-  def belongsTo[A](right: AssociationsWithIdFeature[_, A], merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
+  def belongsTo[A](right: AssociationsFeature[A], merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
     val fk = toDefaultForeignKeyName[A](right)
     belongsToWithJoinCondition[A](right, sqls.eq(this.defaultAlias.field(fk), right.defaultAlias.field(right.primaryKeyFieldName)), merge)
   }
 
-  def belongsToWithJoinCondition[A](right: AssociationsWithIdFeature[_, A], on: SQLSyntax, merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
+  def belongsToWithJoinCondition[A](right: AssociationsFeature[A], on: SQLSyntax, merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
     val joinDef = leftJoinWithDefaults(right, on)
     val extractor = extractBelongsTo[A](right, toDefaultForeignKeyName[A](right), right.defaultAlias, merge)
     new BelongsToAssociation[Entity](this, unshiftJoinDefinition(joinDef, right.defaultJoinDefinitions.filter(_.enabledEvenIfAssociated)), extractor)
   }
 
-  def belongsToWithFk[A](right: AssociationsWithIdFeature[_, A], fk: String, merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
+  def belongsToWithFk[A](right: AssociationsFeature[A], fk: String, merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
     belongsToWithFkAndJoinCondition(right, fk, sqls.eq(this.defaultAlias.field(fk), right.defaultAlias.field(right.primaryKeyFieldName)), merge)
   }
 
@@ -206,7 +206,7 @@ trait AssociationsFeature[Entity]
     new BelongsToAssociation[Entity](this, unshiftJoinDefinition(joinDef, right.defaultJoinDefinitions.filter(_.enabledEvenIfAssociated)), extractor)
   }
 
-  def belongsToWithAlias[A](right: (AssociationsWithIdFeature[_, A], Alias[A]), merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
+  def belongsToWithAlias[A](right: (AssociationsFeature[A], Alias[A]), merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
     val fk = if (right._1.defaultAlias != right._2) {
       val fieldName = right._1.primaryKeyFieldName
       val primaryKeyFieldName = fieldName.head.toString.toUpperCase + fieldName.tail
@@ -217,7 +217,7 @@ trait AssociationsFeature[Entity]
     belongsToWithAliasAndFk(right, fk, merge)
   }
 
-  def belongsToWithAliasAndFk[A](right: (AssociationsWithIdFeature[_, A], Alias[A]), fk: String,
+  def belongsToWithAliasAndFk[A](right: (AssociationsFeature[A], Alias[A]), fk: String,
     merge: (Entity, Option[A]) => Entity): BelongsToAssociation[Entity] = {
     belongsToWithAliasAndFkAndJoinCondition(right, fk, sqls.eq(this.defaultAlias.field(fk), right._2.field(right._1.primaryKeyFieldName)), merge)
   }
@@ -236,15 +236,15 @@ trait AssociationsFeature[Entity]
     defaultHasOneExtractors.add(extractor)
   }
 
-  def hasOne[A](right: AssociationsWithIdFeature[_, A], merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOne[A](right: AssociationsFeature[A], merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithFk[A](right, toDefaultForeignKeyName[Entity](this), merge)
   }
 
-  def hasOneWithJoinCondition[A](right: AssociationsWithIdFeature[_, A], on: SQLSyntax, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOneWithJoinCondition[A](right: AssociationsFeature[A], on: SQLSyntax, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithFkAndJoinCondition(right, toDefaultForeignKeyName[Entity](this), on, merge)
   }
 
-  def hasOneWithFk[A](right: AssociationsWithIdFeature[_, A], fk: String, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOneWithFk[A](right: AssociationsFeature[A], fk: String, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithFkAndJoinCondition(right, fk, sqls.eq(this.defaultAlias.field(this.primaryKeyFieldName), right.defaultAlias.field(fk)), merge)
   }
 
@@ -254,15 +254,15 @@ trait AssociationsFeature[Entity]
     new HasOneAssociation[Entity](this, unshiftJoinDefinition(joinDef, right.defaultJoinDefinitions.filter(_.enabledEvenIfAssociated)), extractor)
   }
 
-  def hasOneWithAlias[A](right: (AssociationsWithIdFeature[_, A], Alias[A]), merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOneWithAlias[A](right: (AssociationsFeature[A], Alias[A]), merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithAliasAndFk(right, toDefaultForeignKeyName[Entity](this), merge)
   }
 
-  def hasOneWithAliasAndJoinCondition[A](right: (AssociationsWithIdFeature[_, A], Alias[A]), on: SQLSyntax, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOneWithAliasAndJoinCondition[A](right: (AssociationsFeature[A], Alias[A]), on: SQLSyntax, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithAliasAndFkAndJoinCondition(right, toDefaultForeignKeyName[Entity](this), on, merge)
   }
 
-  def hasOneWithAliasAndFk[A](right: (AssociationsWithIdFeature[_, A], Alias[A]), fk: String, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
+  def hasOneWithAliasAndFk[A](right: (AssociationsFeature[A], Alias[A]), fk: String, merge: (Entity, Option[A]) => Entity): HasOneAssociation[Entity] = {
     hasOneWithAliasAndFkAndJoinCondition(right, fk, sqls.eq(this.defaultAlias.field(this.primaryKeyFieldName), right._2.field(fk)), merge)
   }
 

--- a/orm/src/test/scala/skinny/orm/feature/AssociationsFeatureSpec.scala
+++ b/orm/src/test/scala/skinny/orm/feature/AssociationsFeatureSpec.scala
@@ -14,6 +14,9 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
   NamedDB('AssociationsFeatureSpec).autoCommit { implicit s =>
     sql"create table company(id bigserial, name varchar(100) not null)".execute.apply()
     sql"create table person(id bigserial, name varchar(100) not null, company_id bigint references company(id))".execute.apply()
+    sql"create table department(id bigserial, name varchar(100) not null, company_id bigint references company(id), primary key (id, company_id))".execute.apply()
+    sql"create table address(id bigserial, address varchar(100) not null, company_id bigint references company(id))".execute.apply()
+    sql"create table company_department(company_id bigint references company(id), department_id bigint references department(id), primary key (company_id, department_id))".execute.apply()
   }
 
   it should "have #defaultIncludesMerge" in {
@@ -23,7 +26,10 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
   }
 
   case class Person(id: Long, name: String, companyId: Option[Long], company: Option[Company] = None)
-  case class Company(id: Long, name: String)
+  case class Company(id: Long, name: String, address: Option[Address] = None, departments: Seq[Department] = Nil)
+  case class Address(id: Long, address: String, companyId: Option[Long])
+  case class Department(id: Long, companyId: Option[Long], name: String, company: Option[Company] = None)
+  case class CompanyDepartment(companyId: Long, departmentId: Long)
 
   object Person extends SkinnyMapper[Person] {
     override def connectionPoolName = 'AssociationsFeatureSpec
@@ -33,7 +39,21 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
   object Company extends SkinnyMapper[Company] {
     override def connectionPoolName = 'AssociationsFeatureSpec
     override def defaultAlias = createAlias("c")
-    override def extract(rs: WrappedResultSet, n: ResultName[Company]) = autoConstruct(rs, n)
+    override def extract(rs: WrappedResultSet, n: ResultName[Company]) = autoConstruct(rs, n, "address", "departments")
+  }
+  object Address extends SkinnyMapper[Address] {
+    override def connectionPoolName = 'AssociationsFeatureSpec
+    override def defaultAlias = createAlias("a")
+    override def extract(rs: WrappedResultSet, n: ResultName[Address]) = autoConstruct(rs, n)
+  }
+  object Department extends SkinnyNoIdMapper[Department] {
+    override def connectionPoolName = 'AssociationsFeatureSpec
+    override def defaultAlias = createAlias("d")
+    override def extract(rs: WrappedResultSet, n: ResultName[Department]) = autoConstruct(rs, n, "company")
+  }
+  object CompanyDepartment extends SkinnyJoinTable[CompanyDepartment] {
+    override def connectionPoolName = 'AssociationsFeatureSpec
+    override def defaultAlias = createAlias("cd")
   }
 
   it should "have #joinWithDefaults" in {
@@ -63,20 +83,56 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
     Person.innerJoin[Company](Company -> Company.defaultAlias, Person -> Person.defaultAlias, (c, p) => sqls"")
   }
 
+  it should "have #hasOne" in {
+    Company.hasOne[Address](Address, (c, a) => c.copy(address = a))
+  }
+
   it should "have #hasOneWithAlias" in {
-    Company.hasOneWithAlias[Person](Person -> Person.defaultAlias, (c, p) => c)
+    Company.hasOneWithAlias[Address](Address -> Address.defaultAlias, (c, a) => c.copy(address = a))
   }
 
   it should "have #hasOneWithAliasAndJoinCondition" in {
-    Person.hasOneWithAliasAndJoinCondition[Company](Company -> Company.defaultAlias, sqls"", (p, c) => p)
+    Company.hasOneWithAliasAndJoinCondition[Address](Address -> Address.defaultAlias, sqls.eq(Company.column.id, Address.column.companyId), (c, a) => c.copy(address = a))
   }
 
   it should "have #hasOneWithAliasAndFk" in {
-    Person.hasOneWithAliasAndFk[Company](Company -> Company.defaultAlias, "id", (p, c) => p)
+    Company.hasOneWithAliasAndFk[Address](Address -> Address.defaultAlias, "company_id", (c, a) => c.copy(address = a))
   }
 
   it should "have #hasOneWithAliasAndFkAndJoinCondition" in {
-    Person.hasOneWithAliasAndFkAndJoinCondition[Company](Company -> Company.defaultAlias, "id", sqls"", (p, c) => p)
+    Company.hasOneWithAliasAndFkAndJoinCondition[Address](Address -> Address.defaultAlias, "company_id", sqls.eq(Company.column.id, Address.column.companyId), (c, a) => c.copy(address = a))
+  }
+
+  it should "have #belongsTo" in {
+    Person.belongsTo[Company](Company, (p, c) => p.copy(company = c))
+  }
+
+  it should "have #belongsToWithAlias" in {
+    Person.belongsToWithAlias[Company](Company -> Company.defaultAlias, (p, c) => p.copy(company = c))
+  }
+
+  it should "have #belongsToWithFk" in {
+    Person.belongsToWithFk[Company](Company, "id", (p, c) => p.copy(company = c))
+  }
+
+  it should "have #belongsToWithAliasAndFk" in {
+    Person.belongsToWithAliasAndFk[Company](Company -> Company.defaultAlias, "id", (p, c) => p.copy(company = c))
+  }
+
+  it should "have #belongsToWithAliasAndFkAndJoinCondition" in {
+    Person.belongsToWithAliasAndFkAndJoinCondition[Company](Company -> Company.defaultAlias, "id", sqls"", (p, c) => p.copy(company = c))
+  }
+
+  it should "have #hasMany" in {
+    Company.hasMany[Department](Department -> Department.defaultAlias, (c, d) => sqls.eq(c.id, d.companyId), (c, d) => c.copy(departments = d))
+  }
+
+  it should "have #hasManyThrough" in {
+    Company.hasManyThrough[Department](CompanyDepartment, Department, (c, d) => c.copy(departments = d))
+  }
+
+  it should "have #hasManyThroughWithFk" in {
+    Company.hasManyThroughWithFk[Department](CompanyDepartment, Department, "company_id", "department_id", (c, d) => c.copy(departments = d))
   }
 
   it should "have #extract" in {


### PR DESCRIPTION
The many argument can be generalized to AssociationsFeature.
This allows these methods to be used, for example, also with NoIdAssociationsFeature objects.