### PR TITLE
Fix an bug on customizing validation messages in SkinnyResource

### DIFF
--- a/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyApiResourceActions.scala
@@ -60,10 +60,8 @@ trait SkinnyApiResourceActions[Id] { self: SkinnyControllerCommonBase =>
    * @param locale current locale
    * @return validator
    */
-  override def validation(params: Params, validations: NewValidation*)(
-    implicit
-    locale: Locale = currentLocale(context).orNull[Locale]
-  ): MapValidator = {
+  override def validation(params: Params, validations: NewValidation*)(implicit
+    locale: Locale = currentLocale(context).orNull[Locale]): MapValidator = {
     validationWithPrefix(params, messageResourceName, validations: _*)(context)
   }
 

--- a/framework/src/main/scala/skinny/controller/SkinnyResourceActions.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyResourceActions.scala
@@ -52,11 +52,9 @@ trait SkinnyResourceActions[Id] extends SkinnyApiResourceActions[Id] {
    * @param locale current locale
    * @return validator
    */
-  override def validation(params: Params, validations: NewValidation*)(
-    implicit
-    locale: Locale = currentLocale.orNull[Locale]
-  ): MapValidator = {
-    validationWithPrefix(params, resourceName, validations: _*)
+  override def validation(params: Params, validations: NewValidation*)(implicit
+                                                                       locale: Locale = currentLocale.orNull[Locale]): MapValidator = {
+    validationWithPrefix(params, messageResourceName, validations: _*)
   }
 
   // ----------------------------


### PR DESCRIPTION
Overriding `messageResourceName` in `SkinnyResource` is ignored. This pull request fixes the bug.