### PR TITLE
Remove BeforeAfter, JsonOperations from SkinnyEngineBase

### DIFF
--- a/engine/src/main/scala/skinny/engine/SkinnyEngineBasicFeatures.scala
+++ b/engine/src/main/scala/skinny/engine/SkinnyEngineBasicFeatures.scala
@@ -1,0 +1,14 @@
+package skinny.engine
+
+import skinny.engine.base.BeforeAfterDsl
+import skinny.engine.json.JSONOperations
+
+/**
+ * Built-in features in SkinnyEngineFilter/SkinnyEngineServlet.
+ * These traits should not be mixed in SkinnyEngineBase.
+ */
+trait SkinnyEngineBasicFeatures
+    extends BeforeAfterDsl
+    with JSONOperations { self: SkinnyEngineBase =>
+
+}

--- a/engine/src/main/scala/skinny/engine/SkinnyEngineFilter.scala
+++ b/engine/src/main/scala/skinny/engine/SkinnyEngineFilter.scala
@@ -24,7 +24,10 @@ import scala.util.DynamicVariable
  *
  * @see SkinnyEngineServlet
  */
-trait SkinnyEngineFilter extends Filter with SkinnyEngineBase {
+trait SkinnyEngineFilter
+    extends Filter
+    with SkinnyEngineBase
+    with SkinnyEngineBasicFeatures {
 
   private[this] val _filterChain: DynamicVariable[FilterChain] = new DynamicVariable[FilterChain](null)
 

--- a/engine/src/main/scala/skinny/engine/csrf/CsrfTokenSupport.scala
+++ b/engine/src/main/scala/skinny/engine/csrf/CsrfTokenSupport.scala
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest
 
 import CsrfTokenSupport._
 import skinny.engine.SkinnyEngineBase
+import skinny.engine.base.BeforeAfterDsl
 import skinny.engine.context.SkinnyEngineContext
 
 /**
@@ -21,7 +22,7 @@ import skinny.engine.context.SkinnyEngineContext
  * `handleForgery()` hook is invoked.  Otherwise, a token for the next
  * request is prepared with `prepareCsrfToken`.
  */
-trait CsrfTokenSupport { this: SkinnyEngineBase =>
+trait CsrfTokenSupport { this: SkinnyEngineBase with BeforeAfterDsl =>
 
   before(isForged) { handleForgery() }
   before() { prepareCsrfToken() }

--- a/engine/src/main/scala/skinny/engine/csrf/XsrfTokenSupport.scala
+++ b/engine/src/main/scala/skinny/engine/csrf/XsrfTokenSupport.scala
@@ -1,5 +1,6 @@
 package skinny.engine.csrf
 
+import skinny.engine.base.BeforeAfterDsl
 import skinny.engine.context.SkinnyEngineContext
 import skinny.engine.{ RouteTransformer, SkinnyEngineBase }
 
@@ -13,7 +14,7 @@ object XsrfTokenSupport {
 
 }
 
-trait XsrfTokenSupport { this: SkinnyEngineBase =>
+trait XsrfTokenSupport { this: SkinnyEngineBase with BeforeAfterDsl =>
 
   import XsrfTokenSupport._
 

--- a/engine/src/main/scala/skinny/engine/i18n/I18nSupport.scala
+++ b/engine/src/main/scala/skinny/engine/i18n/I18nSupport.scala
@@ -2,6 +2,7 @@ package skinny.engine.i18n
 
 import java.util.Locale
 
+import skinny.engine.base.BeforeAfterDsl
 import skinny.engine.context.SkinnyEngineContext
 import skinny.engine.{ SkinnyEngineBase, SkinnyEngineException }
 
@@ -15,7 +16,7 @@ object I18nSupport {
 
 }
 
-trait I18nSupport { this: SkinnyEngineBase =>
+trait I18nSupport { this: SkinnyEngineBase with BeforeAfterDsl =>
 
   import I18nSupport._
 

--- a/engine/src/main/scala/skinny/engine/routing/AsyncRoutingDsl.scala
+++ b/engine/src/main/scala/skinny/engine/routing/AsyncRoutingDsl.scala
@@ -6,12 +6,14 @@ import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import skinny.engine.async.AsyncSupported
 import skinny.engine.{ Action, RouteTransformer, SkinnyEngineBase }
 
+import scala.concurrent.{ ExecutionContext, Future }
+
 trait AsyncRoutingDsl extends AsyncSupported { self: SkinnyEngineBase =>
 
   /**
    * Takes a block and converts it to an action that can be run asynchronously.
    */
-  protected def asynchronously(f: => Any): Action
+  protected def asynchronously(f: => Any): Action = () => Future(f)
 
   protected def onAsyncEvent(event: AsyncEvent)(thunk: => Any): Unit = {
     withRequest(event.getSuppliedRequest.asInstanceOf[HttpServletRequest]) {

--- a/engine/src/main/scala/skinny/engine/scalate/ScalateI18nSupport.scala
+++ b/engine/src/main/scala/skinny/engine/scalate/ScalateI18nSupport.scala
@@ -4,10 +4,13 @@ import java.io.PrintWriter
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
 import org.fusesource.scalate.{ Binding, RenderContext }
+import skinny.engine.base.BeforeAfterDsl
 import skinny.engine.context.SkinnyEngineContext
 import skinny.engine.i18n.{ Messages, I18nSupport }
 
-trait ScalateI18nSupport extends ScalateSupport with I18nSupport {
+trait ScalateI18nSupport
+    extends ScalateSupport
+    with I18nSupport { self: BeforeAfterDsl =>
 
   /*
    * Binding done here seems to work all the time. 
@@ -32,4 +35,5 @@ trait ScalateI18nSupport extends ScalateSupport with I18nSupport {
     context.attributes("messages") = messages(ctx)
     context
   }
+
 }

--- a/engine/src/test/scala/org/scalatra/AfterTest.scala
+++ b/engine/src/test/scala/org/scalatra/AfterTest.scala
@@ -1,10 +1,12 @@
 package org.scalatra
 
 import org.scalatra.test.scalatest.ScalatraFunSuite
-import skinny.engine.{ SkinnyEngineServlet, SkinnyEngineBase }
+import skinny.engine.base.BeforeAfterDsl
+import skinny.engine.{ Action, SkinnyEngineServlet, SkinnyEngineBase }
 
 class AfterTestServlet extends SkinnyEngineServlet with AfterTestAppBase
-trait AfterTestAppBase extends SkinnyEngineBase {
+
+trait AfterTestAppBase extends SkinnyEngineBase with BeforeAfterDsl {
 
   after() {
     response.setStatus(204)

--- a/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyControllerBase.scala
@@ -4,7 +4,7 @@ import skinny._
 import skinny.controller.feature._
 import skinny.engine.context.SkinnyEngineContext
 import skinny.engine.json.JSONOperations
-import skinny.engine.{ SkinnyEngineBase, ApiFormats, UrlGeneratorSupport }
+import skinny.engine.{ SkinnyEngineBasicFeatures, SkinnyEngineBase, ApiFormats, UrlGeneratorSupport }
 import skinny.engine.response.ResponseStatus
 import skinny.engine.routing.Route
 import skinny.filter.SkinnyFilterActivation
@@ -23,6 +23,7 @@ import org.json4s.JDecimal
 
 trait SkinnyControllerBase
     extends SkinnyEngineBase
+    with SkinnyEngineBasicFeatures
     with ApiFormats
     with EnvFeature
     with QueryParamsFeature
@@ -36,7 +37,6 @@ trait SkinnyControllerBase
     with BeforeAfterActionFeature
     with LocaleFeature
     with ValidationFeature
-    with JSONOperations
     with TimeLoggingFeature
     with ThreadLocalRequestFeature
     with SnakeCasedParamKeysFeature

--- a/framework/src/main/scala/skinny/controller/feature/BeforeAfterActionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/BeforeAfterActionFeature.scala
@@ -1,13 +1,16 @@
 package skinny.controller.feature
 
 import skinny.engine.SkinnyEngineBase
+import skinny.engine.base.BeforeAfterDsl
 
 /**
  * beforeAction/afterAction support.
  *
  * @see http://guides.rubyonrails.org/action_controller_overview.html
  */
-trait BeforeAfterActionFeature extends SkinnyEngineBase {
+trait BeforeAfterActionFeature
+    extends SkinnyEngineBase
+    with BeforeAfterDsl {
 
   self: RichRouteFeature with ActionDefinitionFeature with RequestScopeFeature =>
 

--- a/framework/src/main/scala/skinny/controller/feature/FlashFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/FlashFeature.scala
@@ -2,12 +2,12 @@ package skinny.controller.feature
 
 import skinny.controller.Flash
 import skinny.engine.SkinnyEngineBase
-import skinny.engine.base.FlashMapSupport
+import skinny.engine.base.{ BeforeAfterDsl, FlashMapSupport }
 
 /**
  * Easy-to-use Flash support.
  */
-trait FlashFeature extends FlashMapSupport {
+trait FlashFeature extends FlashMapSupport with BeforeAfterDsl {
 
   self: SkinnyEngineBase with RequestScopeFeature =>
 

--- a/framework/src/main/scala/skinny/controller/feature/RequestScopeFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/RequestScopeFeature.scala
@@ -3,6 +3,7 @@ package skinny.controller.feature
 import java.lang.reflect.Modifier
 import skinny.controller.{ KeyAndErrorMessages, Params }
 import skinny.engine.SkinnyEngineBase
+import skinny.engine.base.BeforeAfterDsl
 import skinny.engine.context.SkinnyEngineContext
 import skinny.exception.RequestScopeConflictException
 import java.util.Locale
@@ -76,6 +77,7 @@ object RequestScopeFeature extends LoggerProvider {
  */
 trait RequestScopeFeature
     extends SkinnyEngineBase
+    with BeforeAfterDsl
     with SnakeCasedParamKeysFeature
     with LocaleFeature
     with LoggerProvider {


### PR DESCRIPTION
SkinnyEngineBase itself should be slim as much as possible to enable users their own base trait.