### PR TITLE
Add ParamType.NullableString

### DIFF
--- a/common/src/main/scala/skinny/ParamType.scala
+++ b/common/src/main/scala/skinny/ParamType.scala
@@ -82,6 +82,12 @@ object ParamType {
     case v: String => v
     case v => v.toString
   })
+  case object NullableString extends AbstractParamType({
+    case null | None => null
+    case v: String if v.isEmpty => null
+    case v: String => v
+    case v => v.toString
+  })
   case object Byte extends AbstractParamType({
     case v: String if v.trim.isEmpty => null
     case v: String => v.toByte

--- a/common/src/test/scala/skinny/ParamTypeSpec.scala
+++ b/common/src/test/scala/skinny/ParamTypeSpec.scala
@@ -134,6 +134,19 @@ class ParamTypeSpec extends FlatSpec with Matchers {
     ParamType.String.unapply(null) should equal(None)
   }
 
+  behavior of "ParamType.NullableString"
+
+  it should "convert raw value to expected type" in {
+    ParamType.NullableString.unapply("abc") should equal(Some("abc"))
+    ParamType.NullableString.unapply(123) should equal(Some("123"))
+    ParamType.NullableString.unapply(123L) should equal(Some("123"))
+    ParamType.NullableString.unapply(1.23D) should equal(Some("1.23"))
+    ParamType.NullableString.unapply(1.23F) should equal(Some("1.23"))
+    ParamType.NullableString.unapply("") should equal(Some(null))
+    ParamType.NullableString.unapply("  ") should equal(Some("  "))
+    ParamType.NullableString.unapply(null) should equal(None)
+  }
+
   behavior of "ParamType.Byte"
 
   it should "convert raw value to expected type" in {


### PR DESCRIPTION
This pull request introduces new ParamType to allow inserting nullable String values into a database. 

The existing ParamType.String inserts empty string if user doesn't specify value. Both of the patterns exist in the wild. We don't change the deafult behavior this time but most users prefer using NullableString by default. we might consider changing the default one in the future. 