### PR TITLE
Bump dependencies

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SkinnyFrameworkBuild extends Build {
 
   lazy val currentVersion = "2.1.0-SNAPSHOT"
 
-  lazy val skinnyMicroVersion = "1.0.4"
+  lazy val skinnyMicroVersion = "1.0.5"
   lazy val scalatraTestVersion = "2.4.0"
   lazy val scalikeJDBCVersion = "2.4.0.RC2"
   lazy val h2Version = "1.4.191"
@@ -16,9 +16,11 @@ object SkinnyFrameworkBuild extends Build {
   lazy val mockitoVersion = "1.10.19"
   // Jetty 9.3 dropped Java 7
   lazy val jettyVersion = "9.2.16.v20160414"
-  lazy val logbackVersion = "1.1.6"
-  lazy val slf4jApiVersion = "1.7.19"
+  lazy val logbackVersion = "1.1.7"
+  lazy val slf4jApiVersion = "1.7.21"
   lazy val scalaTestVersion = "2.2.6"
+  lazy val commonsIoVersion = "2.5"
+  lazy val skinnyLogbackVersion = "1.0.9"
 
   lazy val baseSettings = Seq(
     organization := "org.skinny-framework",
@@ -80,7 +82,7 @@ object SkinnyFrameworkBuild extends Build {
         "org.skinny-framework" %% "skinny-micro-common" % skinnyMicroVersion % Compile,
         "org.specs2"           %% "specs2-core"         % "2.5"              % Test,
         "commons-fileupload"   %  "commons-fileupload"  % "1.3.1"            % Test,
-        "commons-io"           %  "commons-io"          % "2.4"              % Test,
+        "commons-io"           %  "commons-io"          % commonsIoVersion   % Test,
         "commons-httpclient"   %  "commons-httpclient"  % "3.1"              % Test,
         "javax.servlet"        %  "javax.servlet-api"   % "3.0.1"            % Test,
         "org.eclipse.jetty"    %  "jetty-server"        % jettyVersion       % Test,
@@ -96,7 +98,7 @@ object SkinnyFrameworkBuild extends Build {
         Seq(
           "org.skinny-framework" %% "skinny-micro"         % skinnyMicroVersion  % Compile,
           "org.skinny-framework" %% "skinny-micro-scalate" % skinnyMicroVersion  % Compile,
-          "commons-io"           %  "commons-io"           % "2.4"               % Compile,
+          "commons-io"           %  "commons-io"           % commonsIoVersion    % Compile,
           "org.scalatra"         %% "scalatra-specs2"      % scalatraTestVersion % Test,
           "org.scalatra"         %% "scalatra-scalatest"   % scalatraTestVersion % Test
         ) ++ compileScalateDependencies(sv) ++ servletApiDependencies ++ testDependencies
@@ -134,7 +136,7 @@ object SkinnyFrameworkBuild extends Build {
       name := "skinny-assets",
       libraryDependencies ++= Seq(
         "ro.isdc.wro4j" %  "rhino"      % "1.7R5-20130223-1",
-        "commons-io"    %  "commons-io" % "2.4"
+        "commons-io"    %  "commons-io" % commonsIoVersion
       ) ++ servletApiDependencies ++ testDependencies
     )
   ).dependsOn(
@@ -146,7 +148,7 @@ object SkinnyFrameworkBuild extends Build {
     settings = baseSettings ++ Seq(
       name := "skinny-task",
       libraryDependencies ++= Seq(
-        "commons-io"           %  "commons-io"          % "2.4"              % Compile,
+        "commons-io"           %  "commons-io"          % commonsIoVersion   % Compile,
         "org.skinny-framework" %% "skinny-micro-common" % skinnyMicroVersion % Compile
       ) ++ testDependencies
     )
@@ -298,7 +300,7 @@ object SkinnyFrameworkBuild extends Build {
       name := "skinny-framework-example",
       libraryDependencies ++= Seq(
         "com.h2database"       %  "h2"                 % h2Version,
-        "org.skinny-framework" %  "skinny-logback"     % "1.0.9",
+        "org.skinny-framework" %  "skinny-logback"     % skinnyLogbackVersion,
         "org.scalatra"         %% "scalatra-specs2"    % scalatraTestVersion % Test,
         "org.scalatra"         %% "scalatra-scalatest" % scalatraTestVersion % Test,
         "org.mockito"          %  "mockito-core"       % mockitoVersion      % Test,
@@ -354,7 +356,7 @@ object SkinnyFrameworkBuild extends Build {
     "org.slf4j"     % "slf4j-api"         % slf4jApiVersion % Compile
   )
   lazy val jodaDependencies = Seq(
-    "joda-time"     %  "joda-time"        % "2.9.2" % Compile,
+    "joda-time"     %  "joda-time"        % "2.9.3" % Compile,
     "org.joda"      %  "joda-convert"     % "1.8.1" % Compile
   )
   lazy val mailDependencies = slf4jApiDependencies ++ Seq(
@@ -362,13 +364,13 @@ object SkinnyFrameworkBuild extends Build {
     "org.jvnet.mock-javamail" %  "mock-javamail"   % "1.9"            % Provided
   )
   lazy val testDependencies = Seq(
-    "org.scalatest"           %% "scalatest"       % scalaTestVersion % Test,
-    "org.mockito"             %  "mockito-core"    % mockitoVersion   % Test,
-    "ch.qos.logback"          %  "logback-classic" % logbackVersion   % Test,
-    "org.jvnet.mock-javamail" %  "mock-javamail"   % "1.9"            % Test,
-    "com.h2database"          %  "h2"              % h2Version        % Test,
-    "org.skinny-framework"    %  "skinny-logback"  % "1.0.9"          % Test,
-    "com.h2database"          %  "h2"              % h2Version        % Test
+    "org.scalatest"           %% "scalatest"       % scalaTestVersion     % Test,
+    "org.mockito"             %  "mockito-core"    % mockitoVersion       % Test,
+    "ch.qos.logback"          %  "logback-classic" % logbackVersion       % Test,
+    "org.jvnet.mock-javamail" %  "mock-javamail"   % "1.9"                % Test,
+    "com.h2database"          %  "h2"              % h2Version            % Test,
+    "org.skinny-framework"    %  "skinny-logback"  % skinnyLogbackVersion % Test,
+    "com.h2database"          %  "h2"              % h2Version            % Test
   )
 
   def _publishTo(v: String) = {

--- a/skinny-blank-app/skinny
+++ b/skinny-blank-app/skinny
@@ -52,17 +52,17 @@ function setup_scalajs() {
   setting_file="${current_dir}/project/_skinny_scalajs.sbt"
   if [ ! -f "${setting_file}" ]; then
     echo "resolvers += \"scala-js-release\" at \"http://dl.bintray.com/scala-js/scala-js-releases\"
-addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"0.6.7\")" > ${setting_file}
+addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"0.6.9\")" > ${setting_file}
 
 echo "lazy val scalajs = (project in file(\"src/main/webapp/WEB-INF/assets\")).settings(
   name := \"application\", // JavaScript file name
-  scalaVersion := \"2.11.7\",
+  scalaVersion := \"2.11.8\",
   unmanagedSourceDirectories in Compile <+= baseDirectory(_ / \"scala\"),
   fullResolvers ~= { _.filterNot(_.name == \"jcenter\") },
   libraryDependencies ++= Seq(
-    \"org.scala-js\" %%% \"scalajs-dom\"    % \"0.8.2\",
-    \"be.doeraene\"  %%% \"scalajs-jquery\" % \"0.8.1\",
-    \"org.monifu\"   %%  \"minitest\"       % \"0.14\" % \"test\"
+    \"org.scala-js\" %%% \"scalajs-dom\"    % \"0.9.0\",
+    \"be.doeraene\"  %%% \"scalajs-jquery\" % \"0.9.0\",
+    \"io.monix\"     %%  \"minitest\"       % \"0.21\" % \"test\"
   ),
   crossTarget in Compile <<= baseDirectory(_ / \"..\" / \"..\" / \"assets\" / \"js\")
 ).enablePlugins(ScalaJSPlugin)" > ${current_dir}/_skinny_scalajs_settings.sbt

--- a/skinny-blank-app/skinny.bat
+++ b/skinny-blank-app/skinny.bat
@@ -377,17 +377,17 @@ GOTO script_eof
 :scalajs_task
 IF NOT EXIST "project\_skinny_scalajs.sbt" (
   ECHO resolvers += "scala-js-release" at "http://dl.bintray.com/scala-js/scala-js-releases" > "project\_skinny_scalajs.sbt"
-  ECHO addSbtPlugin^("org.scala-js" %% "sbt-scalajs" %% "0.6.7"^) >> "project\_skinny_scalajs.sbt"
+  ECHO addSbtPlugin^("org.scala-js" %% "sbt-scalajs" %% "0.6.9"^) >> "project\_skinny_scalajs.sbt"
 
   ECHO lazy val scalajs = ^(project in file^("src/main/webapp/WEB-INF/assets"^)^).settings^( > "_skinny_scalajs_settings.sbt"
   ECHO   name := "application", // JavaScript file name  >> "_skinny_scalajs_settings.sbt"
-  ECHO   scalaVersion := "2.11.7", >> "_skinny_scalajs_settings.sbt"
+  ECHO   scalaVersion := "2.11.8", >> "_skinny_scalajs_settings.sbt"
   ECHO   unmanagedSourceDirectories in Compile ^<+= baseDirectory^(_ / "scala"^), >> "_skinny_scalajs_settings.sbt"
   ECHO   fullResolvers ~= { _.filterNot^(_.name == "jcenter"^) }, >> "_skinny_scalajs_settings.sbt"
   ECHO   libraryDependencies ++= Seq^(                   >> "_skinny_scalajs_settings.sbt"
-  ECHO     "org.scala-js" %%%%%% "scalajs-dom"     %% "0.8.2", >> "_skinny_scalajs_settings.sbt"
-  ECHO     "be.doeraene"  %%%%%% "scalajs-jquery"  %% "0.8.1", >> "_skinny_scalajs_settings.sbt"
-  ECHO     "org.monifu"   %%%%  "minitest"        %% "0.14" %% "test" >> "_skinny_scalajs_settings.sbt"
+  ECHO     "org.scala-js" %%%%%% "scalajs-dom"     %% "0.9.0", >> "_skinny_scalajs_settings.sbt"
+  ECHO     "be.doeraene"  %%%%%% "scalajs-jquery"  %% "0.9.0", >> "_skinny_scalajs_settings.sbt"
+  ECHO     "io.monix"     %%%%  "minitest"        %% "0.21" %% "test" >> "_skinny_scalajs_settings.sbt"
   ECHO   ^), >> "_skinny_scalajs_settings.sbt"
   ECHO   crossTarget in Compile ^<^<= baseDirectory^(_ / ".." / ".." / "assets" / "js"^) >> "_skinny_scalajs_settings.sbt"
   ECHO ^).enablePlugins^(ScalaJSPlugin^) >> "_skinny_scalajs_settings.sbt"


### PR DESCRIPTION
 - skinny-micro 1.0.5
 - sfl4j-api 1.7.21
 - commons-io 2.5
 - joda-time 2.9.3
 - Scala.js 0.6.9