### PR TITLE
Add fork in Test to generated Build.scala

### DIFF
--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -49,12 +49,13 @@ object SkinnyAppBuild extends Build {
       "sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases"
       //,"sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
-    // Faster "./skinny idea" 
+    // Faster "./skinny idea"
     transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
     // the name-hashing algorithm for the incremental compiler.
     incOptions := incOptions.value.withNameHashing(true),
     logBuffered in Test := false,
     javaOptions in Test ++= Seq("-Dskinny.env=test"),
+    fork in Test := true,
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     ideaExcludeFolders := Seq(".idea", ".idea_modules", "db", "target", "task/target", "build", "standalone-build", "node_modules")
   )


### PR DESCRIPTION
Since Java options are passed to the process (the first one would be the Java process that SBT lives in), one needs to fork a new process to run tests in order to read the `-Dskinny.env=test` property.