### PR TITLE
Keep supporting Servlet 3.0 for now

### DIFF
--- a/engine/src/main/scala/skinny/engine/request/EncodedInputStream.scala
+++ b/engine/src/main/scala/skinny/engine/request/EncodedInputStream.scala
@@ -1,15 +1,11 @@
 package skinny.engine.request
 
 import java.io.InputStream
-import javax.servlet.{ ReadListener, ServletInputStream }
+import javax.servlet.ServletInputStream
 
 private[skinny] class EncodedInputStream(
     encoded: InputStream,
     raw: ServletInputStream) extends ServletInputStream {
-
-  override def isFinished: Boolean = raw.isFinished
-  override def isReady: Boolean = raw.isReady
-  override def setReadListener(readListener: ReadListener): Unit = raw.setReadListener(readListener)
 
   override def read(): Int = encoded.read()
   override def read(b: Array[Byte]): Int = read(b, 0, b.length)

--- a/engine/src/main/scala/skinny/engine/request/StableHttpServletRequest.scala
+++ b/engine/src/main/scala/skinny/engine/request/StableHttpServletRequest.scala
@@ -132,9 +132,6 @@ class StableHttpServletRequest(
   private[this] val _getContentType = underlying.getContentType
   override def getContentType: String = _getContentType
 
-  private[this] val _getContentLengthLong = underlying.getContentLengthLong
-  override def getContentLengthLong: Long = _getContentLengthLong
-
   private[this] val _getProtocol = underlying.getProtocol
   override def getProtocol: String = _getProtocol
 
@@ -196,10 +193,6 @@ class StableHttpServletRequest(
     underlying.getSession(create)
   }
 
-  override def changeSessionId(): String = {
-    ensureStableAccessStrictly("changeSessionId")
-    underlying.changeSessionId()
-  }
   override def authenticate(response: HttpServletResponse): Boolean = {
     ensureStableAccessStrictly("authenticate")
     underlying.authenticate(response)
@@ -207,10 +200,6 @@ class StableHttpServletRequest(
   override def logout(): Unit = {
     ensureStableAccessStrictly("logout")
     underlying.logout()
-  }
-  override def upgrade[T <: HttpUpgradeHandler](handlerClass: Class[T]): T = {
-    ensureStableAccessStrictly("upgrade")
-    underlying.upgrade(handlerClass)
   }
 
   override def isUserInRole(role: String): Boolean = {

--- a/engine/src/main/scala/skinny/engine/response/EncodedOutputStream.scala
+++ b/engine/src/main/scala/skinny/engine/response/EncodedOutputStream.scala
@@ -1,7 +1,7 @@
 package skinny.engine.response
 
 import java.io.OutputStream
-import javax.servlet.{ ServletOutputStream, WriteListener }
+import javax.servlet.ServletOutputStream
 
 /** Wraps the specified raw and servlet output streams into one servlet output stream. */
 private[skinny] class EncodedOutputStream(
@@ -18,10 +18,5 @@ private[skinny] class EncodedOutputStream(
   // -------------------------------------------------------------------------------------------------------------------
   override def flush(): Unit = out.flush()
   override def close(): Unit = out.close()
-
-  // - ServletOutputStream  --------------------------------------------------------------------------------------------
-  // -------------------------------------------------------------------------------------------------------------------
-  override def setWriteListener(writeListener: WriteListener): Unit = orig.setWriteListener(writeListener)
-  override def isReady: Boolean = orig.isReady
 
 }

--- a/engine/src/main/scala/skinny/engine/response/EncodedServletResponse.scala
+++ b/engine/src/main/scala/skinny/engine/response/EncodedServletResponse.scala
@@ -51,6 +51,5 @@ private[skinny] class EncodedServletResponse(
 
   // Encoded responses do not have a content length.
   override def setContentLength(i: Int) = {}
-  override def setContentLengthLong(len: Long): Unit = {}
 
 }

--- a/framework/src/main/scala/skinny/session/servlet/SkinnyHttpRequestWrapper.scala
+++ b/framework/src/main/scala/skinny/session/servlet/SkinnyHttpRequestWrapper.scala
@@ -73,9 +73,4 @@ case class SkinnyHttpRequestWrapper(request: HttpServletRequest, session: Skinny
   def getAsyncContext = request.getAsyncContext
   def getDispatcherType = request.getDispatcherType
 
-  // Servlet 3.1
-  def changeSessionId(): String = request.changeSessionId()
-  def upgrade[T <: javax.servlet.http.HttpUpgradeHandler](clazz: Class[T]): T = request.upgrade(clazz)
-  def getContentLengthLong: Long = request.getContentLengthLong
-
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -77,7 +77,7 @@ object SkinnyFrameworkBuild extends Build {
         "commons-fileupload" %  "commons-fileupload" % "1.3.1"            % Test,
         "commons-io"         %  "commons-io"         % "2.4"              % Test,
         "commons-httpclient" %  "commons-httpclient" % "3.1"              % Test,
-        "javax.servlet"      %  "javax.servlet-api"  % "3.1.0"            % Test,
+        "javax.servlet"      %  "javax.servlet-api"  % "3.0.1"            % Test,
         "org.eclipse.jetty"  %  "jetty-server"       % jettyVersion       % Test,
         "org.eclipse.jetty"  %  "jetty-servlet"      % jettyVersion       % Test
       ) ++ slf4jApiDependencies
@@ -179,7 +179,7 @@ object SkinnyFrameworkBuild extends Build {
     settings = baseSettings ++ Seq(
       name := "skinny-standalone",
       libraryDependencies ++= Seq(
-        "javax.servlet"     %  "javax.servlet-api" % "3.1.0"       % Compile,
+        "javax.servlet"     %  "javax.servlet-api" % "3.0.1"       % Compile,
         "org.eclipse.jetty" %  "jetty-webapp"      % jettyVersion  % Compile,
         "org.eclipse.jetty" %  "jetty-servlet"     % jettyVersion  % Compile,
         "org.eclipse.jetty" %  "jetty-server"      % jettyVersion  % Compile
@@ -382,7 +382,7 @@ object SkinnyFrameworkBuild extends Build {
         "org.mockito"        %  "mockito-core"       % mockitoVersion            % Test,
         "org.eclipse.jetty"  %  "jetty-webapp"       % jettyVersion              % "container",
         "org.eclipse.jetty"  %  "jetty-plus"         % jettyVersion              % "container",
-        "javax.servlet"      %  "javax.servlet-api"  % "3.1.0"                   % "container;provided;test"
+        "javax.servlet"      %  "javax.servlet-api"  % "3.0.1"                   % "container;provided;test"
       ),
       mainClass := Some("TaskLauncher"),
       // Scalatra tests become slower when multiple controller tests are loaded in the same time
@@ -438,7 +438,7 @@ object SkinnyFrameworkBuild extends Build {
   )
 
   lazy val servletApiDependencies = Seq(
-    "javax.servlet" % "javax.servlet-api" % "3.1.0"  % Provided
+    "javax.servlet" % "javax.servlet-api" % "3.0.1"  % Provided
   )
   lazy val slf4jApiDependencies   = Seq(
     "org.slf4j"     % "slf4j-api"         % slf4jApiVersion % Compile


### PR DESCRIPTION
There is no specific reason for us to drop Servlet 3.0 right now.