### PR TITLE
Apply namespace on resource name in messages.conf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "2.2.0-RC2"
+lazy val currentVersion = "2.2.0-RC3"
 
 lazy val skinnyMicroVersion = "1.1.0"
 lazy val scalatraTestVersion = "2.4.1"

--- a/example/src/main/scala/controller/CommentsController.scala
+++ b/example/src/main/scala/controller/CommentsController.scala
@@ -15,7 +15,7 @@ object CommentsController extends SkinnyController
   override def resourcesName = "comments"
   override def resourceName = "comment"
 
-  override def createForm = validation(createParams, paramKey("author") is required & maxLength(64))
+  override def createForm = validationWithPrefix(createParams, resourceName, paramKey("author") is required & maxLength(64))
   override def createFormStrongParameters = Seq("author" -> ParamType.String, "text" -> ParamType.String)
 
   override def updateForm = createForm

--- a/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
@@ -38,6 +38,11 @@ trait SkinnyApiResourceActions[Id] { self: SkinnyControllerCommonBase =>
   protected def resourceName: String
 
   /**
+   * Resource name in messages.conf
+   */
+  protected def messageResourceName: String = resourceName
+
+  /**
    * Root element name in the XML response.
    */
   override protected def xmlRootName = resourcesName
@@ -59,7 +64,7 @@ trait SkinnyApiResourceActions[Id] { self: SkinnyControllerCommonBase =>
     implicit
     locale: Locale = currentLocale(context).orNull[Locale]
   ): MapValidator = {
-    validationWithPrefix(params, resourceName, validations: _*)(context)
+    validationWithPrefix(params, messageResourceName, validations: _*)(context)
   }
 
   /**

--- a/run_skinny-blank-app_test.sh
+++ b/run_skinny-blank-app_test.sh
@@ -13,6 +13,9 @@ cd release/skinny-blank-app
 ./skinny g scaffold members1 member1 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
 ./skinny g scaffold:scaml members2 member2 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
 ./skinny g scaffold:jade members3 member3 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
+./skinny g scaffold admin members4 member4 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
+./skinny g scaffold:scaml admin members5 member5 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
+./skinny g scaffold:jade admin members6 member6 name:String activated:Boolean luckyNumber:Option[Long] birthday:Option[LocalDate] && \
 ./skinny db:migrate && \
 ./skinny db:migrate test && \
 ./skinny g reverse-model members1 rev1.member1 && \

--- a/skinny-blank-app/build.sbt
+++ b/skinny-blank-app/build.sbt
@@ -13,7 +13,7 @@ val appOrganization = "org.skinny-framework"
 val appName = "skinny-blank-app"
 val appVersion = "0.1.0-SNAPSHOT"
 
-val skinnyVersion = "2.2.0-RC2"
+val skinnyVersion = "2.2.0-RC3"
 val theScalaVersion = "2.11.8"
 val jettyVersion = "9.2.17.v20160517"
 

--- a/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldJadeGenerator.scala
@@ -21,20 +21,21 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
 
   override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     "-@val s: skinny.Skinny\n" +
       "-@val keyAndErrorMessages: skinny.KeyAndErrorMessages\n\n" +
       packageImportsWarning + "\n\n" +
       nameAndTypeNamePairs.toList.map { case (k, t) => (k, extractTypeIfOptionOrSeq(t)) }.map {
         case (name, "Boolean") =>
           s"""div(class="form-group")
-          |  label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  div(class="controls row")
           |    div(class="col-xs-12")
           |      input(type="checkbox" name="${toSnakeCase(name)}" class="form-control" value="true" checked={s.params.${toSnakeCase(name)}==Some(true)})
           |""".stripMargin
         case (name, "DateTime") =>
           s"""div(class="form-group")
-          |  label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      div(class="col-xs-2")
@@ -57,7 +58,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, "LocalDate") =>
           s"""div(class="form-group")
-          |  label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      div(class="col-xs-2")
@@ -74,7 +75,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, "LocalTime") =>
           s"""div(class="form-group")
-          |  label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      div(class="col-xs-2")
@@ -91,7 +92,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, _) =>
           s"""div(class="form-group")
-          |  label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      div(class="col-xs-12")
@@ -112,11 +113,12 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
 
   override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""-@val s: skinny.Skinny
         |
         |${packageImportsWarning}
         |
-        |h3 #{s.i18n.getOrKey("${resource}.new")}
+        |h3 #{s.i18n.getOrKey("${resourceWithNamespace}.new")}
         |hr
         |
         |-#-for (e <- s.errorMessages)
@@ -129,11 +131,12 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
 
   override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""-@val s: skinny.Skinny
         |
         |${packageImportsWarning}
         |
-        |h3 #{s.i18n.getOrKey("${resource}.edit")} : ##{s.params.id}
+        |h3 #{s.i18n.getOrKey("${resourceWithNamespace}.edit")} : ##{s.params.id}
         |hr
         |
         |-#-for (e <- s.errorMessages)
@@ -147,11 +150,12 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
   override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     val operations = {
       if (operationLinksInIndexPageRequired) {
         s"""|        a(href={s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-default") #{s.i18n.getOrKey("detail")}
             |        a(href={s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-            |        a(data-method="delete" data-confirm={s.i18n.getOrKey("${resource}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}""".stripMargin
+            |        a(data-method="delete" data-confirm={s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}""".stripMargin
       } else {
         s"""|        %a(href={s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-default") #{s.i18n.getOrKey("detail")}""".stripMargin
       }
@@ -163,7 +167,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |h3 #{s.i18n.getOrKey("${resource}.list")}
+        |h3 #{s.i18n.getOrKey("${resourceWithNamespace}.list")}
         |hr
         |-for (notice <- s.flash.notice)
         |  p(class="alert alert-info") #{notice}
@@ -184,7 +188,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |table(class="table table-bordered")
         |  thead
         |    tr
-        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "      th #{s.i18n.getOrKey(\"" + resource + "." + k + "\")}" }.mkString("\n")}
+        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "      th #{s.i18n.getOrKey(\"" + resourceWithNamespace + "." + k + "\")}" }.mkString("\n")}
         |      th
         |  tbody
         |  -for (item <- items)
@@ -203,10 +207,11 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
   override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     val attributesPart = ((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map {
       case (name, _) =>
         s"""    tr
-        |      th #{s.i18n.getOrKey("${resource}.${name}")}
+        |      th #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |      td #{item.${name}}
         |""".stripMargin
     }.mkString
@@ -216,7 +221,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |h3 #{s.i18n.getOrKey("${resource}.detail")}
+        |h3 #{s.i18n.getOrKey("${resourceWithNamespace}.detail")}
         |hr
         |-for (notice <- s.flash.notice)
         |  p(class="alert alert-info") #{notice}
@@ -227,7 +232,7 @@ trait ScaffoldJadeGenerator extends ScaffoldGenerator {
         |div(class="form-actions")
         |  a(class="btn btn-default" href={s.url(${controllerName}.indexUrl)}) #{s.i18n.getOrKey("backToList")}
         |  a(href={s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-        |  a(data-method="delete" data-confirm={s.i18n.getOrKey("${resource}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+        |  a(data-method="delete" data-confirm={s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
         |""".stripMargin
   }
 

--- a/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldScamlGenerator.scala
@@ -21,20 +21,21 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
 
   override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     "-@val s: skinny.Skinny\n" +
       "-@val keyAndErrorMessages: skinny.KeyAndErrorMessages\n\n" +
       packageImportsWarning + "\n\n" +
       nameAndTypeNamePairs.toList.map { case (k, t) => (k, extractTypeIfOptionOrSeq(t)) }.map {
         case (name, "Boolean") =>
           s"""%div(class="form-group")
-           |  %label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resource}.${name}")}
+           |  %label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
            |  %div(class="controls row")
            |    %div(class="col-xs-12")
            |      %input(type="checkbox" name="${toSnakeCase(name)}" class="form-control" value="true" checked={s.params.${toSnakeCase(name)}==Some(true)})
            |""".stripMargin
         case (name, "DateTime") =>
           s"""%div(class="form-group")
-          |  %label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  %label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      %div(class="col-xs-2")
@@ -57,7 +58,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, "LocalDate") =>
           s"""%div(class="form-group")
-          |  %label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  %label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      %div(class="col-xs-2")
@@ -74,7 +75,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, "LocalTime") =>
           s"""%div(class="form-group")
-          |  %label(class="control-label") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  %label(class="control-label") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      %div(class="col-xs-2")
@@ -91,7 +92,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
           |""".stripMargin
         case (name, _) =>
           s"""%div(class="form-group")
-          |  %label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resource}.${name}")}
+          |  %label(class="control-label" for="${toSnakeCase(name)}") #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""})
           |      %div(class="col-xs-12")
@@ -112,11 +113,12 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
 
   override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""-@val s: skinny.Skinny
         |
         |${packageImportsWarning}
         |
-        |%h3 #{s.i18n.getOrKey("${resource}.new")}
+        |%h3 #{s.i18n.getOrKey("${resourceWithNamespace}.new")}
         |%hr
         |
         |-#-for (e <- s.errorMessages)
@@ -129,11 +131,12 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
 
   override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""-@val s: skinny.Skinny
         |
         |${packageImportsWarning}
         |
-        |%h3 #{s.i18n.getOrKey("${resource}.edit")} : ##{s.params.id}
+        |%h3 #{s.i18n.getOrKey("${resourceWithNamespace}.edit")} : ##{s.params.id}
         |%hr
         |
         |-#-for (e <- s.errorMessages)
@@ -147,11 +150,12 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
   override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     val operations = {
       if (operationLinksInIndexPageRequired) {
         s"""|        %a(href={s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-default") #{s.i18n.getOrKey("detail")}
             |        %a(href={s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-            |        %a(data-method="delete" data-confirm={s.i18n.getOrKey("${resource}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}""".stripMargin
+            |        %a(data-method="delete" data-confirm={s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}""".stripMargin
       } else {
         s"""|        %a(href={s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-default") #{s.i18n.getOrKey("detail")}""".stripMargin
       }
@@ -163,7 +167,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |%h3 #{s.i18n.getOrKey("${resource}.list")}
+        |%h3 #{s.i18n.getOrKey("${resourceWithNamespace}.list")}
         |%hr
         |-for (notice <- s.flash.notice)
         |  %p(class="alert alert-info") #{notice}
@@ -184,7 +188,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |%table(class="table table-bordered")
         |  %thead
         |    %tr
-        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "      %th #{s.i18n.getOrKey(\"" + resource + "." + k + "\")}" }.mkString("\n")}
+        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "      %th #{s.i18n.getOrKey(\"" + resourceWithNamespace + "." + k + "\")}" }.mkString("\n")}
         |      %th
         |  %tbody
         |  -for (item <- items)
@@ -203,11 +207,12 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
   override def showHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
 
     val attributesPart = ((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map {
       case (name, _) =>
         s"""    %tr
-        |      %th #{s.i18n.getOrKey("${resource}.${name}")}
+        |      %th #{s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |      %td #{item.${name}}
         |""".stripMargin
     }.mkString
@@ -217,7 +222,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |%h3 #{s.i18n.getOrKey("${resource}.detail")}
+        |%h3 #{s.i18n.getOrKey("${resourceWithNamespace}.detail")}
         |%hr
         |-for (notice <- s.flash.notice)
         |  %p(class="alert alert-info") #{notice}
@@ -228,7 +233,7 @@ trait ScaffoldScamlGenerator extends ScaffoldGenerator {
         |%div(class="form-actions")
         |  %a(class="btn btn-default" href={s.url(${controllerName}.indexUrl)}) #{s.i18n.getOrKey("backToList")}
         |  %a(href={s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-        |  %a(data-method="delete" data-confirm={s.i18n.getOrKey("${resource}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+        |  %a(data-method="delete" data-confirm={s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")} href={s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
         |""".stripMargin
   }
 

--- a/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldSspGenerator.scala
@@ -20,13 +20,14 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
 
   override def formHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     "<%@val s: skinny.Skinny %>\n<%@val keyAndErrorMessages: skinny.KeyAndErrorMessages %>\n\n" +
       packageImportsWarning + "\n\n" +
       nameAndTypeNamePairs.toList.map { case (k, t) => (k, extractTypeIfOptionOrSeq(t)) }.map {
         case (name, "Boolean") =>
           s"""<div class="form-group">
         |  <label class="control-label" for="${toSnakeCase(name)}">
-        |    $${s.i18n.getOrKey("${resource}.${name}")}
+        |    $${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |  </label>
         |  <div class="controls row">
         |    <div class="col-xs-12">
@@ -38,7 +39,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         case (name, "DateTime") =>
           s"""<div class="form-group">
         |  <label class="control-label">
-        |    $${s.i18n.getOrKey("${resource}.${name}")}
+        |    $${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |  </label>
         |  <div class="controls row">
         |    <div class="$${if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""}">
@@ -74,7 +75,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         case (name, "LocalDate") =>
           s"""<div class="form-group">
         |  <label class="control-label">
-        |    $${s.i18n.getOrKey("${resource}.${name}")}
+        |    $${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |  </label>
         |  <div class="controls row">
         |    <div class="$${if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""}">
@@ -101,7 +102,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         case (name, "LocalTime") =>
           s"""<div class="form-group">
         |  <label class="control-label">
-        |    $${s.i18n.getOrKey("${resource}.${name}")}
+        |    $${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |  </label>
         |  <div class="controls row">
         |    <div class="$${if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""}">
@@ -128,7 +129,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         case (name, _) =>
           s"""<div class="form-group">
         |  <label class="control-label" for="${toSnakeCase(name)}">
-        |    $${s.i18n.getOrKey("${resource}.${name}")}
+        |    $${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}
         |  </label>
         |  <div class="controls row">
         |    <div class="$${if(keyAndErrorMessages.hasErrors("${toSnakeCase(name)}")) "has-error" else ""}">
@@ -157,11 +158,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
 
   override def newHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""<%@val s: skinny.Skinny %>
         |
         |${packageImportsWarning}
         |
-        |<h3>$${s.i18n.getOrKey("${resource}.new")}</h3>
+        |<h3>$${s.i18n.getOrKey("${resourceWithNamespace}.new")}</h3>
         |<hr/>
         |
         |<%--
@@ -178,11 +180,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
 
   override def editHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     s"""<%@val s: skinny.Skinny %>
         |
         |${packageImportsWarning}
         |
-        |<h3>$${s.i18n.getOrKey("${resource}.edit")} : #$${s.params.id}</h3>
+        |<h3>$${s.i18n.getOrKey("${resourceWithNamespace}.edit")} : #$${s.params.id}</h3>
         |<hr/>
         |
         |<%--
@@ -200,11 +203,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
   override def indexHtmlCode(namespaces: Seq[String], resources: String, resource: String, nameAndTypeNamePairs: Seq[(String, String)]): String = {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
     val operations = {
       if (operationLinksInIndexPageRequired) {
         s"""|      <a href="$${s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" class="btn btn-default">$${s.i18n.getOrKey("detail")}</a>
             |      <a href="$${s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" class="btn btn-info">$${s.i18n.getOrKey("edit")}</a>
-            |      <a data-method="delete" data-confirm="$${s.i18n.getOrKey("${resource}.delete.confirm")}"
+            |      <a data-method="delete" data-confirm="$${s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")}"
             |        href="$${s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" rel="nofollow" class="btn btn-danger">$${s.i18n.getOrKey("delete")}</a>""".stripMargin
       } else {
         s"""|      <a href="$${s.url(${controllerName}.showUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" class="btn btn-default">$${s.i18n.getOrKey("detail")}</a>""".stripMargin
@@ -217,7 +221,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |<h3>$${s.i18n.getOrKey("${resource}.list")}</h3>
+        |<h3>$${s.i18n.getOrKey("${resourceWithNamespace}.list")}</h3>
         |<hr/>
         |#for (notice <- s.flash.notice)
         |  <p class="alert alert-info">$${notice}</p>
@@ -246,7 +250,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |<table class="table table-bordered">
         |<thead>
         |  <tr>
-        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "    <th>${s.i18n.getOrKey(\"" + resource + "." + k + "\")}</th>" }.mkString("\n")}
+        |${((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map { case (k, _) => "    <th>${s.i18n.getOrKey(\"" + resourceWithNamespace + "." + k + "\")}</th>" }.mkString("\n")}
         |    <th></th>
         |  </tr>
         |</thead>
@@ -275,10 +279,12 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
     val controllerName = "Controllers." + toControllerName(namespaces, resources)
     val modelClassName = toClassName(resource)
     val modelNamespace = toNamespace(modelPackage, namespaces)
+    val resourceWithNamespace = toResourceNameWithNamespace(namespaces, resource)
+
     val attributesPart = ((primaryKeyName -> "Long") :: nameAndTypeNamePairs.toList).map {
       case (name, _) =>
         s"""  <tr>
-        |    <th>$${s.i18n.getOrKey("${resource}.${name}")}</th>
+        |    <th>$${s.i18n.getOrKey("${resourceWithNamespace}.${name}")}</th>
         |    <td>$${item.${name}}</td>
         |  </tr>
         |""".stripMargin
@@ -289,7 +295,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |
         |${packageImportsWarning}
         |
-        |<h3>$${s.i18n.getOrKey("${resource}.detail")}</h3>
+        |<h3>$${s.i18n.getOrKey("${resourceWithNamespace}.detail")}</h3>
         |<hr/>
         |#for (notice <- s.flash.notice)
         |  <p class="alert alert-info">$${notice}</p>
@@ -304,7 +310,7 @@ trait ScaffoldSspGenerator extends ScaffoldGenerator {
         |<div class="form-actions">
         |  <a class="btn btn-default" href="$${s.url(${controllerName}.indexUrl)}">$${s.i18n.getOrKey("backToList")}</a>
         |  <a href="$${s.url(${controllerName}.editUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" class="btn btn-info">$${s.i18n.getOrKey("edit")}</a>
-        |  <a data-method="delete" data-confirm="$${s.i18n.getOrKey("${resource}.delete.confirm")}"
+        |  <a data-method="delete" data-confirm="$${s.i18n.getOrKey("${resourceWithNamespace}.delete.confirm")}"
         |    href="$${s.url(${controllerName}.destroyUrl, "${snakeCasedPrimaryKeyName}" -> item.${primaryKeyName})}" rel="nofollow" class="btn btn-danger">$${s.i18n.getOrKey("delete")}</a>
         |</div>
         |""".stripMargin

--- a/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
@@ -39,6 +39,7 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
           |  override def model = Member
           |  override def resourcesName = "members"
           |  override def resourceName = "member"
+          |  override def messageResourceName = "adminMember"
           |
           |  override def resourcesBasePath = s"/admin/${toSnakeCase(resourcesName)}"
           |  override def useSnakeCasedParamKeys = true
@@ -696,7 +697,7 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
 
   describe("messages.conf") {
     it("should be created as expected") {
-      val code = generator.messagesConfCode("groupMembers", "groupMember", Seq(
+      val code = generator.messagesConfCode("groupMember", "groupMembers", "groupMember", Seq(
         "name" -> "String",
         "isActivated" -> "Boolean",
         "birthday" -> "Option[LocalDate]"

--- a/task/src/test/scala/skinny/task/generator/ScaffoldJadeGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldJadeGeneratorSpec.scala
@@ -25,7 +25,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
           |div(class="form-group")
-          |  label(class="control-label" for="name") #{s.i18n.getOrKey("member.name")}
+          |  label(class="control-label" for="name") #{s.i18n.getOrKey("adminMember.name")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("name")) "has-error" else ""})
           |      div(class="col-xs-12")
@@ -36,7 +36,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |          label(class="control-label") #{error}
           |    - }
           |div(class="form-group")
-          |  label(class="control-label" for="favorite_number") #{s.i18n.getOrKey("member.favoriteNumber")}
+          |  label(class="control-label" for="favorite_number") #{s.i18n.getOrKey("adminMember.favoriteNumber")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("favorite_number")) "has-error" else ""})
           |      div(class="col-xs-12")
@@ -47,7 +47,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |          label(class="control-label") #{error}
           |    - }
           |div(class="form-group")
-          |  label(class="control-label" for="magic_number") #{s.i18n.getOrKey("member.magicNumber")}
+          |  label(class="control-label" for="magic_number") #{s.i18n.getOrKey("adminMember.magicNumber")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("magic_number")) "has-error" else ""})
           |      div(class="col-xs-12")
@@ -58,12 +58,12 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |          label(class="control-label") #{error}
           |    - }
           |div(class="form-group")
-          |  label(class="control-label" for="is_activated") #{s.i18n.getOrKey("member.isActivated")}
+          |  label(class="control-label" for="is_activated") #{s.i18n.getOrKey("adminMember.isActivated")}
           |  div(class="controls row")
           |    div(class="col-xs-12")
           |      input(type="checkbox" name="is_activated" class="form-control" value="true" checked={s.params.is_activated==Some(true)})
           |div(class="form-group")
-          |  label(class="control-label") #{s.i18n.getOrKey("member.birthday")}
+          |  label(class="control-label") #{s.i18n.getOrKey("adminMember.birthday")}
           |  div(class="controls row")
           |    div(class={if(keyAndErrorMessages.hasErrors("birthday")) "has-error" else ""})
           |      div(class="col-xs-2")
@@ -103,7 +103,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |h3 #{s.i18n.getOrKey("member.new")}
+          |h3 #{s.i18n.getOrKey("adminMember.new")}
           |hr
           |
           |-#-for (e <- s.errorMessages)
@@ -133,7 +133,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |h3 #{s.i18n.getOrKey("member.edit")} : ##{s.params.id}
+          |h3 #{s.i18n.getOrKey("adminMember.edit")} : ##{s.params.id}
           |hr
           |
           |-#-for (e <- s.errorMessages)
@@ -166,7 +166,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |h3 #{s.i18n.getOrKey("member.list")}
+          |h3 #{s.i18n.getOrKey("adminMember.list")}
           |hr
           |-for (notice <- s.flash.notice)
           |  p(class="alert alert-info") #{notice}
@@ -187,12 +187,12 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |table(class="table table-bordered")
           |  thead
           |    tr
-          |      th #{s.i18n.getOrKey("member.id")}
-          |      th #{s.i18n.getOrKey("member.name")}
-          |      th #{s.i18n.getOrKey("member.favoriteNumber")}
-          |      th #{s.i18n.getOrKey("member.magicNumber")}
-          |      th #{s.i18n.getOrKey("member.isActivated")}
-          |      th #{s.i18n.getOrKey("member.birthday")}
+          |      th #{s.i18n.getOrKey("adminMember.id")}
+          |      th #{s.i18n.getOrKey("adminMember.name")}
+          |      th #{s.i18n.getOrKey("adminMember.favoriteNumber")}
+          |      th #{s.i18n.getOrKey("adminMember.magicNumber")}
+          |      th #{s.i18n.getOrKey("adminMember.isActivated")}
+          |      th #{s.i18n.getOrKey("adminMember.birthday")}
           |      th
           |  tbody
           |  -for (item <- items)
@@ -206,7 +206,7 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |      td
           |        a(href={s.url(Controllers.adminMembers.showUrl, "id" -> item.id)} class="btn btn-default") #{s.i18n.getOrKey("detail")}
           |        a(href={s.url(Controllers.adminMembers.editUrl, "id" -> item.id)} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-          |        a(data-method="delete" data-confirm={s.i18n.getOrKey("member.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+          |        a(data-method="delete" data-confirm={s.i18n.getOrKey("adminMember.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
           |  -if (items.isEmpty)
           |    tr
           |      td(colspan="7") #{s.i18n.getOrKey("empty")}
@@ -235,36 +235,36 @@ class ScaffoldJadeGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |h3 #{s.i18n.getOrKey("member.detail")}
+          |h3 #{s.i18n.getOrKey("adminMember.detail")}
           |hr
           |-for (notice <- s.flash.notice)
           |  p(class="alert alert-info") #{notice}
           |table(class="table table-bordered")
           |  thead
           |    tr
-          |      th #{s.i18n.getOrKey("member.id")}
+          |      th #{s.i18n.getOrKey("adminMember.id")}
           |      td #{item.id}
           |    tr
-          |      th #{s.i18n.getOrKey("member.name")}
+          |      th #{s.i18n.getOrKey("adminMember.name")}
           |      td #{item.name}
           |    tr
-          |      th #{s.i18n.getOrKey("member.favoriteNumber")}
+          |      th #{s.i18n.getOrKey("adminMember.favoriteNumber")}
           |      td #{item.favoriteNumber}
           |    tr
-          |      th #{s.i18n.getOrKey("member.magicNumber")}
+          |      th #{s.i18n.getOrKey("adminMember.magicNumber")}
           |      td #{item.magicNumber}
           |    tr
-          |      th #{s.i18n.getOrKey("member.isActivated")}
+          |      th #{s.i18n.getOrKey("adminMember.isActivated")}
           |      td #{item.isActivated}
           |    tr
-          |      th #{s.i18n.getOrKey("member.birthday")}
+          |      th #{s.i18n.getOrKey("adminMember.birthday")}
           |      td #{item.birthday}
           |
           |hr
           |div(class="form-actions")
           |  a(class="btn btn-default" href={s.url(Controllers.adminMembers.indexUrl)}) #{s.i18n.getOrKey("backToList")}
           |  a(href={s.url(Controllers.adminMembers.editUrl, "id" -> item.id)} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-          |  a(data-method="delete" data-confirm={s.i18n.getOrKey("member.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+          |  a(data-method="delete" data-confirm={s.i18n.getOrKey("adminMember.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
           |""".stripMargin
       code should equal(expected)
     }

--- a/task/src/test/scala/skinny/task/generator/ScaffoldScamlGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldScamlGeneratorSpec.scala
@@ -25,7 +25,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
           |%div(class="form-group")
-          |  %label(class="control-label" for="name") #{s.i18n.getOrKey("member.name")}
+          |  %label(class="control-label" for="name") #{s.i18n.getOrKey("adminMember.name")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("name")) "has-error" else ""})
           |      %div(class="col-xs-12")
@@ -36,7 +36,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |          %label(class="control-label") #{error}
           |    - }
           |%div(class="form-group")
-          |  %label(class="control-label" for="favorite_number") #{s.i18n.getOrKey("member.favoriteNumber")}
+          |  %label(class="control-label" for="favorite_number") #{s.i18n.getOrKey("adminMember.favoriteNumber")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("favorite_number")) "has-error" else ""})
           |      %div(class="col-xs-12")
@@ -47,7 +47,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |          %label(class="control-label") #{error}
           |    - }
           |%div(class="form-group")
-          |  %label(class="control-label" for="magic_number") #{s.i18n.getOrKey("member.magicNumber")}
+          |  %label(class="control-label" for="magic_number") #{s.i18n.getOrKey("adminMember.magicNumber")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("magic_number")) "has-error" else ""})
           |      %div(class="col-xs-12")
@@ -58,12 +58,12 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |          %label(class="control-label") #{error}
           |    - }
           |%div(class="form-group")
-          |  %label(class="control-label" for="is_activated") #{s.i18n.getOrKey("member.isActivated")}
+          |  %label(class="control-label" for="is_activated") #{s.i18n.getOrKey("adminMember.isActivated")}
           |  %div(class="controls row")
           |    %div(class="col-xs-12")
           |      %input(type="checkbox" name="is_activated" class="form-control" value="true" checked={s.params.is_activated==Some(true)})
           |%div(class="form-group")
-          |  %label(class="control-label") #{s.i18n.getOrKey("member.birthday")}
+          |  %label(class="control-label") #{s.i18n.getOrKey("adminMember.birthday")}
           |  %div(class="controls row")
           |    %div(class={if(keyAndErrorMessages.hasErrors("birthday")) "has-error" else ""})
           |      %div(class="col-xs-2")
@@ -103,7 +103,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |%h3 #{s.i18n.getOrKey("member.new")}
+          |%h3 #{s.i18n.getOrKey("adminMember.new")}
           |%hr
           |
           |-#-for (e <- s.errorMessages)
@@ -133,7 +133,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |%h3 #{s.i18n.getOrKey("member.edit")} : ##{s.params.id}
+          |%h3 #{s.i18n.getOrKey("adminMember.edit")} : ##{s.params.id}
           |%hr
           |
           |-#-for (e <- s.errorMessages)
@@ -166,7 +166,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |%h3 #{s.i18n.getOrKey("member.list")}
+          |%h3 #{s.i18n.getOrKey("adminMember.list")}
           |%hr
           |-for (notice <- s.flash.notice)
           |  %p(class="alert alert-info") #{notice}
@@ -187,12 +187,12 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |%table(class="table table-bordered")
           |  %thead
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.id")}
-          |      %th #{s.i18n.getOrKey("member.name")}
-          |      %th #{s.i18n.getOrKey("member.favoriteNumber")}
-          |      %th #{s.i18n.getOrKey("member.magicNumber")}
-          |      %th #{s.i18n.getOrKey("member.isActivated")}
-          |      %th #{s.i18n.getOrKey("member.birthday")}
+          |      %th #{s.i18n.getOrKey("adminMember.id")}
+          |      %th #{s.i18n.getOrKey("adminMember.name")}
+          |      %th #{s.i18n.getOrKey("adminMember.favoriteNumber")}
+          |      %th #{s.i18n.getOrKey("adminMember.magicNumber")}
+          |      %th #{s.i18n.getOrKey("adminMember.isActivated")}
+          |      %th #{s.i18n.getOrKey("adminMember.birthday")}
           |      %th
           |  %tbody
           |  -for (item <- items)
@@ -206,7 +206,7 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |      %td
           |        %a(href={s.url(Controllers.adminMembers.showUrl, "id" -> item.id)} class="btn btn-default") #{s.i18n.getOrKey("detail")}
           |        %a(href={s.url(Controllers.adminMembers.editUrl, "id" -> item.id)} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-          |        %a(data-method="delete" data-confirm={s.i18n.getOrKey("member.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+          |        %a(data-method="delete" data-confirm={s.i18n.getOrKey("adminMember.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
           |  -if (items.isEmpty)
           |    %tr
           |      %td(colspan="7") #{s.i18n.getOrKey("empty")}
@@ -235,36 +235,36 @@ class ScaffoldScamlGeneratorSpec extends FunSpec with Matchers {
           |-# 1. src/main/scala/templates/ScalatePackage.scala
           |-# 2. scalateTemplateConfig in project/Build.scala
           |
-          |%h3 #{s.i18n.getOrKey("member.detail")}
+          |%h3 #{s.i18n.getOrKey("adminMember.detail")}
           |%hr
           |-for (notice <- s.flash.notice)
           |  %p(class="alert alert-info") #{notice}
           |%table(class="table table-bordered")
           |  %thead
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.id")}
+          |      %th #{s.i18n.getOrKey("adminMember.id")}
           |      %td #{item.id}
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.name")}
+          |      %th #{s.i18n.getOrKey("adminMember.name")}
           |      %td #{item.name}
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.favoriteNumber")}
+          |      %th #{s.i18n.getOrKey("adminMember.favoriteNumber")}
           |      %td #{item.favoriteNumber}
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.magicNumber")}
+          |      %th #{s.i18n.getOrKey("adminMember.magicNumber")}
           |      %td #{item.magicNumber}
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.isActivated")}
+          |      %th #{s.i18n.getOrKey("adminMember.isActivated")}
           |      %td #{item.isActivated}
           |    %tr
-          |      %th #{s.i18n.getOrKey("member.birthday")}
+          |      %th #{s.i18n.getOrKey("adminMember.birthday")}
           |      %td #{item.birthday}
           |
           |%hr
           |%div(class="form-actions")
           |  %a(class="btn btn-default" href={s.url(Controllers.adminMembers.indexUrl)}) #{s.i18n.getOrKey("backToList")}
           |  %a(href={s.url(Controllers.adminMembers.editUrl, "id" -> item.id)} class="btn btn-info") #{s.i18n.getOrKey("edit")}
-          |  %a(data-method="delete" data-confirm={s.i18n.getOrKey("member.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
+          |  %a(data-method="delete" data-confirm={s.i18n.getOrKey("adminMember.delete.confirm")} href={s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)} rel="nofollow" class="btn btn-danger") #{s.i18n.getOrKey("delete")}
           |""".stripMargin
       code should equal(expected)
     }

--- a/task/src/test/scala/skinny/task/generator/ScaffoldSspGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldSspGeneratorSpec.scala
@@ -27,7 +27,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |
           |<div class="form-group">
           |  <label class="control-label" for="name">
-          |    ${s.i18n.getOrKey("member.name")}
+          |    ${s.i18n.getOrKey("adminMember.name")}
           |  </label>
           |  <div class="controls row">
           |    <div class="${if(keyAndErrorMessages.hasErrors("name")) "has-error" else ""}">
@@ -46,7 +46,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |</div>
           |<div class="form-group">
           |  <label class="control-label" for="favorite_number">
-          |    ${s.i18n.getOrKey("member.favoriteNumber")}
+          |    ${s.i18n.getOrKey("adminMember.favoriteNumber")}
           |  </label>
           |  <div class="controls row">
           |    <div class="${if(keyAndErrorMessages.hasErrors("favorite_number")) "has-error" else ""}">
@@ -65,7 +65,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |</div>
           |<div class="form-group">
           |  <label class="control-label" for="magic_number">
-          |    ${s.i18n.getOrKey("member.magicNumber")}
+          |    ${s.i18n.getOrKey("adminMember.magicNumber")}
           |  </label>
           |  <div class="controls row">
           |    <div class="${if(keyAndErrorMessages.hasErrors("magic_number")) "has-error" else ""}">
@@ -84,7 +84,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |</div>
           |<div class="form-group">
           |  <label class="control-label" for="is_activated">
-          |    ${s.i18n.getOrKey("member.isActivated")}
+          |    ${s.i18n.getOrKey("adminMember.isActivated")}
           |  </label>
           |  <div class="controls row">
           |    <div class="col-xs-12">
@@ -94,7 +94,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |</div>
           |<div class="form-group">
           |  <label class="control-label">
-          |    ${s.i18n.getOrKey("member.birthday")}
+          |    ${s.i18n.getOrKey("adminMember.birthday")}
           |  </label>
           |  <div class="controls row">
           |    <div class="${if(keyAndErrorMessages.hasErrors("birthday")) "has-error" else ""}">
@@ -144,7 +144,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           | 2. scalateTemplateConfig in project/Build.scala
           |--%>
           |
-          |<h3>${s.i18n.getOrKey("member.new")}</h3>
+          |<h3>${s.i18n.getOrKey("adminMember.new")}</h3>
           |<hr/>
           |
           |<%--
@@ -178,7 +178,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           | 2. scalateTemplateConfig in project/Build.scala
           |--%>
           |
-          |<h3>${s.i18n.getOrKey("member.edit")} : #${s.params.id}</h3>
+          |<h3>${s.i18n.getOrKey("adminMember.edit")} : #${s.params.id}</h3>
           |<hr/>
           |
           |<%--
@@ -215,7 +215,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           | 2. scalateTemplateConfig in project/Build.scala
           |--%>
           |
-          |<h3>${s.i18n.getOrKey("member.list")}</h3>
+          |<h3>${s.i18n.getOrKey("adminMember.list")}</h3>
           |<hr/>
           |#for (notice <- s.flash.notice)
           |  <p class="alert alert-info">${notice}</p>
@@ -244,12 +244,12 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |<table class="table table-bordered">
           |<thead>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.id")}</th>
-          |    <th>${s.i18n.getOrKey("member.name")}</th>
-          |    <th>${s.i18n.getOrKey("member.favoriteNumber")}</th>
-          |    <th>${s.i18n.getOrKey("member.magicNumber")}</th>
-          |    <th>${s.i18n.getOrKey("member.isActivated")}</th>
-          |    <th>${s.i18n.getOrKey("member.birthday")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.id")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.name")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.favoriteNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.magicNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.isActivated")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.birthday")}</th>
           |    <th></th>
           |  </tr>
           |</thead>
@@ -265,7 +265,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |    <td>
           |      <a href="${s.url(Controllers.adminMembers.showUrl, "id" -> item.id)}" class="btn btn-default">${s.i18n.getOrKey("detail")}</a>
           |      <a href="${s.url(Controllers.adminMembers.editUrl, "id" -> item.id)}" class="btn btn-info">${s.i18n.getOrKey("edit")}</a>
-          |      <a data-method="delete" data-confirm="${s.i18n.getOrKey("member.delete.confirm")}"
+          |      <a data-method="delete" data-confirm="${s.i18n.getOrKey("adminMember.delete.confirm")}"
           |        href="${s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)}" rel="nofollow" class="btn btn-danger">${s.i18n.getOrKey("delete")}</a>
           |    </td>
           |  </tr>
@@ -305,7 +305,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           | 2. scalateTemplateConfig in project/Build.scala
           |--%>
           |
-          |<h3>${s.i18n.getOrKey("member.list")}</h3>
+          |<h3>${s.i18n.getOrKey("adminMember.list")}</h3>
           |<hr/>
           |#for (notice <- s.flash.notice)
           |  <p class="alert alert-info">${notice}</p>
@@ -334,12 +334,12 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |<table class="table table-bordered">
           |<thead>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.id")}</th>
-          |    <th>${s.i18n.getOrKey("member.name")}</th>
-          |    <th>${s.i18n.getOrKey("member.favoriteNumber")}</th>
-          |    <th>${s.i18n.getOrKey("member.magicNumber")}</th>
-          |    <th>${s.i18n.getOrKey("member.isActivated")}</th>
-          |    <th>${s.i18n.getOrKey("member.birthday")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.id")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.name")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.favoriteNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.magicNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.isActivated")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.birthday")}</th>
           |    <th></th>
           |  </tr>
           |</thead>
@@ -389,7 +389,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           | 2. scalateTemplateConfig in project/Build.scala
           |--%>
           |
-          |<h3>${s.i18n.getOrKey("member.detail")}</h3>
+          |<h3>${s.i18n.getOrKey("adminMember.detail")}</h3>
           |<hr/>
           |#for (notice <- s.flash.notice)
           |  <p class="alert alert-info">${notice}</p>
@@ -397,27 +397,27 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |<table class="table table-bordered">
           |<tbody>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.id")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.id")}</th>
           |    <td>${item.id}</td>
           |  </tr>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.name")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.name")}</th>
           |    <td>${item.name}</td>
           |  </tr>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.favoriteNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.favoriteNumber")}</th>
           |    <td>${item.favoriteNumber}</td>
           |  </tr>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.magicNumber")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.magicNumber")}</th>
           |    <td>${item.magicNumber}</td>
           |  </tr>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.isActivated")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.isActivated")}</th>
           |    <td>${item.isActivated}</td>
           |  </tr>
           |  <tr>
-          |    <th>${s.i18n.getOrKey("member.birthday")}</th>
+          |    <th>${s.i18n.getOrKey("adminMember.birthday")}</th>
           |    <td>${item.birthday}</td>
           |  </tr>
           |
@@ -428,7 +428,7 @@ class ScaffoldSspGeneratorSpec extends FunSpec with Matchers {
           |<div class="form-actions">
           |  <a class="btn btn-default" href="${s.url(Controllers.adminMembers.indexUrl)}">${s.i18n.getOrKey("backToList")}</a>
           |  <a href="${s.url(Controllers.adminMembers.editUrl, "id" -> item.id)}" class="btn btn-info">${s.i18n.getOrKey("edit")}</a>
-          |  <a data-method="delete" data-confirm="${s.i18n.getOrKey("member.delete.confirm")}"
+          |  <a data-method="delete" data-confirm="${s.i18n.getOrKey("adminMember.delete.confirm")}"
           |    href="${s.url(Controllers.adminMembers.destroyUrl, "id" -> item.id)}" rel="nofollow" class="btn btn-danger">${s.i18n.getOrKey("delete")}</a>
           |</div>
           |""".stripMargin


### PR DESCRIPTION
This pull request enables appending namespace to resource name to messages.conf if exists. 

There may be a possibility to have same resource names under another namespace. In such cases,  making resource names unique by prepending namespace to it would be fine. The similar fix is already done with `src/test/resources/factories.conf` for factory-girl module. 