### PR TITLE
Bump ScalikeJDBC, Kuromoji versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,17 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion       = "2.4.0"
+lazy val currentVersion       = "2.5.0-SNAPSHOT"
 
 lazy val skinnyMicroVersion   = "1.2.7"
-lazy val scalikeJDBCVersion   = "3.0.2"
+lazy val scalikeJDBCVersion   = "3.1.0"
 lazy val h2Version            = "1.4.196"
-lazy val kuromojiVersion      = "6.6.0"
-lazy val mockitoVersion       = "2.8.47"
+lazy val kuromojiVersion      = "7.0.0"
+lazy val mockitoVersion       = "2.10.0"
 lazy val jettyVersion         = "9.3.20.v20170531"
 lazy val logbackVersion       = "1.2.3"
 lazy val slf4jApiVersion      = "1.7.25"
-lazy val scalaTestVersion     = "3.0.3"
+lazy val scalaTestVersion     = "3.0.4"
 lazy val commonsIoVersion     = "2.5"
 lazy val skinnyLogbackVersion = "1.0.14"
 
@@ -370,7 +370,7 @@ lazy val slf4jApiDependencies = Seq(
 )
 lazy val jodaDependencies = Seq(
   "joda-time" % "joda-time"    % "2.9.9" % Compile,
-  "org.joda"  % "joda-convert" % "1.8.2" % Compile
+  "org.joda"  % "joda-convert" % "1.9"   % Compile
 )
 lazy val mailDependencies = slf4jApiDependencies ++ Seq(
   "javax.mail"              % "mail"          % "1.4.7" % Compile,

--- a/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzerFactory.scala
+++ b/common/src/main/scala/skinny/nlp/SkinnyJapaneseAnalyzerFactory.scala
@@ -3,7 +3,7 @@ package skinny.nlp
 import java.io.{ ByteArrayInputStream, InputStreamReader }
 import org.apache.lucene.analysis.ja.{ JapaneseAnalyzer, JapaneseTokenizer }
 import org.apache.lucene.analysis.ja.dict.UserDictionary
-import org.apache.lucene.analysis.util.CharArraySet
+import org.apache.lucene.analysis.CharArraySet
 import scala.collection.JavaConverters._
 import skinny.util.LoanPattern._
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ fullResolvers ~= { _.filterNot(_.name == "jcenter") }
 addSbtPlugin("io.get-coursier"      % "sbt-coursier"            % "1.0.0-RC11")
 addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.8.0.1")
 addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin"      % "2.1.5")
-addSbtPlugin("com.lucidchart"       % "sbt-scalafmt"            % "1.9")
+addSbtPlugin("com.lucidchart"       % "sbt-scalafmt"            % "1.12")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                 % "1.0.0")
 addSbtPlugin("net.virtual-void"     % "sbt-dependency-graph"    % "0.8.2")
 addSbtPlugin("com.timushev.sbt"     % "sbt-updates"             % "0.3.0")

--- a/skinny-blank-app/build.sbt
+++ b/skinny-blank-app/build.sbt
@@ -13,7 +13,7 @@ val appOrganization = "org.skinny-framework"
 val appName         = "skinny-blank-app"
 val appVersion      = "0.1.0-SNAPSHOT"
 
-val skinnyVersion   = "2.4.0"
+val skinnyVersion   = "2.5.0-SNAPSHOT"
 val theScalaVersion = "2.12.3"
 val jettyVersion    = "9.3.20.v20170531"
 

--- a/skinny-blank-app/project/plugins.sbt
+++ b/skinny-blank-app/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.8.0.1")
 
 // --------
 // format Scala source code automatically
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.9")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.12")
 
 // --------
 // IntelliJ IDEA setting files generator


### PR DESCRIPTION
This pull request upgrades the following:

 - scalikejdbc 3.0 -> 3.1
 - kuromoji 6.6 -> 7.0

If the upgrades work, I will release 2.5.0 with the changes.