### PR TITLE
Add thread id validation to detect illegal dynamic scope access more

### DIFF
--- a/engine/src/main/scala/skinny/engine/scalate/ScalateSupport.scala
+++ b/engine/src/main/scala/skinny/engine/scalate/ScalateSupport.scala
@@ -1,6 +1,7 @@
 package skinny.engine.scalate
 
 import scala.language.reflectiveCalls
+import scala.language.implicitConversions
 
 import java.io.{ PrintWriter, StringWriter }
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
@@ -127,20 +128,9 @@ trait ScalateSupport extends SkinnyEngineBase {
     new SkinnyEngineRenderContext(this, ctx, templateEngine, out, req, resp)
   }
 
-  implicit def skinnyEngineRenderContext: SkinnyEngineRenderContext = {
+  implicit def skinnyEngineRenderContext(implicit ctx: SkinnyEngineContext): SkinnyEngineRenderContext = {
     new SkinnyEngineRenderContext(
-      this, skinnyEngineContext, templateEngine, response.getWriter, request, response)
-  }
-
-  /**
-   * Creates a render context and renders directly to that.  No template
-   * search is performed, and the layout strategy is circumvented.  Clients
-   * are urged to consider layoutTemplate instead.
-   */
-  @deprecated("not idiomatic Scalate; consider layoutTemplate instead", "1.4")
-  def renderTemplate(path: String, attributes: (String, Any)*)(
-    implicit ctx: SkinnyEngineRenderContext) = {
-    createRenderContext(ctx.request, ctx.response, response.writer)(ctx.context).render(path, Map(attributes: _*))
+      this, ctx, templateEngine, response.getWriter, request, response)
   }
 
   /**

--- a/engine/src/test/scala/example/HelloSpec.scala
+++ b/engine/src/test/scala/example/HelloSpec.scala
@@ -38,6 +38,12 @@ object Hello extends WebApp with ScalateSupport {
       responseAsJSON(Map("message" -> s"Hello, ${params.getOrElse("name", "Anonymous")}"))
     }
   }
+
+  get("/dynamic") {
+    Future {
+      request
+    }
+  }
 }
 
 class HelloSpec extends ScalatraFlatSpec {
@@ -86,6 +92,12 @@ class HelloSpec extends ScalatraFlatSpec {
       status should equal(200)
       header("Content-Type") should equal("application/json; charset=utf-8")
       body should equal("""{"message":"Hello, Martin"}""")
+    }
+  }
+
+  it should "detect dynamic value acess when the first access" in {
+    get("/dynamic") {
+      status should equal(500)
     }
   }
 }


### PR DESCRIPTION
This pull request introduces thread id validation to detect `MainThreadLocalEverywhere` access from other threads. 

Previously the dynamic scope issue didn't easily become obvious. With this detection introduced by this PR, it will be easier to detect the issue can happen due to some invalid code than now.