### PR TITLE
Enable doing `skinny g reverse-scaffold-all` toward existing Rails applications

### DIFF
--- a/common/src/main/scala/skinny/activeimplicits/AllImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/AllImplicits.scala
@@ -8,3 +8,4 @@ object AllImplicits extends AllImplicits
 trait AllImplicits
   extends NumberImplicits
   with StringImplicits
+  with InflectorImplicits

--- a/common/src/main/scala/skinny/activeimplicits/InflectorImplicits.scala
+++ b/common/src/main/scala/skinny/activeimplicits/InflectorImplicits.scala
@@ -1,0 +1,36 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2011 Mojolly Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package skinny.activeimplicits
+
+import scala.language.implicitConversions
+
+import skinny.nlp.Inflector
+
+/**
+ * Based on github.com/backchatio/scala-inflector
+ */
+trait InflectorImplicits {
+
+  implicit def string2InflectorString(word: String) = new Inflector.InflectorString(word)
+
+  implicit def int2InflectorInt(number: Int) = new Inflector.InflectorInt(number)
+
+}
+
+object InflectorImplicits extends InflectorImplicits

--- a/common/src/main/scala/skinny/nlp/Inflector.scala
+++ b/common/src/main/scala/skinny/nlp/Inflector.scala
@@ -1,0 +1,254 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2011 Mojolly Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package skinny.nlp
+
+import java.util.Locale._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.matching.Regex
+
+/**
+ * Based on github.com/backchatio/scala-inflector
+ */
+trait Inflector {
+
+  import Inflector._
+
+  private object Rule {
+    def apply(kv: (String, String)) = new Rule(kv._1, kv._2)
+  }
+
+  private class Rule(pattern: String, replacement: String) {
+
+    private[this] val regex = ("""(?i)%s""" format pattern).r
+
+    def apply(word: String) = {
+      if (regex.findFirstIn(word).isEmpty) {
+        None
+      } else {
+        val m = regex.replaceAllIn(word, replacement)
+        if (m == null || m.trim.isEmpty) None
+        else Some(m)
+      }
+    }
+  }
+
+  private[this] val plurals: ListBuffer[Rule] = new ListBuffer[Rule]()
+  private[this] val singulars: ListBuffer[Rule] = new ListBuffer[Rule]()
+  private[this] val uncountables: ListBuffer[String] = new ListBuffer[String]()
+
+  private[this] lazy val fixedPlurals: Seq[Rule] = plurals.reverse
+  private[this] lazy val fixedSingulars: Seq[Rule] = singulars.reverse
+  private[this] lazy val fixedUncountables: Seq[String] = uncountables.reverse
+
+  def addPlural(pattern: String, replacement: String): Unit = {
+    plurals += Rule(pattern -> replacement)
+  }
+
+  def addSingular(pattern: String, replacement: String): Unit = {
+    singulars += Rule(pattern -> replacement)
+  }
+
+  def addIrregular(singular: String, plural: String): Unit = {
+    plurals += Rule(("(" + singular(0) + ")" + singular.substring(1) + "$") -> ("$1" + plural.substring(1)))
+    singulars += Rule(("(" + plural(0) + ")" + plural.substring(1) + "$") -> ("$1" + singular.substring(1)))
+  }
+
+  def addUncountable(word: String): Unit = {
+    uncountables += word
+  }
+
+  def titleize(word: String): String = {
+    """\b([a-z])""".r.replaceAllIn(
+      humanize(underscore(word)),
+      _.group(0).toUpperCase(ENGLISH)
+    )
+  }
+
+  def humanize(word: String): String = capitalize(word.replace("_", " "))
+
+  def camelize(word: String): String = {
+    val w = pascalize(word)
+    w.substring(0, 1).toLowerCase(ENGLISH) + w.substring(1)
+  }
+
+  def pascalize(word: String): String = {
+    val lst = word.split("_").toList
+    (lst.headOption.map(s ⇒ s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
+      lst.tail.map(s ⇒ s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
+  }
+
+  def underscore(word: String): String = {
+    val replacementPattern = "$1_$2"
+    spacesPattern.replaceAllIn(
+      secondPattern.replaceAllIn(
+        firstPattern.replaceAllIn(
+          word,
+          replacementPattern
+        ),
+        replacementPattern
+      ),
+      "_"
+    ).toLowerCase
+  }
+
+  def capitalize(word: String): String = {
+    word.substring(0, 1).toUpperCase(ENGLISH) + word.substring(1).toLowerCase(ENGLISH)
+  }
+
+  def uncapitalize(word: String): String = {
+    word.substring(0, 1).toLowerCase(ENGLISH) + word.substring(1)
+  }
+
+  def ordinalize(word: String): String = _ordanize(word.toInt, word)
+
+  def ordinalize(number: Int): String = _ordanize(number, number.toString)
+
+  private[this] def _ordanize(number: Int, numberString: String) = {
+    val nMod100 = number % 100
+    if (nMod100 >= 11 && nMod100 <= 13) {
+      numberString + "th"
+    } else {
+      (number % 10) match {
+        case 1 ⇒ numberString + "st"
+        case 2 ⇒ numberString + "nd"
+        case 3 ⇒ numberString + "rd"
+        case _ ⇒ numberString + "th"
+      }
+    }
+  }
+
+  def dasherize(word: String): String = underscore(word).replace('_', '-')
+
+  def pluralize(word: String): String = applyRules(fixedPlurals, word)
+
+  def singularize(word: String): String = applyRules(fixedSingulars, word)
+
+  @tailrec
+  private[this] def applyRules(collection: Seq[Rule], word: String): String = {
+    if (fixedUncountables.contains(word.toLowerCase(ENGLISH))) {
+      word
+    } else {
+      if (collection.isEmpty) {
+        word
+      } else {
+        collection.head(word) match {
+          case Some(m) => m
+          case _ => applyRules(collection.tail, word)
+        }
+      }
+    }
+  }
+
+  def interpolate(text: String, vars: Map[String, String]): String = {
+    """\#\{([^}]+)\}""".r.replaceAllIn(text, (_: Regex.Match) match {
+      case Regex.Groups(v) ⇒ vars.getOrElse(v, "")
+    })
+  }
+
+}
+
+object Inflector extends Inflector {
+
+  private val spacesPattern = "[-\\s]".r
+  private val firstPattern = "([A-Z]+)([A-Z][a-z])".r
+  private val secondPattern = "([a-z\\d])([A-Z])".r
+
+  class InflectorString(word: String) {
+    def titleize = Inflector.titleize(word)
+    def humanize = Inflector.humanize(word)
+    def camelize = Inflector.camelize(word)
+    def pascalize = Inflector.pascalize(word)
+    def underscore = Inflector.underscore(word)
+    def dasherize = Inflector.dasherize(word)
+    def uncapitalize = Inflector.uncapitalize(word)
+    def ordinalize = Inflector.ordinalize(word)
+    def pluralize = Inflector.pluralize(word)
+    def singularize = Inflector.singularize(word)
+    def fill(values: (String, String)*) = Inflector.interpolate(word, Map(values: _*))
+  }
+
+  class InflectorInt(number: Int) {
+    def ordinalize = Inflector.ordinalize(number)
+  }
+
+  addPlural("$", "s")
+  addPlural("s$", "s")
+  addPlural("(ax|test)is$", "$1es")
+  addPlural("(octop|vir|alumn|fung)us$", "$1i")
+  addPlural("(alias|status)$", "$1es")
+  addPlural("(bu)s$", "$1ses")
+  addPlural("(buffal|tomat|volcan)o$", "$1oes")
+  addPlural("([ti])um$", "$1a")
+  addPlural("sis$", "ses")
+  addPlural("(?:([^f])fe|([lr])f)$", "$1$2ves")
+  addPlural("(hive)$", "$1s")
+  addPlural("([^aeiouy]|qu)y$", "$1ies")
+  addPlural("(x|ch|ss|sh)$", "$1es")
+  addPlural("(matr|vert|ind)ix|ex$", "$1ices")
+  addPlural("([m|l])ouse$", "$1ice")
+  addPlural("^(ox)$", "$1en")
+  addPlural("(quiz)$", "$1zes")
+
+  addSingular("s$", "")
+  addSingular("(n)ews$", "$1ews")
+  addSingular("([ti])a$", "$1um")
+  addSingular("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "$1$2sis")
+  addSingular("(^analy)ses$", "$1sis")
+  addSingular("([^f])ves$", "$1fe")
+  addSingular("(hive)s$", "$1")
+  addSingular("(tive)s$", "$1")
+  addSingular("([lr])ves$", "$1f")
+  addSingular("([^aeiouy]|qu)ies$", "$1y")
+  addSingular("(s)eries$", "$1eries")
+  addSingular("(m)ovies$", "$1ovie")
+  addSingular("(x|ch|ss|sh)es$", "$1")
+  addSingular("([m|l])ice$", "$1ouse")
+  addSingular("(bus)es$", "$1")
+  addSingular("(o)es$", "$1")
+  addSingular("(shoe)s$", "$1")
+  addSingular("(cris|ax|test)es$", "$1is")
+  addSingular("(octop|vir|alumn|fung)i$", "$1us")
+  addSingular("(alias|status)es$", "$1")
+  addSingular("^(ox)en", "$1")
+  addSingular("(vert|ind)ices$", "$1ex")
+  addSingular("(matr)ices$", "$1ix")
+  addSingular("(quiz)zes$", "$1")
+
+  addIrregular("person", "people")
+  addIrregular("man", "men")
+  addIrregular("child", "children")
+  addIrregular("sex", "sexes")
+  addIrregular("move", "moves")
+  addIrregular("goose", "geese")
+  addIrregular("alumna", "alumnae")
+
+  addUncountable("equipment")
+  addUncountable("information")
+  addUncountable("rice")
+  addUncountable("money")
+  addUncountable("species")
+  addUncountable("series")
+  addUncountable("fish")
+  addUncountable("sheep")
+  addUncountable("deer")
+  addUncountable("aircraft")
+
+}

--- a/common/src/test/scala/skinny/activeimplicits/AllImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/AllImplicitsSpec.scala
@@ -8,6 +8,7 @@ class AllImplicitsSpec extends FlatSpec with Matchers {
     def duration = 100.seconds
     def weeks = 4.weeks
     def removeFoo(str: String) = str.remove("foo")
+    def pluralize(str: String) = str.pluralize
   }
 
   it should "be available" in {
@@ -15,6 +16,7 @@ class AllImplicitsSpec extends FlatSpec with Matchers {
     Sample.duration should equal(100.seconds)
     Sample.weeks should equal(4.weeks)
     Sample.removeFoo("foo bar") should equal(" bar")
+    Sample.pluralize("company") should equal("companies")
   }
 
 }

--- a/common/src/test/scala/skinny/activeimplicits/InflectorImplicitsSpec.scala
+++ b/common/src/test/scala/skinny/activeimplicits/InflectorImplicitsSpec.scala
@@ -1,0 +1,18 @@
+package skinny.activeimplicits
+
+import org.scalatest._
+
+class InflectorImplicitsSpec extends FlatSpec with Matchers with InflectorImplicits {
+
+  it should "have implicits" in {
+    "company".pluralize should equal("companies")
+    "companies".singularize should equal("company")
+
+    "coin".pluralize should equal("coins")
+    "coins".singularize should equal("coin")
+
+    "person".pluralize should equal("people")
+    "people".singularize should equal("person")
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,9 +6,9 @@ import scala.language.postfixOps
 
 object SkinnyFrameworkBuild extends Build {
 
-  lazy val currentVersion = "2.1.1"
+  lazy val currentVersion = "2.1.2-SNAPSHOT"
 
-  lazy val skinnyMicroVersion = "1.0.5"
+  lazy val skinnyMicroVersion = "1.0.6"
   lazy val scalatraTestVersion = "2.4.1"
   lazy val scalikeJDBCVersion = "2.4.1"
   lazy val h2Version = "1.4.191"

--- a/skinny-blank-app/project/Build.scala
+++ b/skinny-blank-app/project/Build.scala
@@ -15,7 +15,7 @@ object SkinnyAppBuild extends Build {
   val appName = "skinny-blank-app"
   val appVersion = "0.1.0-SNAPSHOT"
 
-  val skinnyVersion = "2.1.1"
+  val skinnyVersion = "2.1.2-SNAPSHOT"
   val theScalaVersion = "2.11.8"
   val jettyVersion = "9.2.17.v20160517"
 

--- a/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/CodeGenerator.scala
@@ -14,6 +14,70 @@ import skinny.util.StringUtil
 
 import scala.io.Source
 
+object CodeGenerator {
+
+  def convertReservedWord(name: String): String = {
+    CodeGenerator.reservedWordConversionRules.find { case (k, _) => k == name } match {
+      case Some((_, newName)) => newName
+      case _ => name
+    }
+  }
+
+  val reservedWordConversionRules = Map(
+    "abstract" -> "theAbstract",
+    "case" -> "theCase",
+    "catch" -> "theCatch",
+    "class" -> "theClass",
+    "def" -> "theDef",
+    "do" -> "theDo",
+    "else" -> "theElse",
+    "extends" -> "theExtends",
+    "false" -> "theFalse",
+    "final" -> "theFinal",
+    "finally" -> "theFinally",
+    "for" -> "theFor",
+    "forSome" -> "theForSome",
+    "if" -> "theIf",
+    "implicit" -> "theImplicit",
+    "import" -> "theImport",
+    "lazy" -> "theLazy",
+    "match" -> "theMatch",
+    "new" -> "theNew",
+    "null" -> "theNull",
+    "object" -> "theObject",
+    "override" -> "theOverride",
+    "package" -> "thePackage",
+    "private" -> "isPrivate",
+    "protected" -> "isProtected",
+    "return" -> "theReturn",
+    "sealed" -> "isSealed",
+    "super" -> "isSuper",
+    "this" -> "theThis",
+    "throw" -> "theThrow",
+    "trait" -> "theTrait",
+    "try" -> "theTry",
+    "true" -> "theTrue",
+    "type" -> "theType",
+    "val" -> "theVal",
+    "var" -> "theVar",
+    "while" -> "theWhile",
+    "with" -> "theWith",
+    "yield" -> "theYield",
+    "clone" -> "theClone",
+    "equals" -> "theEquals",
+    "hashCode" -> "theHashCode",
+    "toString" -> "theToString",
+    "finalize" -> "finalizeRequired",
+    "getClass" -> "theGetClass",
+    "notify" -> "notifyRequired",
+    "notifyAll" -> "notifyAllRequired",
+    "wait" -> "waitRequired",
+    "asInstanceOf" -> "theAsInstanceOf",
+    "isInstanceOf" -> "instanceOf",
+    "synchronized" -> "isSynchronized"
+  )
+}
+
 /**
  * Code generator.
  */

--- a/task/src/main/scala/skinny/task/generator/ReverseGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseGenerator.scala
@@ -1,7 +1,10 @@
 package skinny.task.generator
 
+import java.util.Locale
+
 import scalikejdbc.DB
-import scalikejdbc.metadata.{ Table, ForeignKey }
+import scalikejdbc.metadata.{ ForeignKey, Table }
+import skinny.nlp.Inflector
 
 trait ReverseGenerator extends CodeGenerator {
 
@@ -23,7 +26,8 @@ trait ReverseGenerator extends CodeGenerator {
     val hasManyAssociations: Seq[String] = {
       if (cachedTables.isEmpty) Nil
       else {
-        val expectedFkName = s"${toFirstCharLower(toCamelCase(tableName))}${pkName.map(toFirstCharUpper).getOrElse("Id")}"
+        val singularized = Inflector.singularize(toClassName(tableName))
+        val expectedFkName = s"${toFirstCharLower(singularized)}${pkName.map(toFirstCharUpper).getOrElse("Id")}"
         val hasManyTables: Seq[Table] = cachedTables.filter { table =>
           table.foreignKeys.exists { (fk) =>
             fk.foreignTableName.toLowerCase == tableName.toLowerCase &&
@@ -31,7 +35,7 @@ trait ReverseGenerator extends CodeGenerator {
           }
         }
         hasManyTables.map { table =>
-          val name = toCamelCase(table.name.toLowerCase)
+          val name = toCamelCase(Inflector.singularize(table.name.toLowerCase(Locale.ENGLISH)))
           s"${name}s:Seq[${toClassName(name)}]"
         }
       }

--- a/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelAllGenerator.scala
@@ -3,6 +3,7 @@ package skinny.task.generator
 import skinny.{ DBSettings, SkinnyEnv }
 import scalikejdbc._
 import scalikejdbc.metadata.Table
+import skinny.nlp.Inflector
 
 /**
  * Reverse Model All generator.
@@ -49,7 +50,8 @@ trait ReverseModelAllGenerator extends CodeGenerator {
     }
     tables.map { table =>
       val tableName = table.name.toLowerCase
-      val args: List[String] = Seq(Some(tableName), Some(toCamelCase(tableName)), skinnyEnv).flatten.toList
+      val className = Inflector.singularize(toCamelCase(tableName))
+      val args: List[String] = Seq(Some(tableName), Some(className), skinnyEnv).flatten.toList
       generator.run(args)
     }
   }

--- a/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseModelGenerator.scala
@@ -1,8 +1,10 @@
 package skinny.task.generator
 
 import java.util.Locale
-import skinny.{ DBSettings, SkinnyEnv, ParamType }
-import scalikejdbc.metadata.{ Table, Column }
+
+import skinny.{ DBSettings, ParamType, SkinnyEnv }
+import scalikejdbc.metadata.{ Column, Table }
+import skinny.nlp.Inflector
 
 /**
  * Reverse Model generator.
@@ -110,7 +112,9 @@ trait ReverseModelGenerator extends CodeGenerator with ReverseGenerator {
       override def modelPackageDir = self.modelPackageDir
     }
 
-    val _nameWithPackage = nameWithPackage.getOrElse(toClassName(tableName.toLowerCase))
+    val _nameWithPackage = nameWithPackage.getOrElse(
+      Inflector.singularize(toClassName(tableName.toLowerCase))
+    )
     val namespace = _nameWithPackage.split("\\.").init.mkString(".")
     val name = _nameWithPackage.split("\\.").last
     generator.run(Seq(namespace, name) ++ fields)

--- a/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseScaffoldAllGenerator.scala
@@ -3,6 +3,7 @@ package skinny.task.generator
 import skinny.{ DBSettings, SkinnyEnv }
 import scalikejdbc._
 import scalikejdbc.metadata.Table
+import skinny.nlp.Inflector
 
 /**
  * Reverse Model All generator.
@@ -48,7 +49,8 @@ trait ReverseScaffoldAllGenerator extends CodeGenerator {
     }
     tables.map { table =>
       val tableName = table.name.toLowerCase
-      val args: List[String] = List(tableName, toCamelCase(tableName) + "s", toCamelCase(tableName))
+      val className = Inflector.singularize(toClassName(tableName))
+      val args: List[String] = List(tableName, Inflector.pluralize(className), className)
       generator.run(templateType, args, SkinnyEnv.get())
     }
   }

--- a/task/src/main/scala/skinny/task/generator/ReverseScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ReverseScaffoldGenerator.scala
@@ -77,16 +77,18 @@ trait ReverseScaffoldGenerator extends CodeGenerator with ReverseGenerator {
         }
       } else None
       val fields: List[String] = {
-        val fields = if (hasId) {
-          columns
-            .map(column => toScaffoldFieldDef(column))
-            .filter(param => param != "id:Long" && param != "id:Option[Long]")
-            .filter(param => !param.startsWith(pkName.get + ":"))
-            .map(param => toCamelCase(param))
-        } else {
-          columns
-            .map(column => toScaffoldFieldDef(column))
-            .map(param => toCamelCase(param))
+        val fields: List[String] = {
+          if (hasId) {
+            columns
+              .map(column => toScaffoldFieldDef(column))
+              .filter(param => param != "id:Long" && param != "id:Option[Long]")
+              .filter(param => !param.startsWith(pkName.get + ":"))
+              .map(param => toCamelCase(param))
+          } else {
+            columns
+              .map(column => toScaffoldFieldDef(column))
+              .map(param => toCamelCase(param))
+          }
         }
         if (createAssociationsForForeignKeys) {
           fields ++ extractAssociationParams(tableName, pkName, cachedTables)

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -1,6 +1,8 @@
 package skinny.task.generator
 
 import java.io.File
+import java.nio.charset.Charset
+
 import org.joda.time._
 import org.apache.commons.io.FileUtils
 import skinny.ParamType
@@ -110,17 +112,19 @@ trait ScaffoldGenerator extends CodeGenerator {
           val nameAndTypeNamePairsForModel = generatorArgs.map(a => (a.name, a.typeName))
           modelGenerator.generate(namespaces, resource, tableName.orElse(Some(toSnakeCase(resources))), nameAndTypeNamePairsForModel)
           modelGenerator.generateSpec(namespaces, resource, nameAndTypeNamePairsForModel)
+          val convertedNameAndTypeNamePairs = nameAndTypeNamePairs
+            .map { case (name, typeName) => CodeGenerator.convertReservedWord(name) -> typeName }
 
           if (withId) {
             // Views
-            generateFormView(namespaces, resources, resource, nameAndTypeNamePairs)
-            generateNewView(namespaces, resources, resource, nameAndTypeNamePairs)
-            generateEditView(namespaces, resources, resource, nameAndTypeNamePairs)
-            generateIndexView(namespaces, resources, resource, nameAndTypeNamePairs)
-            generateShowView(namespaces, resources, resource, nameAndTypeNamePairs)
+            generateFormView(namespaces, resources, resource, convertedNameAndTypeNamePairs)
+            generateNewView(namespaces, resources, resource, convertedNameAndTypeNamePairs)
+            generateEditView(namespaces, resources, resource, convertedNameAndTypeNamePairs)
+            generateIndexView(namespaces, resources, resource, convertedNameAndTypeNamePairs)
+            generateShowView(namespaces, resources, resource, convertedNameAndTypeNamePairs)
 
             // messages.conf
-            generateMessages(resources, resource, nameAndTypeNamePairs)
+            generateMessages(resources, resource, convertedNameAndTypeNamePairs)
           }
 
           // migration SQL
@@ -660,7 +664,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, formHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs))
+      FileUtils.write(file, formHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs), Charset.defaultCharset())
       println("  \"" + file.getPath + "\" created.")
     }
   }
@@ -673,7 +677,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, newHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs))
+      FileUtils.write(file, newHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs), Charset.defaultCharset())
       println("  \"" + file.getPath + "\" created.")
     }
   }
@@ -686,7 +690,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, editHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs))
+      FileUtils.write(file, editHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs), Charset.defaultCharset())
       println("  \"" + file.getPath + "\" created.")
     }
   }
@@ -699,7 +703,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, indexHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs))
+      FileUtils.write(file, indexHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs), Charset.defaultCharset())
       println("  \"" + file.getPath + "\" created.")
     }
   }
@@ -712,7 +716,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     if (file.exists()) {
       println("  \"" + file.getPath + "\" skipped.")
     } else {
-      FileUtils.write(file, showHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs))
+      FileUtils.write(file, showHtmlCode(namespaces, resources, resource, nameAndTypeNamePairs), Charset.defaultCharset())
       println("  \"" + file.getPath + "\" created.")
     }
   }

--- a/task/src/test/scala/skinny/task/generator/ReverseModelAllGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ReverseModelAllGeneratorSpec.scala
@@ -1,11 +1,12 @@
 package skinny.task.generator
 
 import java.io.File
+import java.nio.charset.Charset
 
 import org.apache.commons.io.FileUtils
 import org.scalatest._
 import scalikejdbc._
-import skinny.{ SkinnyEnv, DBSettings }
+import skinny.{ DBSettings, SkinnyEnv }
 
 class ReverseModelAllGeneratorSpec extends FunSpec with Matchers {
 
@@ -43,7 +44,10 @@ create table member (
       FileUtils.deleteDirectory(new File("tmp/ReverseModelAllGeneratorSpec"))
       generator.run(List(SkinnyEnv.getOrDevelopment()))
 
-      val company = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Company.scala"))
+      val company = FileUtils.readFileToString(
+        new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Company.scala"),
+        Charset.defaultCharset()
+      )
       company should equal(
         s"""package model
 
@@ -76,7 +80,10 @@ object Company extends SkinnyCRUDMapper[Company] {
 """.stripMargin
       )
 
-      val member = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Member.scala"))
+      val member = FileUtils.readFileToString(
+        new File("tmp/ReverseModelAllGeneratorSpec/src/main/scala/model/Member.scala"),
+        Charset.defaultCharset()
+      )
       member should equal(
         s"""package model
 
@@ -107,7 +114,10 @@ object Member extends SkinnyCRUDMapper[Member] {
 """.stripMargin
       )
 
-      val companySpec = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/CompanySpec.scala"))
+      val companySpec = FileUtils.readFileToString(
+        new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/CompanySpec.scala"),
+        Charset.defaultCharset()
+      )
       companySpec should equal(
         s"""package model
 
@@ -124,7 +134,10 @@ class CompanySpec extends FlatSpec with Matchers with DBSettings with AutoRollba
 """
       )
 
-      val memberSpec = FileUtils.readFileToString(new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/MemberSpec.scala"))
+      val memberSpec = FileUtils.readFileToString(
+        new File("tmp/ReverseModelAllGeneratorSpec/src/test/scala/model/MemberSpec.scala"),
+        Charset.defaultCharset()
+      )
       memberSpec should equal(
         s"""package model
 

--- a/task/src/test/scala/skinny/task/generator/ReverseScaffoldAllGenerator_InflectorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ReverseScaffoldAllGenerator_InflectorSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import scalikejdbc._
 import skinny.{ DBSettings, SkinnyEnv }
 
-class ReverseScaffoldAllGeneratorSpec extends FunSpec with Matchers {
+class ReverseScaffoldAllGenerator_InflectorSpec extends FunSpec with Matchers {
 
   val generator = new ReverseScaffoldAllGenerator {
     override def sourceDir = "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala"
@@ -24,25 +24,36 @@ class ReverseScaffoldAllGeneratorSpec extends FunSpec with Matchers {
       DBSettings.initialize()
       DB.localTx { implicit s =>
         sql"""
-create table user_group (
+drop table user_group if exists;
+drop table user_groups if exists;
+create table user_groups (
   id bigserial not null primary key,
   name varchar(100) not null,
   url varchar(512)
 );
-create table organization (
+
+drop table organization if exists;
+drop table organizations if exists;
+create table organizations (
   id bigserial not null primary key,
   name varchar(100) not null,
   url varchar(512) not null
 );
-create table developer (
+
+drop table developer if exists;
+drop table developers if exists;
+create table developers (
   id bigserial not null primary key,
   name varchar(512) not null,
   nickname varchar(32),
-  user_group_id bigint references user_group(id)
+  user_group_id bigint references user_groups(id)
 );
-create table organization_developer (
-  organization_id bigint not null references organization(id),
-  developer_id bigint not null references developer(id)
+
+drop table organization_developer if exists;
+drop table organization_developers if exists;
+create table organization_developers (
+  organization_id bigint not null references organizations(id),
+  developer_id bigint not null references developers(id)
 );
 """.execute.apply()
       }
@@ -71,7 +82,7 @@ case class Developer(
 )
 
 object Developer extends SkinnyCRUDMapper[Developer] {
-  override lazy val tableName = "developer"
+  override lazy val tableName = "developers"
   override lazy val defaultAlias = createAlias("d")
 
   lazy val userGroupRef = belongsTo[UserGroup](UserGroup, (d, ug) => d.copy(userGroup = ug))
@@ -107,7 +118,7 @@ case class Organization(
 )
 
 object Organization extends SkinnyCRUDMapper[Organization] {
-  override lazy val tableName = "organization"
+  override lazy val tableName = "organizations"
   override lazy val defaultAlias = createAlias("o")
 
   lazy val developersRef = hasManyThrough[Developer](
@@ -141,7 +152,7 @@ case class OrganizationDeveloper(
 )
 
 object OrganizationDeveloper extends SkinnyNoIdCRUDMapper[OrganizationDeveloper] {
-  override lazy val tableName = "organization_developer"
+  override lazy val tableName = "organization_developers"
   override lazy val defaultAlias = createAlias("od")
 
   lazy val developerRef = belongsTo[Developer](Developer, (od, d) => od.copy(developer = d))

--- a/task/src/test/scala/skinny/task/generator/ReverseScaffoldAllGenerator_reservedWordsSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ReverseScaffoldAllGenerator_reservedWordsSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import scalikejdbc._
 import skinny.{ DBSettings, SkinnyEnv }
 
-class ReverseScaffoldAllGeneratorSpec extends FunSpec with Matchers {
+class ReverseScaffoldAllGenerator_reservedWordsSpec extends FunSpec with Matchers {
 
   val generator = new ReverseScaffoldAllGenerator {
     override def sourceDir = "tmp/ReverseScaffoldAllGeneratorSpec/src/main/scala"
@@ -24,25 +24,36 @@ class ReverseScaffoldAllGeneratorSpec extends FunSpec with Matchers {
       DBSettings.initialize()
       DB.localTx { implicit s =>
         sql"""
-create table user_group (
+drop table user_group if exists;
+drop table user_groups if exists;
+create table user_groups (
   id bigserial not null primary key,
   name varchar(100) not null,
-  url varchar(512)
+  type varchar(512)
 );
-create table organization (
+
+drop table organization if exists;
+drop table organizations if exists;
+create table organizations (
   id bigserial not null primary key,
   name varchar(100) not null,
-  url varchar(512) not null
+  type varchar(512) not null
 );
-create table developer (
+
+drop table developer if exists;
+drop table developers if exists;
+create table developers (
   id bigserial not null primary key,
   name varchar(512) not null,
   nickname varchar(32),
-  user_group_id bigint references user_group(id)
+  user_group_id bigint references user_groups(id)
 );
-create table organization_developer (
-  organization_id bigint not null references organization(id),
-  developer_id bigint not null references developer(id)
+
+drop table organization_developer if exists;
+drop table organization_developers if exists;
+create table organization_developers (
+  organization_id bigint not null references organizations(id),
+  developer_id bigint not null references developers(id)
 );
 """.execute.apply()
       }
@@ -71,7 +82,7 @@ case class Developer(
 )
 
 object Developer extends SkinnyCRUDMapper[Developer] {
-  override lazy val tableName = "developer"
+  override lazy val tableName = "developers"
   override lazy val defaultAlias = createAlias("d")
 
   lazy val userGroupRef = belongsTo[UserGroup](UserGroup, (d, ug) => d.copy(userGroup = ug))
@@ -102,13 +113,14 @@ import org.joda.time._
 case class Organization(
   id: Long,
   name: String,
-  url: String,
+  theType: String,
   developers: Seq[Developer] = Nil
 )
 
 object Organization extends SkinnyCRUDMapper[Organization] {
-  override lazy val tableName = "organization"
+  override lazy val tableName = "organizations"
   override lazy val defaultAlias = createAlias("o")
+  override lazy val nameConverters = Map("^theType$$" -> "type")
 
   lazy val developersRef = hasManyThrough[Developer](
     through = OrganizationDeveloper,
@@ -141,7 +153,7 @@ case class OrganizationDeveloper(
 )
 
 object OrganizationDeveloper extends SkinnyNoIdCRUDMapper[OrganizationDeveloper] {
-  override lazy val tableName = "organization_developer"
+  override lazy val tableName = "organization_developers"
   override lazy val defaultAlias = createAlias("od")
 
   lazy val developerRef = belongsTo[Developer](Developer, (od, d) => od.copy(developer = d))


### PR DESCRIPTION
This pull request brings the following things:

- [x] Rails-ish Inflector support (ported from github.com/backchatio/scala-inflector)
- [x] Embracing plural table names in reverse-scaffold generator command
- [x] Avoid compilation error when the field name is a Scala reserved word or method name
- [x] Ensure it works with Redmine project