### PR TITLE
fix "match may not be exhaustive" warning

### DIFF
--- a/framework/src/main/scala/skinny/controller/feature/SkinnyControllerCommonBase.scala
+++ b/framework/src/main/scala/skinny/controller/feature/SkinnyControllerCommonBase.scala
@@ -128,6 +128,10 @@ trait SkinnyControllerCommonBase
         xs flatMap { v =>
           _toXml(name, v)
         }
+      case JSet(xs) =>
+        xs.flatMap { v =>
+          _toXml(name, v)
+        }(collection.breakOut)
       case JInt(x)     => new XmlElem(name, x.toString)
       case JLong(x)    => new XmlElem(name, x.toString)
       case JDouble(x)  => new XmlElem(name, x.toString)


### PR DESCRIPTION
- https://github.com/json4s/json4s/commit/5dc445ea3499ce5170c019e8bd331b7ddc75f4c1#diff-068ccf519551985c71c4a8dc08c54094R174
- https://github.com/json4s/json4s/blob/357110b7e7668f95c21aa2f5d4779fcf6b47eee7/core/src/main/scala/org/json4s/Xml.scala#L174

```
[warn] /home/travis/build/skinny-framework/skinny-framework/framework/src/main/scala/skinny/controller/feature/SkinnyControllerCommonBase.scala:125: match may not be exhaustive.
[warn] It would fail on the following input: JSet(_)
[warn]     def _toXml(name: String, json: JValue): NodeSeq = json match {
[warn]                                                       ^
```