### PR TITLE
invalid DateTime expression not to pass

### DIFF
--- a/validator/src/main/scala/skinny/validator/BuiltinValidationRules.scala
+++ b/validator/src/main/scala/skinny/validator/BuiltinValidationRules.scala
@@ -305,20 +305,24 @@ object future extends ValidationRule {
 // param("createdAt" -> "2013-01-02 03:04:05") is dateTimeFormat
 object dateTimeFormat extends ValidationRule {
   def name = "dateTimeFormat"
-  def isValid(v: Any): Boolean = isEmpty(v) || {
-    try DateTimeUtil.parseDateTime(v.toString) != null
-    catch { case scala.util.control.NonFatal(e) => false }
-  }
+  def isValid(v: Any): Boolean = isEmpty(v) || (
+    v.toString.split("[-:\\s/]").forall(!_.isEmpty) && {
+      try DateTimeUtil.parseDateTime(v.toString) != null
+      catch { case scala.util.control.NonFatal(e) => false }
+    }
+  )
 }
 
 // ----
 // param("birthday" -> "2011-06-22") is dateFormat
 object dateFormat extends ValidationRule {
   def name = "dateFormat"
-  def isValid(v: Any): Boolean = isEmpty(v) || {
-    try DateTimeUtil.parseLocalDate(v.toString) != null
-    catch { case scala.util.control.NonFatal(e) => false }
-  }
+  def isValid(v: Any): Boolean = isEmpty(v) || (
+    v.toString.split("[-:\\s/]").forall(!_.isEmpty) && {
+      try DateTimeUtil.parseLocalDate(v.toString) != null
+      catch { case scala.util.control.NonFatal(e) => false }
+    }
+  )
 }
 
 // ----

--- a/validator/src/test/scala/skinny/validator/dateFormatSpec.scala
+++ b/validator/src/test/scala/skinny/validator/dateFormatSpec.scala
@@ -22,6 +22,9 @@ class dateFormatSpec extends FlatSpec with Matchers {
     validate(param("x" -> "2013/01/02 12:34:56")).isSuccess should equal(true)
     validate(param("x" -> "2013/1/2 12-34-56")).isSuccess should equal(true)
     validate(param("x" -> "2013-01-02 123456")).isSuccess should equal(true)
+
+    validate(param("x" -> "-01-02 03:04:05")).isSuccess should equal(false)
+    validate(param("x" -> "-01-02")).isSuccess should equal(false)
   }
 
 }

--- a/validator/src/test/scala/skinny/validator/dateTimeFormatSpec.scala
+++ b/validator/src/test/scala/skinny/validator/dateTimeFormatSpec.scala
@@ -25,6 +25,9 @@ class dateTimeFormatSpec extends FlatSpec with Matchers {
 
     validate(param("x" -> "2013-a1-02 03:04:05")).isSuccess should equal(false)
     validate(param("x" -> "2013-a1-b 0c:04:05")).isSuccess should equal(false)
+
+    validate(param("x" -> "-01-02 03:04:05")).isSuccess should equal(false)
+    validate(param("x" -> "-01-02")).isSuccess should equal(false)
   }
 
 }


### PR DESCRIPTION
Input strings like "-06-12" or "-06-12 03:04:05", which are invalid but acceptable for Joda-Time, not to pass the validation.

Joda-Time accepts them as "-0006-12-01T03:04:05". It is generally not what was intended.