### PR TITLE
Fixed NullPointerException in MockController with SkinnySessionFilter

### DIFF
--- a/example/src/test/scala/controller/RootControllerSpec.scala
+++ b/example/src/test/scala/controller/RootControllerSpec.scala
@@ -2,8 +2,9 @@ package controller
 
 import org.scalatest._
 import skinny.test.MockController
+import skinny.DBSettings
 
-class RootControllerSpec extends FunSpec with Matchers {
+class RootControllerSpec extends FunSpec with Matchers with DBSettings {
 
   describe("RootController") {
 

--- a/example/src/test/scala/controller/RootControllerSpec.scala
+++ b/example/src/test/scala/controller/RootControllerSpec.scala
@@ -1,0 +1,21 @@
+package controller
+
+import org.scalatest._
+import skinny.test.MockController
+
+class RootControllerSpec extends FunSpec with Matchers {
+
+  describe("RootController") {
+
+    def createMockController = new RootController with MockController
+
+    describe("skinny session filter") {
+      it("works") {
+        val controller = createMockController
+        controller.index
+        controller.status should equal(200)
+      }
+    }
+
+  }
+}

--- a/test/src/main/scala/skinny/test/MockHttpServletRequest.scala
+++ b/test/src/main/scala/skinny/test/MockHttpServletRequest.scala
@@ -39,7 +39,11 @@ class MockHttpServletRequest extends HttpServletRequest {
   override def startAsync(servletRequest: ServletRequest, servletResponse: ServletResponse): AsyncContext = asyncContext
   override def startAsync(): AsyncContext = asyncContext
 
-  var servletContext: ServletContext = mock(classOf[ServletContext])
+  var servletContext: ServletContext = {
+    val ctx = mock(classOf[ServletContext], RETURNS_DEEP_STUBS)
+    when(ctx.getSessionCookieConfig).thenReturn(mock(classOf[SessionCookieConfig]))
+    ctx
+  }
 
   override def getServletContext: ServletContext = servletContext
   override def getRealPath(path: String): String = servletContext.getRealPath(path)

--- a/test/src/main/scala/skinny/test/MockHttpServletRequest.scala
+++ b/test/src/main/scala/skinny/test/MockHttpServletRequest.scala
@@ -40,7 +40,7 @@ class MockHttpServletRequest extends HttpServletRequest {
   override def startAsync(): AsyncContext = asyncContext
 
   var servletContext: ServletContext = {
-    val ctx = mock(classOf[ServletContext], RETURNS_DEEP_STUBS)
+    val ctx = mock(classOf[ServletContext])
     when(ctx.getSessionCookieConfig).thenReturn(mock(classOf[SessionCookieConfig]))
     ctx
   }


### PR DESCRIPTION
```
[info]     java.lang.NullPointerException:
[info]     at skinny.session.SkinnyHttpSession$.getOrCreateJDBCImpl(SkinnyHttpSession.scala:43)
[info]     at skinny.session.SkinnyHttpSession$.getOrCreate(SkinnyHttpSession.scala:35)
[info]     at skinny.filter.SkinnySessionFilterBase$class.initializeSkinnySession(SkinnySessionFilterBase.scala:36)
[info]     at controller.RootController.initializeSkinnySession(RootController.scala:8)
[info]     at skinny.filter.SkinnySessionFilterBase$$anonfun$skinnySession$1.apply(SkinnySessionFilterBase.scala:55)
[info]     at skinny.filter.SkinnySessionFilterBase$$anonfun$skinnySession$1.apply(SkinnySessionFilterBase.scala:55)
[info]     at scala.Option.getOrElse(Option.scala:121)
[info]     at skinny.filter.SkinnySessionFilterBase$class.skinnySession(SkinnySessionFilterBase.scala:54)
[info]     at controller.RootController.skinnySession(RootController.scala:8)
[info]     at skinny.filter.SkinnySessionFilterBase$class.currentLocale(SkinnySessionFilterBase.scala:83)
```

https://travis-ci.org/BlackPrincess/skinny-framework/jobs/122314161#L3207-L3221