### PR TITLE
Bump Scala 2.12, update JDKs for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ scala:
   - 2.13.0-M4
 jdk:
   - oraclejdk8
-  - openjdk11
+  # TODO: need to fix
+  #- openjdk11
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ language: scala
 sudo: false
 scala:
   - 2.11.12
-  - 2.12.6
+  - 2.12.7
   - 2.13.0-M4
 jdk:
   - oraclejdk8
+  - openjdk11
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 matrix:
   include:
-  - scala: 2.12.6
+  - scala: 2.12.7
     jdk: oraclejdk9
-  - scala: 2.12.6
+  - scala: 2.12.7
     jdk: oraclejdk10
 script: 
   - travis_retry "./travis.sh"

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ lazy val baseSettings = Seq(
   ),
   publishTo := _publishTo(version.value),
   sbtPlugin := false,
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.13.0-M4", "2.12.6", "2.11.12"),
+  scalaVersion := "2.12.7",
+  crossScalaVersions := Seq("2.13.0-M4", "2.12.7", "2.11.12"),
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xfuture"),
   libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
   unmanagedSourceDirectories in Compile += {


### PR DESCRIPTION
This pull request bumps Scala 2.12 to 2.12.7. Also, I've added more JDKs to test.