### PR TITLE
Bump skinny-micro to 0.9.11

### DIFF
--- a/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
@@ -214,7 +214,7 @@ trait SkinnyApiResourceActions[Id] { self: SkinnyControllerCommonBase =>
       }
       status = 201
       val ext = if (format == Format.HTML) "" else "." + format.name
-      response.setHeader("Location", s"${contextPath}/${normalizedResourcesBasePath}/${model.idToRawValue(id)}${ext}")
+      response(context).setHeader("Location", s"${contextPath}/${normalizedResourcesBasePath}/${model.idToRawValue(id)}${ext}")
     } else {
       status = 400
       renderWithFormat(keyAndErrorMessages)

--- a/framework/src/main/scala/skinny/controller/feature/AngularXSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/AngularXSRFProtectionFeature.scala
@@ -58,7 +58,7 @@ trait AngularXSRFProtectionFeature extends AngularXSRFCookieProviderFeature {
         s"""
         | ------------------------------------------
         |  [Angular XSRF Protection Enabled]
-        |  method      : ${request.getMethod}
+        |  method      : ${request(context).getMethod}
         |  requestPath : ${requestPath(context)}
         |  actionName  : ${currentActionName}
         |  only        : ${forgeryProtectionIncludedActionNames.mkString(", ")}
@@ -88,6 +88,7 @@ trait AngularXSRFProtectionFeature extends AngularXSRFCookieProviderFeature {
   def handleForgeryIfDetected(): Unit = halt(403)
 
   def isForged: Boolean = {
+    implicit val ctx = context
     val unsafeMethod = !request.requestMethod.isSafe
     val headerValue = request.headers.get(xsrfHeaderName)
     val cookieValue = request.cookies.get(xsrfCookieName)

--- a/framework/src/main/scala/skinny/controller/feature/CORSFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/CORSFeature.scala
@@ -11,7 +11,7 @@ import skinny.micro.SkinnyMicroBase
 trait CORSFeature { self: SkinnyMicroBase with BeforeAfterActionFeature =>
 
   beforeAction() {
-    response.setHeader("Access-Control-Allow-Origin", "*")
+    response(context).setHeader("Access-Control-Allow-Origin", "*")
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
@@ -59,7 +59,7 @@ trait CSRFProtectionFeature extends CSRFTokenSupport {
         s"""
         | ------------------------------------------
         |  [CSRF Protection Enabled]
-        |  method      : ${request.getMethod}
+        |  method      : ${request(context).getMethod}
         |  requestPath : ${requestPath(context)}
         |  actionName  : ${currentActionName}
         |  only        : ${forgeryProtectionIncludedActionNames.mkString(", ")}

--- a/framework/src/main/scala/skinny/controller/feature/JSONFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/JSONFeature.scala
@@ -1,7 +1,7 @@
 package skinny.controller.feature
 
 import skinny.micro.SkinnyMicroBase
-import skinny.micro.contrib.JSONSupport
+import skinny.micro.contrib.json4s.JSONSupport
 
 trait JSONFeature extends JSONSupport { self: SkinnyMicroBase =>
 

--- a/framework/src/main/scala/skinny/controller/feature/JSONParamsAutoBinderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/JSONParamsAutoBinderFeature.scala
@@ -1,6 +1,6 @@
 package skinny.controller.feature
 
-import skinny.micro.contrib.JSONParamsAutoBinderSupport
+import skinny.micro.contrib.json4s.JSONParamsAutoBinderSupport
 
 /**
  * Merging JSON request body into Scalatra params.

--- a/framework/src/main/scala/skinny/controller/feature/TemplateEngineFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/TemplateEngineFeature.scala
@@ -2,7 +2,7 @@ package skinny.controller.feature
 
 import skinny.Format
 import skinny.micro.context.SkinnyContext
-import skinny.micro.contrib.JSONSupport
+import skinny.micro.contrib.json4s.JSONSupport
 import skinny.micro.response.ResponseStatus
 import skinny.logging.LoggerProvider
 import skinny.exception.ViewTemplateNotFoundException

--- a/framework/src/main/scala/skinny/controller/feature/ThreadLocalRequestFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/ThreadLocalRequestFeature.scala
@@ -8,7 +8,7 @@ trait ThreadLocalRequestFeature { self: BeforeAfterActionFeature =>
    * Stores request as a thread-local value.
    */
   beforeAction() {
-    ThreadLocalRequest.save(request)
+    ThreadLocalRequest.save(request(context))
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/XContentTypeOptionsNosniffHeaderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/XContentTypeOptionsNosniffHeaderFeature.scala
@@ -15,7 +15,7 @@ trait XContentTypeOptionsNosniffHeaderFeature { self: SkinnyMicroBase with Befor
   // NOTE: To force this header to all responses
   //beforeAction() {
   before() {
-    response.setHeader("X-Content-Type-Options", "nosniff")
+    response(context).setHeader("X-Content-Type-Options", "nosniff")
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/XFrameOptionsHeaderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/XFrameOptionsHeaderFeature.scala
@@ -17,7 +17,7 @@ trait XFrameOptionsHeaderFeature { self: SkinnyMicroBase with BeforeAfterActionF
 
   // NOTE: for all HTML responses defined as Skinny routes
   beforeAction() {
-    response.setHeader("X-Frame-Options", xFrameOptionsPolicy)
+    response(context).setHeader("X-Frame-Options", xFrameOptionsPolicy)
   }
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/XXSSProtectionHeaderFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/XXSSProtectionHeaderFeature.scala
@@ -11,7 +11,7 @@ trait XXSSProtectionHeaderFeature { self: SkinnyMicroBase with BeforeAfterAction
 
   // NOTE: for all HTML responses defined as Skinny routes
   beforeAction() {
-    response.setHeader("X-XSS-Protection", "1; mode=block")
+    response(context).setHeader("X-XSS-Protection", "1; mode=block")
   }
 
 }

--- a/framework/src/test/scala/skinny/controller/feature/BeforeAfterFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/BeforeAfterFeatureSpec.scala
@@ -64,7 +64,9 @@ class BeforeAfterFeatureSpec extends ScalatraFlatSpec {
       body should equal("bar")
     }
     get("/second/y") {
-      body should equal("Y!")
+      // body should equal("Y!")
+      // skinny-micro's filter won't be applied here
+      body should equal("")
     }
   }
 
@@ -74,7 +76,9 @@ class BeforeAfterFeatureSpec extends ScalatraFlatSpec {
       body should equal("")
     }
     get("/third/y") {
-      body should equal("Y!")
+      // body should equal("Y!")
+      // skinny-micro's filter won't be applied here
+      body should equal("")
     }
   }
 }

--- a/framework/src/test/scala/skinny/controller/feature/JSONFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/JSONFeatureSpec.scala
@@ -7,6 +7,7 @@ import skinny.micro.async.AsyncResult
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.language.postfixOps
+import scala.util.Try
 
 // on Scala 2.10.0 ScalaTest #equal matcher with inner case classes works but it fails on higher version
 case class Sample(id: Long, firstName: String)
@@ -44,13 +45,13 @@ class JSONFeatureSpec extends ScalatraFlatSpec {
 
     def toJSONString7 = toJSONString(dennis)
 
-    def fromJSON1: Option[Sample] = fromJSONString[Sample]("""{"id":1,"first_name":"Alice"}""")
-    def fromJSON2: Option[List[Sample]] = fromJSONString[List[Sample]]("""[{"id":1,"first_name":"Alice"},{"id":2,"first_name":"Bob"}]""")
+    def fromJSON1: Try[Sample] = fromJSONString[Sample]("""{"id":1,"first_name":"Alice"}""")
+    def fromJSON2: Try[List[Sample]] = fromJSONString[List[Sample]]("""[{"id":1,"first_name":"Alice"},{"id":2,"first_name":"Bob"}]""")
 
-    def fromJSON3: Option[Sample] = fromJSONString[Sample]("""{"id":1,"firstName":"Alice"}""")
-    def fromJSON4: Option[List[Sample]] = fromJSONString[List[Sample]]("""[{"id":1,"firstName":"Alice"},{"id":2,"firstName":"Bob"}]""")
+    def fromJSON3: Try[Sample] = fromJSONString[Sample]("""{"id":1,"firstName":"Alice"}""")
+    def fromJSON4: Try[List[Sample]] = fromJSONString[List[Sample]]("""[{"id":1,"firstName":"Alice"},{"id":2,"firstName":"Bob"}]""")
 
-    def fromJSON5: Option[Person] = fromJSONString[Person](
+    def fromJSON5: Try[Person] = fromJSONString[Person](
       """{"name":"Dennis","parent":{"name":"Alice","parent":null,"children":[]},"children":[{"name":"Bob","parent":{"name":"Alice","parent":null,"children":[]},"children":[]},{"name":"Chris","parent":{"name":"Alice","parent":null,"children":[]},"children":[{"name":"Bob","parent":{"name":"Alice","parent":null,"children":[]},"children":[]}]}]}""")
   }
 

--- a/json/src/main/scala/skinny/json/package.scala
+++ b/json/src/main/scala/skinny/json/package.scala
@@ -1,0 +1,11 @@
+package skinny
+
+package object json {
+
+  type JSONStringOps = skinny.json4s.JSONStringOps
+  val JSONStringOps = skinny.json4s.JSONStringOps
+
+  type AngularJSONStringOps = skinny.json4s.AngularJSONStringOps
+  val AngularJSONStringOps = skinny.json4s.AngularJSONStringOps
+
+}

--- a/json/src/test/scala/skinny/util/JSONStringOpsSpec.scala
+++ b/json/src/test/scala/skinny/util/JSONStringOpsSpec.scala
@@ -3,6 +3,8 @@ package skinny.util
 import org.scalatest._
 import skinny.json.JSONStringOps
 
+import scala.util.{ Success, Try }
+
 // http://www.playframework.com/documentation/2.2.x/ScalaJson
 case class UserResponse(user: User)
 case class User(name: String, age: Int, email: String, isAlive: Boolean = false, friend: Option[User] = None)
@@ -29,7 +31,7 @@ class JSONStringOpsSpec extends FunSpec with Matchers {
         """.stripMargin
 
       val userResponse = JSONStringOps.fromJSONString[UserResponse](jsonString)
-      userResponse.isDefined should be(true)
+      userResponse.isSuccess should be(true)
 
       val user = userResponse.get.user
       user.age should equal(25)
@@ -61,7 +63,7 @@ class JSONStringOpsSpec extends FunSpec with Matchers {
     it("converts JSON string value to Something object") {
       val source = Something("abC", 123)
       val json = JSONStringOps.toJSONStringAsIs(source)
-      val result: Option[Something] = JSONStringOps.fromJSONString[Something](json, false)
+      val result: Try[Something] = JSONStringOps.fromJSONString[Something](json, false)
       result.get.fooBarBaz should equal(source.fooBarBaz)
       result.get.hogeFooBar should equal(source.hogeFooBar)
     }
@@ -69,7 +71,7 @@ class JSONStringOpsSpec extends FunSpec with Matchers {
     it("converts snake_cased JSON string value to Something object") {
       val source = Something("abC", 123)
       val json = JSONStringOps.toJSONString(source, true)
-      val result: Option[Something] = JSONStringOps.fromJSONString[Something](json, false)
+      val result: Try[Something] = JSONStringOps.fromJSONString[Something](json, false)
       result.get.fooBarBaz should equal(source.fooBarBaz)
       result.get.hogeFooBar should equal(source.hogeFooBar)
     }
@@ -97,10 +99,10 @@ class JSONStringOpsSpec extends FunSpec with Matchers {
         "name" -> "name's length must be less than 32.",
         "something_like_that" -> "")
 
-      val result: Option[Map[String, Any]] = JSONStringOps.fromJSONString[Map[String, String]](
+      val result: Try[Map[String, Any]] = JSONStringOps.fromJSONString[Map[String, String]](
         JSONStringOps.toJSONString(source), true)
 
-      result.get should equal(source)
+      result should equal(Success(source))
     }
 
   }

--- a/oauth2/src/main/scala/skinny/oauth2/client/backlog/BacklogAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/backlog/BacklogAPI.scala
@@ -14,7 +14,7 @@ case class BacklogAPI(spaceID: String) extends LoggerProvider {
         BearerRequest(s"https://${spaceID}.backlogtool.com/api/v2/users/myself").accessToken(token.accessToken)
       }
       logger.debug(s"Backlog authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[BacklogUser](response.body)
+      JSONStringOps.fromJSONString[BacklogUser](response.body).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Backlog user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/backlog/BacklogJPAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/backlog/BacklogJPAPI.scala
@@ -14,7 +14,7 @@ case class BacklogJPAPI(spaceID: String) extends LoggerProvider {
         BearerRequest(s"https://${spaceID}.backlog.jp/api/v2/users/myself").accessToken(token.accessToken)
       }
       logger.debug(s"Backlog authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[BacklogUser](response.body)
+      JSONStringOps.fromJSONString[BacklogUser](response.body).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Backlog user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/dropbox/DropboxAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/dropbox/DropboxAPI.scala
@@ -16,7 +16,7 @@ trait DropboxAPI extends LoggerProvider {
         BearerRequest("https://api.dropbox.com/1/account/info").accessToken(token.accessToken)
       }
       logger.debug(s"Dropbox authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[RawDropboxUser](response.body).map(_.toDropboxUser)
+      JSONStringOps.fromJSONString[RawDropboxUser](response.body).map(_.toDropboxUser).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Dropbox user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/facebook/FacebookGraphAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/facebook/FacebookGraphAPI.scala
@@ -16,7 +16,7 @@ trait FacebookGraphAPI extends LoggerProvider {
         BearerRequest("https://graph.facebook.com/v2.1/me").accessToken(token.accessToken)
       }
       logger.debug(s"Facebook authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[FacebookUser](response.body)
+      JSONStringOps.fromJSONString[FacebookUser](response.body).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Facebook user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/github/GitHubAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/github/GitHubAPI.scala
@@ -16,7 +16,7 @@ trait GitHubAPI extends LoggerProvider {
         BearerRequest("https://api.github.com/user").accessToken(token.accessToken)
       }
       logger.debug(s"GitHub authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[GitHubUser](response.body)
+      JSONStringOps.fromJSONString[GitHubUser](response.body).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current GitHub user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/google/GooglePlusAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/google/GooglePlusAPI.scala
@@ -17,7 +17,7 @@ trait GooglePlusAPI extends LoggerProvider {
         BearerRequest("https://www.googleapis.com/plus/v1/people/me").accessToken(token.accessToken)
       }
       logger.debug(s"Google authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[GoogleUser](response.body)
+      JSONStringOps.fromJSONString[GoogleUser](response.body).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Google user information because ${e.getMessage}", e)

--- a/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkAPI.scala
+++ b/oauth2/src/main/scala/skinny/oauth2/client/typetalk/TypetalkAPI.scala
@@ -14,7 +14,7 @@ trait TypetalkAPI extends LoggerProvider {
         BearerRequest("https://typetalk.in/api/v1/profile").accessToken(token.accessToken)
       }
       logger.debug(s"Typetalk authorized user: ${response.body}")
-      JSONStringOps.fromJSONString[MyProfileResponse](response.body).map(_.account)
+      JSONStringOps.fromJSONString[MyProfileResponse](response.body).map(_.account).toOption
     } catch {
       case NonFatal(e) =>
         logger.error(s"Failed to get current Typetalk user information because ${e.getMessage}", e)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SkinnyFrameworkBuild extends Build {
 
   lazy val currentVersion = "2.0.0-SNAPSHOT"
 
-  lazy val skinnyMicroVersion = "0.9.6"
+  lazy val skinnyMicroVersion = "0.9.11"
   // Scalatra 2.4 will be incompatible with Skinny
   lazy val compatibleScalatraVersion = "2.3.1"
   lazy val scalikeJDBCVersion = "2.2.8"
@@ -19,12 +19,13 @@ object SkinnyFrameworkBuild extends Build {
   lazy val jettyVersion = "9.2.13.v20150730"
   lazy val logbackVersion = "1.1.3"
   lazy val slf4jApiVersion = "1.7.12"
+  lazy val json4SVersion = "3.3.0.RC5"
   lazy val scalaTestVersion = "2.2.5"
 
   lazy val baseSettings = Seq(
     organization := "org.skinny-framework",
     version := currentVersion,
-    dependencyOverrides += "org.slf4j" %  "slf4j-api"  % slf4jApiVersion,
+    dependencyOverrides += "org.slf4j" % "slf4j-api" % slf4jApiVersion,
     resolvers ++= Seq(
       "sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases"
       , "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
@@ -91,7 +92,6 @@ object SkinnyFrameworkBuild extends Build {
       libraryDependencies <++= (scalaVersion) { (sv) =>
         Seq(
           "org.skinny-framework" %% "skinny-micro"         % skinnyMicroVersion        % Compile,
-          "org.skinny-framework" %% "skinny-micro-json"    % skinnyMicroVersion        % Compile,
           "org.skinny-framework" %% "skinny-micro-scalate" % skinnyMicroVersion        % Compile,
           "commons-io"           %  "commons-io"           % "2.4"                     % Compile,
           "org.scalatra"         %% "scalatra-specs2"      % compatibleScalatraVersion % Test,
@@ -101,6 +101,7 @@ object SkinnyFrameworkBuild extends Build {
     )
   ).dependsOn(
     common,
+    json,
     validator,
     orm,
     mailer,
@@ -230,7 +231,7 @@ object SkinnyFrameworkBuild extends Build {
     settings = baseSettings ++ Seq(
       name := "skinny-json",
       libraryDependencies ++= Seq(
-        "org.skinny-framework" %% "skinny-micro-json" % skinnyMicroVersion % Compile
+        "org.skinny-framework" %% "skinny-micro-json4s" % skinnyMicroVersion % Compile
       ) ++ testDependencies
     )
   )
@@ -239,11 +240,10 @@ object SkinnyFrameworkBuild extends Build {
     settings = baseSettings ++ Seq(
       name := "skinny-oauth2",
       libraryDependencies ++= Seq(
-        "org.skinny-framework"   %% "skinny-micro-json"             % skinnyMicroVersion % Compile,
         "org.apache.oltu.oauth2" %  "org.apache.oltu.oauth2.client" % "1.0.0"            % Compile exclude("org.slf4j", "slf4j-api")
       ) ++ servletApiDependencies ++ testDependencies
     )
-  ).dependsOn(common)
+  ).dependsOn(common, json)
 
   lazy val oauth2Controller = Project(id = "oauth2Controller", base = file("oauth2-controller"),
     settings = baseSettings ++ Seq(

--- a/test/src/main/scala/skinny/test/MockControllerBase.scala
+++ b/test/src/main/scala/skinny/test/MockControllerBase.scala
@@ -38,9 +38,9 @@ trait MockControllerBase extends SkinnyControllerBase with JSONParamsAutoBinderF
     new MockHttpServletResponse
   }
 
-  override def request(implicit ctx: SkinnyContext): HttpServletRequest = mockRequest
+  override def request(implicit ctx: SkinnyContext = context): HttpServletRequest = mockRequest
 
-  override def response(implicit ctx: SkinnyContext): HttpServletResponse = mockResponse
+  override def response(implicit ctx: SkinnyContext = context): HttpServletResponse = mockResponse
 
   override implicit def servletContext: ServletContext = mock(classOf[ServletContext])
 
@@ -73,9 +73,9 @@ trait MockControllerBase extends SkinnyControllerBase with JSONParamsAutoBinderF
   }
 
   private[this] val _params = TrieMap[String, Seq[String]]()
-  private def _scalatraParams = new SkinnyMicroParams(_params.toMap)
+
   override def params(implicit ctx: SkinnyContext) = {
-    val mergedParams = (super.params(ctx) ++ _scalatraParams).mapValues(v => Seq(v))
+    val mergedParams = (super.params(ctx) ++ new SkinnyMicroParams(_params.toMap)).mapValues(v => Seq(v))
     new SkinnyMicroParams(if (_parsedBody.isDefined) {
       getMergedMultiParams(mergedParams, parsedBody(ctx).extract[Map[String, String]].mapValues(v => Seq(v)))
     } else {
@@ -92,8 +92,8 @@ trait MockControllerBase extends SkinnyControllerBase with JSONParamsAutoBinderF
     _parsedBody.getOrElse(JNothing)
   }
 
-  def prepareJSONBodyRequest(json: String) = {
-    _parsedBody = JSONStringOps.fromJSONStringToJValue(json)
+  def prepareJSONBodyRequest(json: String): Unit = {
+    _parsedBody = JSONStringOps.fromJSONStringToJValue(json).toOption
   }
 
   // initialize this controller

--- a/yeoman-generator-skinny/app/templates/project/Build.scala
+++ b/yeoman-generator-skinny/app/templates/project/Build.scala
@@ -32,7 +32,7 @@ object SkinnyAppBuild extends Build {
       "org.scala-lang"         %  "scala-library"            % scalaVersion.value,
       "org.scala-lang"         %  "scala-reflect"            % scalaVersion.value,
       "org.scala-lang"         %  "scala-compiler"           % scalaVersion.value,
-      "org.scala-lang.modules" %% "scala-xml"                % "1.0.4",
+      "org.scala-lang.modules" %% "scala-xml"                % "1.0.5",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
       "org.slf4j"              %  "slf4j-api"                % "1.7.12"
     ),


### PR DESCRIPTION
This pull request brings a breaking change to JSONStringOps.

before: `JSONStringOps#fromJSONString[A](String): Option[A]`
after: `JSONStringOps#fromJSONString[A](String): scala.util.Try[A]`

- JSONStringOps#fromJSONString returns Try instead of Option
- SkinnyMicroBase doesn't provide thread-local request/response by default