### PR TITLE
Switch to sbt-servlet-plugin

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,11 +1,12 @@
 import sbt._, Keys._
-import org.scalatra.sbt._, PluginKeys._
 import skinny.scalate.ScalatePlugin._, ScalateKeys._
+import skinny.servlet._, ServletPlugin._, ServletKeys._
+
 import scala.language.postfixOps
 
 object SkinnyFrameworkBuild extends Build {
 
-  lazy val currentVersion = "1.3.19"
+  lazy val currentVersion = "1.4.0-SNAPSHOT"
   lazy val scalatraVersion = "2.3.1"
   lazy val json4SVersion = "3.2.11"
   lazy val scalikeJDBCVersion = "2.2.7"
@@ -36,9 +37,7 @@ object SkinnyFrameworkBuild extends Build {
     incOptions := incOptions.value.withNameHashing(true),
     logBuffered in Test := false,
     javaOptions in Test ++= Seq("-Dskinny.env=test"),
-    // TODO: Test failure in velocity module when enabling CachedResolution
-    // (java.lang.NoSuchMethodError: javax.servlet.ServletContext.getContextPath()Ljava/lang/String;)
-    // updateOptions := updateOptions.value.withCachedResolution(true),
+    updateOptions := updateOptions.value.withCachedResolution(true),
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7", "-encoding", "UTF-8", "-Xlint:-options"),
     javacOptions in doc := Seq("-source", "1.7"),
     pomExtra := _pomExtra
@@ -277,7 +276,7 @@ object SkinnyFrameworkBuild extends Build {
   // example and tests with a real project
   
   lazy val example = Project(id = "example", base = file("example"),
-    settings = baseSettings ++ ScalatraPlugin.scalatraWithJRebel ++ scalateSettings ++ Seq(
+    settings = baseSettings ++ servletSettings ++ scalateSettings ++ Seq(
       name := "skinny-framework-example",
       libraryDependencies ++= Seq(
         "com.h2database"     %  "h2"                 % h2Version,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,32 +1,17 @@
 resolvers += Classpaths.sbtPluginReleases
+resolvers += "sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases"
 
-// TODO: https://github.com/jrudolph/sbt-dependency-graph/issues/67
-//addMavenResolverPlugin
+addMavenResolverPlugin
 
 addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.7.1.0")
-
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5" excludeAll(
-  ExclusionRule(organization = "org.mortbay.jetty"),
-  ExclusionRule(organization = "org.eclipse.jetty"),
-  ExclusionRule(organization = "org.apache.tomcat.embed"),
-  ExclusionRule(organization = "com.earldouglas")
-))
-// TODO: scalatra-sbt 0.3.5 is incompatible with xsbt-web-plugin 1.0.0
-// https://github.com/scalatra/scalatra-sbt/issues/9
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.1" excludeAll(
-  ExclusionRule(organization = "org.mortbay.jetty"),
-  ExclusionRule(organization = "org.eclipse.jetty"),
-  ExclusionRule(organization = "org.apache.tomcat.embed")
-))
-
-addSbtPlugin("com.typesafe.sbt"     % "sbt-scalariform"      % "1.3.0")
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea"             % "1.6.0")
-addSbtPlugin("com.jsuereth"         % "sbt-pgp"              % "1.0.0")
-addSbtPlugin("net.virtual-void"     % "sbt-dependency-graph" % "0.7.5")
-addSbtPlugin("com.timushev.sbt"     % "sbt-updates"          % "0.1.8")
-addSbtPlugin("org.scoverage"        % "sbt-scoverage"        % "1.1.0")
-addSbtPlugin("org.scoverage"        % "sbt-coveralls"        % "1.0.0")
-//addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"         % "0.2.1")
+addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin"      % "1.4.0.RC3")
+addSbtPlugin("com.typesafe.sbt"     % "sbt-scalariform"         % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea"                % "1.6.0")
+addSbtPlugin("com.jsuereth"         % "sbt-pgp"                 % "1.0.0")
+addSbtPlugin("net.virtual-void"     % "sbt-dependency-graph"    % "0.7.5")
+addSbtPlugin("com.timushev.sbt"     % "sbt-updates"             % "0.1.8")
+addSbtPlugin("org.scoverage"        % "sbt-scoverage"           % "1.1.0")
+addSbtPlugin("org.scoverage"        % "sbt-coveralls"           % "1.0.0")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 

--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -1,9 +1,8 @@
 import sbt._, Keys._
-import org.scalatra.sbt._, PluginKeys._
 import skinny.scalate.ScalatePlugin._, ScalateKeys._
-import com.earldouglas.xsbtwebplugin.WebPlugin._
-import com.earldouglas.xsbtwebplugin.PluginKeys._
+import skinny.servlet._, ServletPlugin._, ServletKeys._
 import org.sbtidea.SbtIdeaPlugin._
+
 import scala.language.postfixOps
 
 object SkinnyAppBuild extends Build {
@@ -21,7 +20,7 @@ object SkinnyAppBuild extends Build {
   val theScalaVersion = "2.11.7"
   val jettyVersion = "9.2.11.v20150529"
 
-  lazy val baseSettings = ScalatraPlugin.scalatraWithJRebel ++ Seq(
+  lazy val baseSettings = servletSettings ++ Seq(
     organization := appOrganization,
     name         := appName,
     version      := appVersion,
@@ -53,6 +52,7 @@ object SkinnyAppBuild extends Build {
     transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
     // the name-hashing algorithm for the incremental compiler.
     incOptions := incOptions.value.withNameHashing(true),
+    updateOptions := updateOptions.value.withCachedResolution(true),
     logBuffered in Test := false,
     javaOptions in Test ++= Seq("-Dskinny.env=test"),
     fork in Test := true,

--- a/yeoman-generator-skinny/app/templates/project/plugins.sbt
+++ b/yeoman-generator-skinny/app/templates/project/plugins.sbt
@@ -2,6 +2,7 @@
 // sbt plugins for this Skinny app project
 // --------------------------------------------
 resolvers += Classpaths.sbtPluginReleases
+resolvers += "sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases"
 
 // Internally uses Eclipse Aether to resolve Maven dependencies instead of Apache Ivy
 // https://github.com/sbt/sbt/releases/tag/v0.13.8
@@ -12,21 +13,8 @@ resolvers += Classpaths.sbtPluginReleases
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 // --------
-// Scalatra/Scalate sbt plugin
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5" excludeAll(
-  ExclusionRule(organization = "org.mortbay.jetty"),
-  ExclusionRule(organization = "org.eclipse.jetty"),
-  ExclusionRule(organization = "org.apache.tomcat.embed"),
-  ExclusionRule(organization = "com.earldouglas")
-))
-// scalatra-sbt depends on xsbt-web-plugin
-// TODO: scalatra-sbt 0.3.5 is incompatible with xsbt-web-plugin 1.0.0
-// https://github.com/scalatra/scalatra-sbt/issues/9
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.1" excludeAll(
-  ExclusionRule(organization = "org.mortbay.jetty"),
-  ExclusionRule(organization = "org.eclipse.jetty"),
-  ExclusionRule(organization = "org.apache.tomcat.embed")
-))
+// Servlet app packager/runner plugin
+addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin" % "1.4.0.RC3")
 
 // Scalate template files precompilation
 addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.7.1.0")
@@ -44,7 +32,7 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 // scoverage for test coverage (./skinny test:coverage)
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 // Coveralls integration - http://coveralls.io/
-//addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+//addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 // check the latest version of dependencies
 // addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.8")


### PR DESCRIPTION
xsbt-web-plugin 1.x has some issues for skinny. sbt-servlet-plugin is a fork of xsbt-web-plugin 0.9 and I've renamed most of things.

https://github.com/skinny-framework/sbt-servlet-plugin