### PR TITLE
Add skinny routes command to display available routes information

### DIFF
--- a/framework/src/main/scala/skinny/bootstrap/NOOPServletContext.scala
+++ b/framework/src/main/scala/skinny/bootstrap/NOOPServletContext.scala
@@ -1,0 +1,190 @@
+package skinny.bootstrap
+
+import java.io.InputStream
+import java.net.URL
+import java.util.EventListener
+import javax.servlet._
+import javax.servlet.descriptor.JspConfigDescriptor
+
+import scala.collection.JavaConverters._
+
+/**
+  * NOOP ServletContext mainly used for loading routes without a Servlet container.
+  */
+class NOOPServletContext extends ServletContext {
+
+  val dummyServletRegistrationDynamic = new ServletRegistration.Dynamic {
+
+    override def setServletSecurity(constraint: ServletSecurityElement): java.util.Set[String] = Set[String]().asJava
+
+    override def setRunAsRole(roleName: String): Unit = {}
+
+    override def setLoadOnStartup(loadOnStartup: Int): Unit = {}
+
+    override def setMultipartConfig(multipartConfig: MultipartConfigElement): Unit = {}
+
+    override def setAsyncSupported(isAsyncSupported: Boolean): Unit = {}
+
+    override def getMappings: java.util.Collection[String] = Seq[String]().asJava
+
+    override def getRunAsRole: String = null
+
+    override def addMapping(urlPatterns: String*): java.util.Set[String] = Set[String]().asJava
+
+    override def setInitParameters(initParameters: java.util.Map[String, String]): java.util.Set[String] = Set[String]().asJava
+
+    override def getName: String = null
+
+    override def getClassName: String = this.getClass.getCanonicalName
+
+    override def setInitParameter(name: String, value: String): Boolean = true
+
+    override def getInitParameters: java.util.Map[String, String] = Map[String, String]().asJava
+
+    override def getInitParameter(name: String): String = null
+
+  }
+
+  val dummyFilterRegistrationDynamic = new FilterRegistration.Dynamic {
+
+    override def getUrlPatternMappings: java.util.Collection[String] = Seq[String]().asJava
+
+    override def addMappingForServletNames(dispatcherTypes: java.util.EnumSet[DispatcherType], isMatchAfter: Boolean, servletNames: String*): Unit = {}
+
+    override def getServletNameMappings: java.util.Collection[String] = Seq[String]().asJava
+
+    override def addMappingForUrlPatterns(dispatcherTypes: java.util.EnumSet[DispatcherType], isMatchAfter: Boolean, urlPatterns: String*): Unit = {}
+
+    override def setAsyncSupported(isAsyncSupported: Boolean): Unit = {}
+
+    override def setInitParameters(initParameters: java.util.Map[String, String]): java.util.Set[String] = Set[String]().asJava
+
+    override def getName: String = null
+
+    override def getClassName: String = this.getClass.getCanonicalName
+
+    override def setInitParameter(name: String, value: String): Boolean = true
+
+    override def getInitParameters: java.util.Map[String, String] = Map[String, String]().asJava
+
+    override def getInitParameter(name: String): String = null
+
+  }
+
+  override def getRequestDispatcher(path: String): RequestDispatcher = null
+
+  override def getJspConfigDescriptor: JspConfigDescriptor = null
+
+  override def getNamedDispatcher(name: String): RequestDispatcher = null
+
+  override def getRealPath(path: String): String = path
+
+  override def getServletContextName: String = ""
+
+  override def getEffectiveSessionTrackingModes: java.util.Set[SessionTrackingMode] = Set[SessionTrackingMode]().asJava
+
+  override def getFilterRegistrations: java.util.Map[String, _ <: FilterRegistration] = Map[String, FilterRegistration]().asJava
+
+  override def log(msg: String): Unit = {}
+
+  override def log(exception: Exception, msg: String): Unit = {}
+
+  override def log(message: String, throwable: Throwable): Unit = {}
+
+  override def getAttribute(name: String): AnyRef = null
+
+  override def removeAttribute(name: String): Unit = {}
+
+  override def getContextPath: String = ""
+
+  override def getSessionCookieConfig: SessionCookieConfig = null
+
+  override def getEffectiveMinorVersion: Int = 0
+
+  override def getServlets: java.util.Enumeration[Servlet] = Iterator[Servlet]().asJavaEnumeration
+
+  override def setInitParameter(name: String, value: String): Boolean = true
+
+  override def getServletRegistrations: java.util.Map[String, _ <: ServletRegistration] = Map[String, ServletRegistration]().asJava
+
+  override def getDefaultSessionTrackingModes: java.util.Set[SessionTrackingMode] = Set[SessionTrackingMode]().asJava
+
+  override def getResourceAsStream(path: String): InputStream = null
+
+  override def getServletRegistration(servletName: String): ServletRegistration = null
+
+  override def getContext(uripath: String): ServletContext = this
+
+  override def declareRoles(roleNames: String*): Unit = {}
+
+  override def getServletNames: java.util.Enumeration[String] = Iterator[String]().asJavaEnumeration
+
+  override def createListener[T <: EventListener](clazz: Class[T]): T = clazz.newInstance()
+
+  override def getEffectiveMajorVersion: Int = 3
+
+  override def setAttribute(name: String, `object`: scala.Any): Unit = {}
+
+  override def getClassLoader: ClassLoader = getClass.getClassLoader
+
+  override def getAttributeNames: java.util.Enumeration[String] = Iterator[String]().asJavaEnumeration
+
+  override def getResourcePaths(path: String): java.util.Set[String] = Set[String]().asJava
+
+  override def getServlet(name: String): Servlet = null
+
+  override def getServerInfo: String = null
+
+  override def addListener(className: String): Unit = {}
+
+  override def addListener[T <: EventListener](t: T): Unit = {}
+
+  override def addListener(listenerClass: Class[_ <: EventListener]): Unit = {}
+
+  override def addServlet(servletName: String, className: String): ServletRegistration.Dynamic = {
+    dummyServletRegistrationDynamic
+  }
+
+  override def addServlet(servletName: String, servlet: Servlet): ServletRegistration.Dynamic = {
+    dummyServletRegistrationDynamic
+  }
+
+  override def addServlet(servletName: String, servletClass: Class[_ <: Servlet]): ServletRegistration.Dynamic = {
+    dummyServletRegistrationDynamic
+  }
+
+  override def getMinorVersion: Int = 0
+
+  override def getInitParameterNames: java.util.Enumeration[String] = Iterator[String]().asJavaEnumeration
+
+  override def setSessionTrackingModes(sessionTrackingModes: java.util.Set[SessionTrackingMode]): Unit = {}
+
+  override def addFilter(filterName: String, className: String): FilterRegistration.Dynamic = {
+    dummyFilterRegistrationDynamic
+  }
+
+  override def addFilter(filterName: String, filter: Filter): FilterRegistration.Dynamic = {
+    dummyFilterRegistrationDynamic
+  }
+
+  override def addFilter(filterName: String, filterClass: Class[_ <: Filter]): FilterRegistration.Dynamic = {
+    dummyFilterRegistrationDynamic
+  }
+
+  override def getFilterRegistration(filterName: String): FilterRegistration = null
+
+  override def getMimeType(file: String): String = null
+
+  override def getMajorVersion: Int = 3
+
+  override def createServlet[T <: Servlet](clazz: Class[T]): T = clazz.newInstance()
+
+  override def getInitParameter(name: String): String = null
+
+  override def getResource(path: String): URL = new URL(path)
+
+  override def createFilter[T <: Filter](clazz: Class[T]): T = clazz.newInstance()
+
+}
+
+object NOOPServletContext extends NOOPServletContext

--- a/framework/src/main/scala/skinny/bootstrap/SkinnyLifeCycle.scala
+++ b/framework/src/main/scala/skinny/bootstrap/SkinnyLifeCycle.scala
@@ -2,6 +2,7 @@ package skinny.bootstrap
 
 import javax.servlet.ServletContext
 import skinny.micro.LifeCycle
+import skinny.micro.routing.RouteRegistry
 import skinny.worker._
 
 /**
@@ -38,12 +39,14 @@ trait SkinnyLifeCycle extends LifeCycle {
 
   override def init(ctx: ServletContext): Unit = {
     if (dbSettingsEnabled) skinny.DBSettings.initialize()
+    RouteRegistry.init()
     initSkinnyApp(ctx)
   }
 
   override def destroy(context: ServletContext) {
     if (dbSettingsEnabled) skinny.DBSettings.destroy()
     if (workerServiceEnabled) skinnyWorkerService.shutdownNow()
+    RouteRegistry.init()
     super.destroy(context)
   }
 

--- a/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
@@ -19,7 +19,7 @@ trait CSRFProtectionFeature extends CSRFTokenSupport {
   self: SkinnyMicroBase with ActionDefinitionFeature with BeforeAfterActionFeature with RequestScopeFeature with LoggerProvider =>
 
   /**
-   * Overrides Scalatra's default key name.
+   * Overrides Skinny Micro's default key name.
    */
   override def csrfKey: String = CSRFProtectionFeature.DEFAULT_KEY
 

--- a/framework/src/main/scala/skinny/routing/RichRoute.scala
+++ b/framework/src/main/scala/skinny/routing/RichRoute.scala
@@ -1,7 +1,7 @@
 package skinny.routing
 
 import skinny.controller.feature.SkinnyControllerCommonBase
-import skinny.controller.{ ActionDefinition, SkinnyControllerBase }
+import skinny.controller.ActionDefinition
 import skinny.micro.Handler
 import skinny.micro.constant.HttpMethod
 import skinny.micro.routing.Route

--- a/framework/src/test/scala/skinny/bootstrap/NOOPServletContextSpec.scala
+++ b/framework/src/test/scala/skinny/bootstrap/NOOPServletContextSpec.scala
@@ -1,0 +1,46 @@
+package skinny.bootstrap
+
+import javax.servlet.ServletContext
+
+import org.scalatest._
+import skinny.controller.{ SkinnyApiController, SkinnyServlet, SkinnyController }
+import skinny.micro.WebApp
+import skinny.micro.routing.RouteRegistry
+
+class NOOPServletContextSpec extends FunSpec with Matchers {
+  RouteRegistry.init()
+
+  val app1 = new SkinnyController {
+    get("/1/echo") { params.get("name") }
+  }
+  object app2 extends SkinnyServlet {
+    post("/2/echo") { params.get("name") }
+  }
+  // loaded routing DSLs will be displayed
+  val app3 = new WebApp {
+    get("/3/micro") {}
+  }
+  object app4 extends SkinnyApiController {
+    // unloaded object's configuration won't be displayed
+    options("/4/unused") {}
+  }
+
+  class Bootstrap extends SkinnyLifeCycle {
+    override def initSkinnyApp(ctx: ServletContext): Unit = {
+      app1.mount(ctx)
+      app2.mount(ctx)
+    }
+  }
+
+  describe("NOOPServletContext") {
+    it("works") {
+      (new Bootstrap).initSkinnyApp(NOOPServletContext)
+      RouteRegistry.toString() should equal(
+        """GET	/1/echo
+          |POST	/2/echo
+          |GET	/3/micro
+          |""".stripMargin)
+    }
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SkinnyFrameworkBuild extends Build {
 
   lazy val currentVersion = "2.0.4-SNAPSHOT"
 
-  lazy val skinnyMicroVersion = "1.0.0"
+  lazy val skinnyMicroVersion = "1.0.1"
   lazy val scalatraTestVersion = "2.4.0"
   lazy val scalikeJDBCVersion = "2.3.4"
   lazy val h2Version = "1.4.190"

--- a/run_skinny-blank-app_test.sh
+++ b/run_skinny-blank-app_test.sh
@@ -19,6 +19,7 @@ cd release/skinny-blank-app
 ./skinny g reverse-scaffold members2 rev1 members2 member2 && \
 ./skinny g reverse-model members1 rev2.member1 test && \
 ./skinny g reverse-scaffold members2 rev2.members2 member2 && \
+./skinny routes && \
 ./skinny test && \
 ./skinny test:coverage && \
 ./skinny scalajs:package && \

--- a/skinny-blank-app/project/Build.scala
+++ b/skinny-blank-app/project/Build.scala
@@ -15,7 +15,7 @@ object SkinnyAppBuild extends Build {
   val appName = "skinny-blank-app"
   val appVersion = "0.1.0-SNAPSHOT"
 
-  val skinnyVersion = "2.0.3"
+  val skinnyVersion = "2.0.4-SNAPSHOT"
   val theScalaVersion = "2.11.7"
   val jettyVersion = "9.2.14.v20151106"
 
@@ -103,7 +103,8 @@ object SkinnyAppBuild extends Build {
   lazy val task = Project(id = "task", base = file("task"),
     settings = baseSettings ++ Seq(
       mainClass := Some("TaskRunner"),
-      name := appName + "-task"
+      name := appName + "-task",
+      libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0"
     )
   ) dependsOn(dev)
 

--- a/skinny-blank-app/skinny
+++ b/skinny-blank-app/skinny
@@ -170,6 +170,10 @@ elif [ "$command" == "g" -o "$command" == "generate" ]; then
     command="task/run generate:$generator_type $@"
     ${sbt_path} "${command}"
   fi
+elif [ "$command" == "routes" ]; then
+  copy_resources_to_task
+  shift
+  ${sbt_path} "task/run routes $@"
 elif [ "$command" == "db:migrate" ]; then
   copy_resources_to_task
   shift
@@ -229,6 +233,7 @@ else
   echo "  ~compile        : will compile all the classes when changes are detected"
   echo "  db:migrate      : will execute database migration"
   echo "  db:repair       : will recover when previous migration failed"
+  echo "  routes          : will display routes information"
   echo "  test            : will run all the tests"
   echo "  ~test           : will run all the tests when changes are detected"
   echo "  testQuick       : will run only failed tests"

--- a/skinny-blank-app/skinny.bat
+++ b/skinny-blank-app/skinny.bat
@@ -186,6 +186,15 @@ IF "%is_task_run%"=="true" (
   GOTO script_eof
 )
 
+IF "%command%"=="routes" (
+  RMDIR task\src\main\resources /S /q
+  RMDIR task\target /S /q
+  MKDIR task\src\main\resources
+  XCOPY src\main\resources task\src\main\resources /E /D /q
+  sbt "task/run routes"
+  GOTO script_eof
+)
+
 IF "%command%"=="db:migrate" (
   RMDIR task\src\main\resources /S /q
   RMDIR task\target /S /q
@@ -293,6 +302,7 @@ ECHO   compile            : will compile all the classes
 ECHO   ~compile           : will compile all the classes when changes are detected
 ECHO   db:migrate         : will execute database migration
 ECHO   db:repair          : will recover when previous migration failed
+ECHO   routes             : will display routes information"
 ECHO   test               : will run all the tests
 ECHO   ~test              : will run all the tests when changes are detected
 ECHO   testQuick          : will run only failed tests

--- a/skinny-blank-app/task/src/main/scala/TaskRunner.scala
+++ b/skinny-blank-app/task/src/main/scala/TaskRunner.scala
@@ -4,6 +4,11 @@ object TaskRunner extends skinny.task.TaskLauncher {
     val buildDir = params.headOption.getOrElse("build")
     skinny.task.AssetsPrecompileTask.main(Array(buildDir))
   })
+  register("routes", (params) => {
+    import skinny.bootstrap._
+    (new Bootstrap()).initSkinnyApp(NOOPServletContext)
+    println(skinny.micro.routing.RouteRegistry.toString)
+  })
 
   // simple example
   /*


### PR DESCRIPTION
This pull request newly adds `skinny routes` command to call skinny-micro's new RouteRegistry API. https://github.com/skinny-framework/skinny-micro/pull/19

Output example:
https://travis-ci.org/seratch/skinny-framework/jobs/101226394#L4059

```
GET /?
GET /admin/help
GET /admin/sandbox/api
GET /assets/css/*
GET /assets/js/*
GET /help
GET /members
POST  /members
GET /members.:ext
POST  /members.:ext
GET /members/
POST  /members/
DELETE  /members/:id
GET /members/:id
PATCH /members/:id
POST  /members/:id
PUT /members/:id
DELETE  /members/:id.:ext
GET /members/:id.:ext
PATCH /members/:id.:ext
POST  /members/:id.:ext
PUT /members/:id.:ext
GET /members/:id/edit
GET /members/new
```
