### PR TITLE
fix deprecation warnings. s/lines/lineStream/

### DIFF
--- a/assets/src/main/scala/skinny/assets/CoffeeScriptCompiler.scala
+++ b/assets/src/main/scala/skinny/assets/CoffeeScriptCompiler.scala
@@ -39,9 +39,7 @@ case class CoffeeScriptCompiler(bare: Boolean = false) {
 
   private[this] def coffeeCommand = if (isWindows) "coffee.bat" else "coffee"
 
-  // TODO Scala 2.11 method lines in trait ProcessBuilder is deprecated: Use lineStream instead.
-  // lineStream doesn't exist in Scala 2.10
-  private[this] def nativeCompilerDescription = Seq(coffeeCommand, "-v").lines.mkString
+  private[this] def nativeCompilerDescription = Seq(coffeeCommand, "-v").lineStream.mkString
 
   private[this] def nativeCompilerCommand =
     Seq(coffeeCommand, "--compile", "--stdio") ++ (if (bare) Seq("--bare") else Nil)
@@ -55,7 +53,7 @@ case class CoffeeScriptCompiler(bare: Boolean = false) {
       //  at java.lang.Object.wait(Native Method)
       false
     } else {
-      try Seq(coffeeCommand, "-v").lines.size > 0
+      try Seq(coffeeCommand, "-v").lineStream.size > 0
       catch { case e: IOException => false }
     }
   }

--- a/assets/src/main/scala/skinny/assets/LessCompiler.scala
+++ b/assets/src/main/scala/skinny/assets/LessCompiler.scala
@@ -24,7 +24,7 @@ class LessCompiler {
 
   private[this] def lessCommand = if (isWindows) "lessc.bat" else "lessc"
 
-  private[this] def nativeCompilerDescription = Seq(lessCommand, "-v").lines.mkString
+  private[this] def nativeCompilerDescription = Seq(lessCommand, "-v").lineStream.mkString
 
   private[this] def nativeCompilerCommand = Seq(lessCommand, "-") // after "-" read stdin
 
@@ -35,7 +35,7 @@ class LessCompiler {
       //  at java.lang.Object.wait(Native Method)
       false
     } else {
-      try Seq(lessCommand, "-v").lines.size > 0
+      try Seq(lessCommand, "-v").lineStream.size > 0
       catch { case e: IOException => false }
     }
   }

--- a/assets/src/main/scala/skinny/assets/ReactJSXCompiler.scala
+++ b/assets/src/main/scala/skinny/assets/ReactJSXCompiler.scala
@@ -42,7 +42,7 @@ class ReactJSXCompiler {
 
   private[this] def jsxCommand = if (isWindows) "jsx.bat" else "jsx"
 
-  private[this] def nativeCompilerDescription = Seq(jsxCommand, "--version").lines.mkString
+  private[this] def nativeCompilerDescription = Seq(jsxCommand, "--version").lineStream.mkString
 
   private[this] def nativeCompilerCommand = Seq(jsxCommand)
 
@@ -53,7 +53,7 @@ class ReactJSXCompiler {
       //  at java.lang.Object.wait(Native Method)
       false
     } else {
-      try !Seq(jsxCommand, "--version").lines.mkString.isEmpty
+      try !Seq(jsxCommand, "--version").lineStream.mkString.isEmpty
       catch { case e: IOException => false }
     }
   }

--- a/assets/src/main/scala/skinny/assets/SassCompiler.scala
+++ b/assets/src/main/scala/skinny/assets/SassCompiler.scala
@@ -24,7 +24,7 @@ class SassCompiler {
     */
   private[this] def ensureSassCommand() = {
     try {
-      Seq(sassCommand, "-v").lines // > /dev/null
+      Seq(sassCommand, "-v").lineStream // > /dev/null
     } catch {
       case e: IOException =>
         throw new AssetsPrecompileFailureException(


### PR DESCRIPTION
dropped Scala 2.10 support since https://github.com/skinny-framework/skinny-framework/commit/c734b1cd7072858e175e60ee770b74e2a64954ee