### PR TITLE
Enable #countBy method also for joins queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "2.3.6-SNAPSHOT"
+lazy val currentVersion = "2.3.5"
 
 lazy val skinnyMicroVersion = "1.2.4"
 lazy val scalikeJDBCVersion = "2.5.0"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "2.3.5"
+lazy val currentVersion = "2.3.6-SNAPSHOT"
 
 lazy val skinnyMicroVersion = "1.2.4"
 lazy val scalikeJDBCVersion = "2.5.0"

--- a/orm/src/main/scala/skinny/orm/SkinnyMapperBase.scala
+++ b/orm/src/main/scala/skinny/orm/SkinnyMapperBase.scala
@@ -33,6 +33,11 @@ trait SkinnyMapperBase[Entity] extends SQLSyntaxSupport[Entity] {
   def singleSelectQuery: SelectSQLBuilder[Entity] = select.from(as(defaultAlias))
 
   /**
+   * Returns simple select count query.
+   */
+  def simpleCountQuery: SelectSQLBuilder[Entity] = select(sqls.count).from(as(defaultAlias))
+
+  /**
    * Returns select query builder.
    */
   def defaultSelectQuery: SelectSQLBuilder[Entity] = singleSelectQuery

--- a/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
@@ -411,7 +411,7 @@ trait AssociationsFeature[Entity]
   }
 
   /**
-   * Returns th default select query builder for this mapper.
+   * Returns the default select query builder for this mapper.
    *
    * @return select query builder
    */
@@ -420,7 +420,7 @@ trait AssociationsFeature[Entity]
   }
 
   /**
-   * Returns th count query builder for this mapper.
+   * Returns the count query builder for this mapper.
    *
    * @return select query builder
    */

--- a/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
@@ -416,13 +416,26 @@ trait AssociationsFeature[Entity]
    * @return select query builder
    */
   override def defaultSelectQuery: SelectSQLBuilder[Entity] = {
+    buildDefaultJoins(super.defaultSelectQuery)
+  }
+
+  /**
+   * Returns th count query builder for this mapper.
+   *
+   * @return select query builder
+   */
+  override def simpleCountQuery: SelectSQLBuilder[Entity] = {
+    buildDefaultJoins(super.simpleCountQuery)
+  }
+
+  private[this] def buildDefaultJoins(selectQuery: SelectSQLBuilder[Entity]): SelectSQLBuilder[Entity] = {
     // Notice: LinkedHashSet because elements in the order they were inserted
     val definitions = defaultJoinDefinitions.foldLeft(mutable.LinkedHashSet[JoinDefinition[_]]()) { (dfs, df) =>
       val currentName = df.rightAlias.tableAliasName
       val duplicated = dfs.exists(d => d.rightAlias.tableAliasName == currentName)
       if (duplicated) dfs else dfs + df
     }
-    definitions.foldLeft(super.defaultSelectQuery) { (query, join) =>
+    definitions.foldLeft(selectQuery) { (query, join) =>
       join.joinType match {
         case InnerJoin if join.enabledByDefault => query.innerJoin(join.rightMapper.as(join.rightAlias)).on(join.on)
         case LeftOuterJoin if join.enabledByDefault => query.leftJoin(join.rightMapper.as(join.rightAlias)).on(join.on)

--- a/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/AssociationsFeature.scala
@@ -783,4 +783,12 @@ trait AssociationsFeature[Entity]
     )
   }
 
+  def countQueryWithAssociations: SelectSQLBuilder[Entity] = {
+    selectQueryWithAdditionalAssociations(
+      simpleCountQuery,
+      belongsToAssociations,
+      hasOneAssociations,
+      hasManyAssociations
+    )
+  }
 }

--- a/orm/src/main/scala/skinny/orm/feature/NoIdFinderFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/NoIdFinderFeature.scala
@@ -37,7 +37,7 @@ trait NoIdFinderFeature[Entity]
    */
   def countBy(where: SQLSyntax)(implicit s: DBSession = autoSession): Long = {
     withSQL {
-      select(sqls.count).from(as(defaultAlias)).where(where).and(defaultScopeWithDefaultAlias)
+      countQueryWithAssociations.where(where).and(defaultScopeWithDefaultAlias)
     }.map(_.long(1)).single.apply().getOrElse(0L)
   }
 

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -238,6 +238,13 @@ class SkinnyORMSpec extends fixture.FunSpec with Matchers
         Member.countBy(sqls.eq(s.countryId, countryId))) should be > (0L)
     }
 
+    it("should have #countBy(SQLSyntax) with associations joins") { implicit session =>
+      val skillName = Skill.limit(1).offset(0).apply().map(_.name).head
+      println(skillName)
+      val s = Skill.defaultAlias
+      Member.joins[Long](Member.skillsSimpleRef).countBy(sqls.eq(s.name, skillName)) should be > (0L)
+    }
+
     it("should have #updateById(Long)") { implicit session =>
       val countryId = Country.limit(1).offset(0).apply().map(_.id).head
       val memberId = Member.createWithAttributes(

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -238,15 +238,15 @@ class SkinnyORMSpec extends fixture.FunSpec with Matchers
         Member.countBy(sqls.eq(s.countryId, countryId))) should be > (0L)
     }
 
-    it("should have #countBy(SQLSyntax) with associations hasMany(byDefault)") { implicit session =>
+    it("should have #countBy(SQLSyntax) with associations (byDefault)") { implicit session =>
       val n = Name.defaultAlias
-      val mn = Member.mentoreeAlias
-      val bobId = Member.joins(Member.name).findBy(sqls.eq(n.first, "Bob").and.eq(n.last, "Marley"))
+      val mn = Member.mentorAlias
+      val aliceId = Member.findAllBy(sqls.eq(n.first, "Alice").and.eq(n.last, "Cooper")).apply(0).id
 
-      Member.joins[Long](Member.mentorees).countBy(sqls.eq(mn.id, 1)) should be > (0L)
+      Member.joins[Long](Member.mentorees).countBy(sqls.eq(mn.id, aliceId)) should be > (0L)
     }
 
-    it("should have #countBy(SQLSyntax) with associations hasManyThrough") { implicit session =>
+    it("should have #countBy(SQLSyntax) with associations") { implicit session =>
       val skillName = Skill.limit(1).offset(0).apply().map(_.name).head
       val s = Skill.defaultAlias
       Member.joins[Long](Member.skillsSimpleRef).countBy(sqls.eq(s.name, skillName)) should be > (0L)

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -238,9 +238,16 @@ class SkinnyORMSpec extends fixture.FunSpec with Matchers
         Member.countBy(sqls.eq(s.countryId, countryId))) should be > (0L)
     }
 
-    it("should have #countBy(SQLSyntax) with associations joins") { implicit session =>
+    it("should have #countBy(SQLSyntax) with associations hasMany(byDefault)") { implicit session =>
+      val n = Name.defaultAlias
+      val mn = Member.mentoreeAlias
+      val bobId = Member.joins(Member.name).findBy(sqls.eq(n.first, "Bob").and.eq(n.last, "Marley"))
+
+      Member.joins[Long](Member.mentorees).countBy(sqls.eq(mn.id, 1)) should be > (0L)
+    }
+
+    it("should have #countBy(SQLSyntax) with associations hasManyThrough") { implicit session =>
       val skillName = Skill.limit(1).offset(0).apply().map(_.name).head
-      println(skillName)
       val s = Skill.defaultAlias
       Member.joins[Long](Member.skillsSimpleRef).countBy(sqls.eq(s.name, skillName)) should be > (0L)
     }

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -243,7 +243,7 @@ class SkinnyORMSpec extends fixture.FunSpec with Matchers
       val mn = Member.mentorAlias
       val aliceId = Member.findAllBy(sqls.eq(n.first, "Alice").and.eq(n.last, "Cooper")).apply(0).id
 
-      Member.joins[Long](Member.mentorees).countBy(sqls.eq(mn.id, aliceId)) should be > (0L)
+      Member.countBy(sqls.eq(mn.id, aliceId)) should be > (0L)
     }
 
     it("should have #countBy(SQLSyntax) with associations") { implicit session =>


### PR DESCRIPTION
I found joins finder is can't "countBy".
This pull request is correspond patch to that.