### PR TITLE
Remove system properties from i18n messages

### DIFF
--- a/common/src/main/scala/skinny/I18n.scala
+++ b/common/src/main/scala/skinny/I18n.scala
@@ -27,7 +27,7 @@ case class I18n(locale: Locale = null) extends LoggerProvider {
     val ext = ".conf"
     val prefix = "messages"
     val resource = Option(locale).map { l => prefix + "_" + l.toString + ext }.getOrElse(prefix + ext)
-    TypesafeConfigReader.loadAsMap(resource)
+    TypesafeConfigReader.loadAsMapWithoutSystemProperties(resource)
   })
 
   /**

--- a/common/src/main/scala/skinny/util/TypesafeConfigReader.scala
+++ b/common/src/main/scala/skinny/util/TypesafeConfigReader.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.URL
 
 import com.typesafe.config._
+import com.typesafe.config.impl.ConfigImpl
 import scala.collection.JavaConverters._
 import scala.util.Try
 
@@ -26,12 +27,35 @@ object TypesafeConfigReader {
   def load(resource: String): Config = ConfigFactory.load(getClass.getClassLoader, resource)
 
   /**
+   * Loads config values without system properties.
+   *
+   * @param resource file resource
+   * @return config
+   */
+  def loadWithoutSystemProperties(resource: String): Config = {
+    val loader: ClassLoader = getClass.getClassLoader
+    val parseOptions: ConfigParseOptions = ConfigParseOptions.defaults.setClassLoader(loader)
+    val config: Config = ConfigImpl.parseResourcesAnySyntax(resource, parseOptions).toConfig
+    config.resolve(ConfigResolveOptions.defaults)
+  }
+
+  /**
    * Loads a configuration file as Map object.
    *
    * @param resource file resource
    * @return Map object
    */
   def loadAsMap(resource: String): Map[String, String] = fromConfigToMap(load(resource))
+
+  /**
+   * Loads config values without system properties.
+   *
+   * @param resource file resource
+   * @return Map object
+   */
+  def loadAsMapWithoutSystemProperties(resource: String): Map[String, String] = {
+    fromConfigToMap(loadWithoutSystemProperties(resource))
+  }
 
   /**
    * Loads a Map object from Typesafe-config object.

--- a/common/src/test/resources/messages.conf
+++ b/common/src/test/resources/messages.conf
@@ -1,3 +1,4 @@
 name=Name
 foo.name=FooName
 foo.bar.baz=Baz
+user.name=user-name

--- a/common/src/test/scala/skinny/I18nSpec.scala
+++ b/common/src/test/scala/skinny/I18nSpec.scala
@@ -20,4 +20,9 @@ class I18nSpec extends FlatSpec with Matchers {
     i18n.get("foo.bar.baz") should equal(Some("バズ"))
   }
 
+  it should "load user.name correctly" in {
+    val i18n = I18n()
+    i18n.get("user.name") should equal(Some("user-name"))
+  }
+
 }

--- a/validator/src/test/scala/skinny/validator/MessagesSpec.scala
+++ b/validator/src/test/scala/skinny/validator/MessagesSpec.scala
@@ -42,4 +42,9 @@ class MessagesSpec extends FlatSpec with Matchers {
     messages.size should equal(1)
   }
 
+  it should "load user.name correctly" in {
+    val msgs = Messages.loadFromConfig()
+    msgs.get("user.name") should equal(None)
+  }
+
 }


### PR DESCRIPTION
typesafe-config always places priority on system properties when loading config values.
https://github.com/typesafehub/config#standard-behavior

This pull request changes the behavior only for i18n messages.