### PR TITLE
Bump deps' version, get rid of neo-sbt-scalafmt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val skinnyMicroVersion      = "2.0.0"
 lazy val scalikeJDBCVersion      = "3.3.0"
 lazy val h2Version               = "1.4.197"
 lazy val kuromojiVersion         = "7.4.0"
-lazy val mockitoVersion          = "2.20.1"
+lazy val mockitoVersion          = "2.21.0"
 lazy val jettyVersion            = "9.4.11.v20180605"
 lazy val logbackVersion          = "1.2.3"
 lazy val slf4jApiVersion         = "1.7.25"
@@ -21,7 +21,10 @@ lazy val collectionCompatVersion = "0.1.1"
 lazy val baseSettings = Seq(
   organization := "org.skinny-framework",
   version := currentVersion,
-  dependencyOverrides += "org.slf4j" % "slf4j-api" % slf4jApiVersion,
+  dependencyOverrides ++= Seq(
+    "org.slf4j"              % "slf4j-api"  % slf4jApiVersion,
+    "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
+  ),
   resolvers ++= Seq(
     "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
     //, "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
@@ -163,8 +166,8 @@ lazy val orm = (project in file("orm"))
   .settings(
     name := "skinny-orm",
     libraryDependencies ++= scalikejdbcDependencies ++ servletApiDependencies ++ Seq(
-      "org.flywaydb"    % "flyway-core"            % "5.0.7"            % Compile,
-      "org.hibernate"   % "hibernate-core"         % "5.3.3.Final"      % Test,
+      "org.flywaydb"    % "flyway-core"            % "5.1.4"            % Compile,
+      "org.hibernate"   % "hibernate-core"         % "5.3.4.Final"      % Test,
       "org.scalikejdbc" %% "scalikejdbc-joda-time" % scalikeJDBCVersion % Test
     ) ++ testDependencies(scalaVersion.value)
   )
@@ -188,7 +191,7 @@ lazy val freemarker = (project in file("freemarker"))
     name := "skinny-freemarker",
     libraryDependencies ++= servletApiDependencies ++ Seq(
       "commons-beanutils"    % "commons-beanutils"  % "1.9.3"            % Compile,
-      "org.freemarker"       % "freemarker"         % "2.3.23"           % Compile,
+      "org.freemarker"       % "freemarker"         % "2.3.28"           % Compile,
       "org.skinny-framework" %% "skinny-micro-test" % skinnyMicroVersion % Test
     ) ++ testDependencies(scalaVersion.value)
   )

--- a/orm/src/main/scala/skinny/orm/feature/DynamicTableNameFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/DynamicTableNameFeature.scala
@@ -21,10 +21,12 @@ trait DynamicTableNameFeatureWithId[Id, Entity] { self: SkinnyMapperBase[Entity]
     */
   def withTableName(
       tableName: String
-  ): DynamicTableNameFeatureWithId[Id, Entity] with FinderFeatureWithId[Id, Entity] with QueryingFeatureWithId[
-    Id,
-    Entity
-  ] = {
+  ): DynamicTableNameFeatureWithId[Id, Entity]
+    with FinderFeatureWithId[Id, Entity]
+    with QueryingFeatureWithId[
+      Id,
+      Entity
+    ] = {
     val _self            = this
     val dynamicTableName = tableName
 

--- a/orm/src/main/scala/skinny/orm/feature/JoinsFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/JoinsFeature.scala
@@ -20,10 +20,13 @@ trait JoinsFeature[Entity] extends SkinnyMapperBase[Entity] with AssociationsFea
     */
   def joins[Id](
       associations: Association[_]*
-  ): JoinsFeature[Entity] with IdFeature[Id] with FinderFeatureWithId[Id, Entity] with QueryingFeatureWithId[
-    Id,
-    Entity
-  ] = {
+  ): JoinsFeature[Entity]
+    with IdFeature[Id]
+    with FinderFeatureWithId[Id, Entity]
+    with QueryingFeatureWithId[
+      Id,
+      Entity
+    ] = {
     val _self         = this
     val _associations = associations
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ fullResolvers ~= { _.filterNot(_.name == "jcenter") }
 addSbtPlugin("io.get-coursier"      % "sbt-coursier"            % "1.0.3")
 addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.9.0.0")
 addSbtPlugin("org.skinny-framework" % "sbt-servlet-plugin"      % "3.0.4")
-addSbtPlugin("com.lucidchart"       % "sbt-scalafmt"            % "1.15")
+addSbtPlugin("com.geirsson"         % "sbt-scalafmt"            % "1.5.1")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                 % "1.1.2")
 addSbtPlugin("net.virtual-void"     % "sbt-dependency-graph"    % "0.9.1")
 addSbtPlugin("com.timushev.sbt"     % "sbt-updates"             % "0.3.4")

--- a/travis.sh
+++ b/travis.sh
@@ -13,7 +13,7 @@ if [[ "$TEST_TYPE" == "framework" ]]; then
   # sass 3.5 requires Ruby 2.0+
   gem install sass -v 3.4.25 &&
   sbt "example/run db:migrate test" &&
-  sbt ++$TRAVIS_SCALA_VERSION scalafmt::test sbt:scalafmt::test test:scalafmt::test test
+  sbt ++$TRAVIS_SCALA_VERSION scalafmtSbtCheck scalafmtCheck test
 elif [[ "$TEST_TYPE" == "blank-app" && "$TRAVIS_SCALA_VERSION" == 2.12* ]]; then
   export SBT_OPTS="" &&  yes|./run_skinny-blank-app_test.sh
 fi


### PR DESCRIPTION
In this commit, I've upgraded the following libs (only patch versions):

* mockito
* flyway-core
* freemarker
* scalafmt

Also, I've decided to get rid of net-sbt-scalafmt because the sbt plugin is no longer actively maintained.

As the successor, I switched to sbt-scalafmt.