### PR TITLE
Bump jetty, scalajs, skinny-micro, etc..

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,14 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "2.3.2"
+lazy val currentVersion = "2.3.3-SNAPSHOT"
 
-lazy val skinnyMicroVersion = "1.2.1"
+lazy val skinnyMicroVersion = "1.2.2"
 lazy val scalikeJDBCVersion = "2.5.0"
 lazy val h2Version = "1.4.193"
 lazy val kuromojiVersion = "6.3.0"
-lazy val mockitoVersion = "2.3.5"
-lazy val jettyVersion = "9.3.14.v20161028"
+lazy val mockitoVersion = "2.3.11"
+lazy val jettyVersion = "9.3.15.v20161220"
 lazy val logbackVersion = "1.1.8"
 lazy val slf4jApiVersion = "1.7.22"
 lazy val scalaTestVersion = "3.0.1"
@@ -66,7 +66,7 @@ lazy val common = (project in file("common")).settings(baseSettings).settings(
       "org.apache.lucene"    %  "lucene-analyzers-kuromoji" % kuromojiVersion    % Provided
     ) ++ (scalaVersion.value match {
       case v if v.startsWith("2.11.") || v.startsWith("2.12.") =>
-        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4" % Compile)
+        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5" % Compile)
       case _ => Nil
     })
   }
@@ -308,7 +308,7 @@ lazy val slf4jApiDependencies   = Seq(
   "org.slf4j"     % "slf4j-api"         % slf4jApiVersion % Compile
 )
 lazy val jodaDependencies = Seq(
-  "joda-time"     %  "joda-time"        % "2.9.6" % Compile,
+  "joda-time"     %  "joda-time"        % "2.9.7" % Compile,
   "org.joda"      %  "joda-convert"     % "1.8.1" % Compile
 )
 lazy val mailDependencies = slf4jApiDependencies ++ Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ fullResolvers ~= { _.filterNot(_.name == "jcenter") }
 //addSbtPlugin("io.get-coursier"      % "sbt-coursier"            % "1.0.0-M15-1")
 
 addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.8.0.0")
-addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin"      % "2.1.0")
+addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin"      % "2.1.1")
 addSbtPlugin("org.scalariform"      % "sbt-scalariform"         % "1.6.0")
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea"                % "1.6.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                 % "1.0.0")

--- a/skinny-blank-app/build.sbt
+++ b/skinny-blank-app/build.sbt
@@ -13,9 +13,9 @@ val appOrganization = "org.skinny-framework"
 val appName = "skinny-blank-app"
 val appVersion = "0.1.0-SNAPSHOT"
 
-val skinnyVersion = "2.3.2"
+val skinnyVersion = "2.3.3-SNAPSHOT"
 val theScalaVersion = "2.12.1"
-val jettyVersion = "9.3.14.v20161028"
+val jettyVersion = "9.3.15.v20161220"
 
 lazy val baseSettings = servletSettings ++ Seq(
   organization := appOrganization,
@@ -27,7 +27,7 @@ lazy val baseSettings = servletSettings ++ Seq(
     "org.scala-lang"         %  "scala-reflect"            % scalaVersion.value,
     "org.scala-lang"         %  "scala-compiler"           % scalaVersion.value,
     "org.scala-lang.modules" %% "scala-xml"                % "1.0.6",
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5",
     "org.slf4j"              %  "slf4j-api"                % "1.7.22"
   ),
   libraryDependencies ++= Seq(

--- a/skinny-blank-app/project/plugins.sbt
+++ b/skinny-blank-app/project/plugins.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 // --------
 // Servlet app packager/runner plugin
-addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin" % "2.1.0")
+addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin" % "2.1.1")
 
 // Scalate template files precompilation
 addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.8.0.0")

--- a/skinny-blank-app/skinny
+++ b/skinny-blank-app/skinny
@@ -54,11 +54,11 @@ function setup_scalajs() {
   setting_file="${current_dir}/project/_skinny_scalajs.sbt"
   if [ ! -f "${setting_file}" ]; then
     echo "resolvers += \"scala-js-release\" at \"http://dl.bintray.com/scala-js/scala-js-releases\"
-addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"0.6.13\")" > ${setting_file}
+addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"0.6.14\")" > ${setting_file}
 
 echo "lazy val scalajs = (project in file(\"src/main/webapp/WEB-INF/assets\")).settings(
   name := \"application\", // JavaScript file name
-  scalaVersion := \"2.11.8\",
+  scalaVersion := \"2.12.1\",
   unmanagedSourceDirectories in Compile += baseDirectory(_ / \"scala\").value,
   fullResolvers ~= { _.filterNot(_.name == \"jcenter\") },
   libraryDependencies ++= Seq(

--- a/skinny-blank-app/skinny.bat
+++ b/skinny-blank-app/skinny.bat
@@ -384,11 +384,11 @@ GOTO script_eof
 :scalajs_task
 IF NOT EXIST "project\_skinny_scalajs.sbt" (
   ECHO resolvers += "scala-js-release" at "http://dl.bintray.com/scala-js/scala-js-releases" > "project\_skinny_scalajs.sbt"
-  ECHO addSbtPlugin^("org.scala-js" %% "sbt-scalajs" %% "0.6.13"^) >> "project\_skinny_scalajs.sbt"
+  ECHO addSbtPlugin^("org.scala-js" %% "sbt-scalajs" %% "0.6.14"^) >> "project\_skinny_scalajs.sbt"
 
   ECHO lazy val scalajs = ^(project in file^("src/main/webapp/WEB-INF/assets"^)^).settings^( > "_skinny_scalajs_settings.sbt"
   ECHO   name := "application", // JavaScript file name  >> "_skinny_scalajs_settings.sbt"
-  ECHO   scalaVersion := "2.11.8", >> "_skinny_scalajs_settings.sbt"
+  ECHO   scalaVersion := "2.12.1", >> "_skinny_scalajs_settings.sbt"
   ECHO   unmanagedSourceDirectories in Compile ^<= baseDirectory^(_ / "scala"^).value, >> "_skinny_scalajs_settings.sbt"
   ECHO   fullResolvers ~= { _.filterNot^(_.name == "jcenter"^) }, >> "_skinny_scalajs_settings.sbt"
   ECHO   libraryDependencies ++= Seq^(                   >> "_skinny_scalajs_settings.sbt"


### PR DESCRIPTION
This pull request bumps the following dependencies for 2.3.3 release.

- Jetty 9.3.14 -> 9.3.15
- Skinny Micro 1.2.1 -> 1.2.2
- scala-parser-combinators 1.0.4 -> 1.0.5
- joda-time 2.9.6 -> 2.9.7
- sbt-servlet-plugin 2.1.0 -> 2.1.1
- scala.js 0.6.13 -> 0.6.14
- Scala version for Scala.js 2.11.8 -> 2.12.1
