### PR TITLE
Get rid of Symbol in the framework since v4

### DIFF
--- a/assets/src/main/scala/skinny/controller/AssetsController.scala
+++ b/assets/src/main/scala/skinny/controller/AssetsController.scala
@@ -428,7 +428,7 @@ class AssetsController extends SkinnyController {
 object AssetsController extends AssetsController with Routes {
 
   // Unfortunately, *.* seems not to work.
-  val jsRootUrl  = get(s"${jsRootPath}/*")(js).as(Symbol("js"))
-  val cssRootUrl = get(s"${cssRootPath}/*")(css).as(Symbol("css"))
+  val jsRootUrl  = get(s"${jsRootPath}/*")(js).as("js")
+  val cssRootUrl = get(s"${cssRootPath}/*")(css).as("css")
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import skinny.servlet._, ServletPlugin._, ServletKeys._
 
 import scala.language.postfixOps
 
-lazy val currentVersion = "3.2.0"
+lazy val currentVersion = "4.0.0-SNAPSHOT"
 
 lazy val skinnyMicroVersion = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/example/src/main/scala/controller/Controllers.scala
+++ b/example/src/main/scala/controller/Controllers.scala
@@ -47,116 +47,116 @@ object Controllers {
   object companies extends CompaniesController {}
 
   object root extends RootController with Routes {
-    val indexUrl        = get("/")(index).as(Symbol("index"))
-    val sessionRenewUrl = get("/session/renew")(renewSessionAttributes).as(Symbol("sessionRenew"))
-    val errorUrl        = get("/error")(errorExample).as(Symbol("error"))
-    val reactUrl        = get("/react")(reactExample).as(Symbol("react"))
-    val nestedI18nUrl   = get("/nested-i18n")(nestedI18nExample).as(Symbol("nestedI18n"))
-    val invalidateUrl   = get("/invalidate")(invalidateExample).as(Symbol("invalidate"))
+    val indexUrl        = get("/")(index).as("index")
+    val sessionRenewUrl = get("/session/renew")(renewSessionAttributes).as("sessionRenew")
+    val errorUrl        = get("/error")(errorExample).as("error")
+    val reactUrl        = get("/react")(reactExample).as("react")
+    val nestedI18nUrl   = get("/nested-i18n")(nestedI18nExample).as("nestedI18n")
+    val invalidateUrl   = get("/invalidate")(invalidateExample).as("invalidate")
   }
 
   object programmers extends ProgrammersController with Routes {
-    val joinCompanyUrl  = post("/programmers/:programmerId/company/:companyId")(joinCompany).as(Symbol("joinCompany"))
-    val leaveCompanyUrl = delete("/programmers/:programmerId/company")(leaveCompany).as(Symbol("leaveCompany"))
-    val addSkillUrl     = post("/programmers/:programmerId/skills/:skillId")(addSkill).as(Symbol("addSkill"))
-    val deleteSkillUrl  = delete("/programmers/:programmerId/skills/:skillId")(deleteSkill).as(Symbol("deleteSkill"))
+    val joinCompanyUrl  = post("/programmers/:programmerId/company/:companyId")(joinCompany).as("joinCompany")
+    val leaveCompanyUrl = delete("/programmers/:programmerId/company")(leaveCompany).as("leaveCompany")
+    val addSkillUrl     = post("/programmers/:programmerId/skills/:skillId")(addSkill).as("addSkill")
+    val deleteSkillUrl  = delete("/programmers/:programmerId/skills/:skillId")(deleteSkill).as("deleteSkill")
   }
 
   object customLayout extends CustomLayoutController with Routes {
-    val indexUrl   = get("/custom-layout/?".r)(index).as(Symbol("index"))
-    val defaultUrl = get("/custom-layout/default")(default).as(Symbol("default"))
-    val barUrl     = get("/custom-layout/bar")(bar).as(Symbol("bar"))
+    val indexUrl   = get("/custom-layout/?".r)(index).as("index")
+    val defaultUrl = get("/custom-layout/default")(default).as("default")
+    val barUrl     = get("/custom-layout/bar")(bar).as("bar")
   }
 
   object mail extends MailController with Routes {
-    val indexUrl = get("/mail/")(index).as(Symbol("index"))
-    val sspUrl   = get("/mail/ssp")(ssp).as(Symbol("ssp"))
+    val indexUrl = get("/mail/")(index).as("index")
+    val sspUrl   = get("/mail/ssp")(ssp).as("ssp")
   }
 
   object mustache extends MustacheController with Routes {
-    val indexUrl = get("/mustache/?".r)(index).as(Symbol("index"))
+    val indexUrl = get("/mustache/?".r)(index).as("index")
   }
 
   object thymeleaf extends ThymeleafController with Routes {
-    val indexUrl = get("/thymeleaf/?".r)(index).as(Symbol("index"))
+    val indexUrl = get("/thymeleaf/?".r)(index).as("index")
   }
   object freemarker extends FreeMarkerController with Routes {
-    val indexUrl = get("/freemarker/?".r)(index).as(Symbol("index"))
+    val indexUrl = get("/freemarker/?".r)(index).as("index")
   }
 
   object sampleApi extends SampleApiController with Routes {
-    val createCompanyUrl = post("/api/companies")(createCompany).as(Symbol("createCompany"))
-    val companiesUrl     = get("/api/companies")(companiesJson).as(Symbol("companies"))
+    val createCompanyUrl = post("/api/companies")(createCompany).as("createCompany")
+    val companiesUrl     = get("/api/companies")(companiesJson).as("companies")
   }
   object sampleTxApi extends SampleTxApiController with Routes {
-    get("/api/error")(index).as(Symbol("index"))
+    get("/api/error")(index).as("index")
   }
 
   object fileUpload extends FileUploadController with Routes {
-    val formUrl   = get("/fileupload")(form).as(Symbol("form"))
-    val submitUrl = post("/fileupload/submit")(submit).as(Symbol("submit"))
+    val formUrl   = get("/fileupload")(form).as("form")
+    val submitUrl = post("/fileupload/submit")(submit).as("submit")
   }
   object fileDownload extends FileDownloadController with Routes {
-    val indexUrl = get("/filedownload")(index).as(Symbol("index"))
-    val smallUrl = get("/filedownload/small")(small).as(Symbol("small"))
-    val nullUrl  = get("/filedownload/null")(nullValue).as(Symbol("null"))
-    val errorUrl = get("/filedownload/error")(error).as(Symbol("error"))
+    val indexUrl = get("/filedownload")(index).as("index")
+    val smallUrl = get("/filedownload/small")(small).as("small")
+    val nullUrl  = get("/filedownload/null")(nullValue).as("null")
+    val errorUrl = get("/filedownload/error")(error).as("error")
   }
 
   object dashboard extends DashboardController with Routes {
-    val indexUrl = get("/dashboard/")(index).as(Symbol("index"))
+    val indexUrl = get("/dashboard/")(index).as("index")
   }
 
   object angularApp extends AngularAppController with Routes {
-    val indexUrl       = get("/angular/app")(index).as(Symbol("index"))
-    val programmersUrl = get("/angular/programmers/")(programmers).as(Symbol("programmers"))
+    val indexUrl       = get("/angular/app")(index).as("index")
+    val programmersUrl = get("/angular/programmers/")(programmers).as("programmers")
   }
 
   object facebook extends FacebookController with Routes {
-    val loginUrl    = get("/facebook")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/facebook/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/facebook/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/facebook")(loginRedirect).as("login")
+    val callbackUrl = get("/facebook/callback")(callback).as("callback")
+    val okUrl       = get("/facebook/ok")(ok).as("ok")
   }
 
   object github extends GitHubController with Routes {
-    val loginUrl    = get("/github")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/github/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/github/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/github")(loginRedirect).as("login")
+    val callbackUrl = get("/github/callback")(callback).as("callback")
+    val okUrl       = get("/github/ok")(ok).as("ok")
   }
 
   object google extends GoogleController with Routes {
-    val loginUrl    = get("/google")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/google/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/google/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/google")(loginRedirect).as("login")
+    val callbackUrl = get("/google/callback")(callback).as("callback")
+    val okUrl       = get("/google/ok")(ok).as("ok")
   }
 
   object twitter extends TwitterController with Routes {
-    val loginUrl    = get("/twitter")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/twitter/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/twitter/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/twitter")(loginRedirect).as("login")
+    val callbackUrl = get("/twitter/callback")(callback).as("callback")
+    val okUrl       = get("/twitter/ok")(ok).as("ok")
   }
 
   object typetalk extends TypetalkController with Routes {
-    val loginUrl    = get("/typetalk")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/typetalk/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/typetalk/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/typetalk")(loginRedirect).as("login")
+    val callbackUrl = get("/typetalk/callback")(callback).as("callback")
+    val okUrl       = get("/typetalk/ok")(ok).as("ok")
   }
 
   object dropbox extends DropboxController with Routes {
-    val loginUrl    = get("/dropbox")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/dropbox/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/dropbox/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/dropbox")(loginRedirect).as("login")
+    val callbackUrl = get("/dropbox/callback")(callback).as("callback")
+    val okUrl       = get("/dropbox/ok")(ok).as("ok")
   }
 
   object backlog extends BacklogController with Routes {
-    val loginUrl    = get("/backlog")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/backlog/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/backlog/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/backlog")(loginRedirect).as("login")
+    val callbackUrl = get("/backlog/callback")(callback).as("callback")
+    val okUrl       = get("/backlog/ok")(ok).as("ok")
   }
   object backlogJp extends BacklogJPController with Routes {
-    val loginUrl    = get("/backlogjp")(loginRedirect).as(Symbol("login"))
-    val callbackUrl = get("/backlogjp/callback")(callback).as(Symbol("callback"))
-    val okUrl       = get("/backlogjp/ok")(ok).as(Symbol("ok"))
+    val loginUrl    = get("/backlogjp")(loginRedirect).as("login")
+    val callbackUrl = get("/backlogjp/callback")(callback).as("callback")
+    val okUrl       = get("/backlogjp/ok")(ok).as("ok")
   }
 
 }

--- a/example/src/main/scala/controller/ErrorController.scala
+++ b/example/src/main/scala/controller/ErrorController.scala
@@ -11,14 +11,14 @@ object ErrorController extends ApplicationController with TxPerRequestFilter wit
     throw new RuntimeException
   }
 
-  val runtimeUrl = get("/error/runtime")(runtime).as(Symbol("errorPage"))
+  val runtimeUrl = get("/error/runtime")(runtime).as("errorPage")
 
   get("/error/rollback") {
-    Company.createWithAttributes(Symbol("name") -> "Typesafe", Symbol("createdAt") -> DateTime.now)
+    Company.createWithAttributes("name" -> "Typesafe", "createdAt" -> DateTime.now)
 
     rollbackTxPerRequest
     logger.info("Transaction should be rolled back.")
 
-  }.as(Symbol("rollbackPage"))
+  }.as("rollbackPage")
 
 }

--- a/example/src/main/scala/controller/ProgrammersController.scala
+++ b/example/src/main/scala/controller/ProgrammersController.scala
@@ -15,13 +15,7 @@ class ProgrammersController extends SkinnyResource with ApplicationController {
   override def itemName  = resourceName
 
   beforeAction(
-    only = Seq(Symbol("index"),
-               Symbol("indexWithSlash"),
-               Symbol("new"),
-               Symbol("create"),
-               Symbol("createWithSlash"),
-               Symbol("edit"),
-               Symbol("update"))
+    only = Seq("index", "indexWithSlash", "new", "create", "createWithSlash", "edit", "update")
   ) {
     set("companies", Company.findAll())
     set("skills", Skill.findAll())

--- a/example/src/main/scala/controller/SkillsController.scala
+++ b/example/src/main/scala/controller/SkillsController.scala
@@ -36,6 +36,6 @@ object SkillsController
     "ok"
   }
 
-  get("/skills/skinny-session-bug")(skinnySessionBug).as(Symbol("bug"))
+  get("/skills/skinny-session-bug")(skinnySessionBug).as("bug")
 
 }

--- a/example/src/test/scala/integrationtest/AngularXHRProgrammersControllerSpec.scala
+++ b/example/src/test/scala/integrationtest/AngularXHRProgrammersControllerSpec.scala
@@ -22,7 +22,7 @@ class AngularXHRProgrammersControllerSpec extends SkinnyFlatSpec with unit.Skinn
 
   it should "accept resource list request" in {
     val programmer = Programmer.findAllWithLimitOffset(1, 0).headOption.getOrElse {
-      FactoryGirl(Programmer).create(Symbol("name") -> "Alice")
+      FactoryGirl(Programmer).create("name" -> "Alice")
     }
     get("/angular/programmers.json") {
       logger.debug(body)

--- a/example/src/test/scala/integrationtest/ProgrammersControllerSpec.scala
+++ b/example/src/test/scala/integrationtest/ProgrammersControllerSpec.scala
@@ -106,7 +106,7 @@ class ProgrammersControllerSpec extends SkinnyFlatSpec with unit.SkinnyTesting {
   }
 
   it should "delete a programmer" in {
-    val id = Programmer.createWithAttributes(Symbol("name") -> "Unit Test Programmer", Symbol("favoriteNumber") -> 123)
+    val id = Programmer.createWithAttributes("name" -> "Unit Test Programmer", "favoriteNumber" -> 123)
     delete(s"/programmers/${id}") {
       status should equal(403)
     }
@@ -130,7 +130,7 @@ class ProgrammersControllerSpec extends SkinnyFlatSpec with unit.SkinnyTesting {
 
   it should "add a programmer to a company" in {
     val id =
-      Programmer.createWithAttributes(Symbol("name") -> "JoinCompany Test Programmer", Symbol("favoriteNumber") -> 123)
+      Programmer.createWithAttributes("name" -> "JoinCompany Test Programmer", "favoriteNumber" -> 123)
     try {
       withSession("csrf-token" -> "aaaaaa") {
         post(s"/programmers/${id}/company/${company.id}", "csrf-token" -> "aaaaaa") {
@@ -144,7 +144,7 @@ class ProgrammersControllerSpec extends SkinnyFlatSpec with unit.SkinnyTesting {
 
   it should "remove a programmer from a company" in {
     val id =
-      Programmer.createWithAttributes(Symbol("name") -> "LeaveCompany Test Programmer", Symbol("favoriteNumber") -> 123)
+      Programmer.createWithAttributes("name" -> "LeaveCompany Test Programmer", "favoriteNumber" -> 123)
     try {
       withSession("csrf-token" -> "aaaaaa") {
         post(s"/programmers/${id}/company/${company.id}", "csrf-token" -> "aaaaaa") {

--- a/example/src/test/scala/integrationtest/RootControllerSpec.scala
+++ b/example/src/test/scala/integrationtest/RootControllerSpec.scala
@@ -15,7 +15,7 @@ class RootControllerSpec extends SkinnyFlatSpec with unit.SkinnyTesting {
   addFilter(ErrorController, "/*")
   addFilter(new RootController with Routes {
     override val echoService = new EchoServiceMock
-    get("/mock/?".r)(index).as(Symbol("index"))
+    get("/mock/?".r)(index).as("index")
   }, "/*")
 
   it should "show top page" in {

--- a/factory-girl/src/test/scala/blog/BlogSpec.scala
+++ b/factory-girl/src/test/scala/blog/BlogSpec.scala
@@ -9,17 +9,17 @@ import skinny.logging.Logging
 
 class BlogSpec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback with Logging {
 
-  override def db(): DB = NamedDB(Symbol("fg")).toDB()
+  override def db(): DB = NamedDB("fg").toDB()
 
   describe("variables") {
     it("should be available") { implicit session =>
-      val post = FactoryGirl(Post).withVariables(Symbol("name") -> "Kaz").create()
+      val post = FactoryGirl(Post).withVariables("name" -> "Kaz").create()
       post.title should equal("I just started this blog")
       post.body should equal("Hello, everyone! My name is Kaz. And bulah bulah...")
     }
 
     it("should be available with string interpolation") { implicit session =>
-      val post = FactoryGirl(Post, Symbol("post2")).withVariables(Symbol("name") -> "Kaz").create()
+      val post = FactoryGirl(Post, "post2").withVariables("name" -> "Kaz").create()
       post.title should equal("I just started this blog")
       post.body should not equal ("Hello, everyone! My name is Kaz. And bulah bulah... ${System.currentTimeMillis}")
     }
@@ -39,7 +39,7 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
   describe("non-string values") {
     it("should be accepted") { implicit session =>
       intercept[Exception] {
-        FactoryGirl(Post).create(Symbol("name") -> None) // should not accepted as 'None'
+        FactoryGirl(Post).create("name" -> None) // should not accepted as 'None'
       }
     }
   }

--- a/factory-girl/src/test/scala/blog/Connection.scala
+++ b/factory-girl/src/test/scala/blog/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("fg"), "jdbc:h2:mem:fg", "sa", "sa")
+  ConnectionPool.add("fg", "jdbc:h2:mem:fg", "sa", "sa")
 }

--- a/factory-girl/src/test/scala/blog/CreateTables.scala
+++ b/factory-girl/src/test/scala/blog/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("fg"))
+  override val dbSeedsAutoSession = NamedAutoSession("fg")
 
   addSeedSQL(
     sql"""

--- a/factory-girl/src/test/scala/blog/Post.scala
+++ b/factory-girl/src/test/scala/blog/Post.scala
@@ -15,7 +15,7 @@ case class Post(
 )
 
 object Post extends SkinnyCRUDMapper[Post] with TimestampsFeature[Post] {
-  override val connectionPoolName = Symbol("fg")
+  override val connectionPoolName = "fg"
   override val tableName          = "posts"
   override val defaultAlias       = createAlias("p")
 

--- a/factory-girl/src/test/scala/blog/PostTag.scala
+++ b/factory-girl/src/test/scala/blog/PostTag.scala
@@ -12,7 +12,7 @@ case class PostTag(
 )
 
 object PostTag extends SkinnyJoinTable[PostTag] {
-  override val connectionPoolName = Symbol("fg")
+  override val connectionPoolName = "fg"
   override val tableName          = "posts_tags"
   override val defaultAlias       = createAlias("pt")
 

--- a/factory-girl/src/test/scala/blog/Tag.scala
+++ b/factory-girl/src/test/scala/blog/Tag.scala
@@ -12,7 +12,7 @@ case class Tag(
 )
 
 object Tag extends SkinnyCRUDMapper[Tag] with TimestampsFeature[Tag] {
-  override val connectionPoolName = Symbol("fg")
+  override val connectionPoolName = "fg"
   override val tableName          = "tags"
   override val defaultAlias       = createAlias("t")
 

--- a/factory-girl/src/test/scala/sysadmin/Connection.scala
+++ b/factory-girl/src/test/scala/sysadmin/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("sysadmin"), "jdbc:h2:mem:sysadmin", "sa", "sa")
+  ConnectionPool.add("sysadmin", "jdbc:h2:mem:sysadmin", "sa", "sa")
 }

--- a/factory-girl/src/test/scala/sysadmin/CreateTables.scala
+++ b/factory-girl/src/test/scala/sysadmin/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("sysadmin"))
+  override val dbSeedsAutoSession = NamedAutoSession("sysadmin")
 
   addSeedSQL(
     sql"""

--- a/factory-girl/src/test/scala/sysadmin/SystemAdminSpec.scala
+++ b/factory-girl/src/test/scala/sysadmin/SystemAdminSpec.scala
@@ -14,7 +14,7 @@ class userAdminSpec
     with AutoRollback
     with Logging {
 
-  override def db(): DB = NamedDB(Symbol("sysadmin")).toDB()
+  override def db(): DB = NamedDB("sysadmin").toDB()
 
   describe("factory.conf") {
     it("should be available") { implicit session =>
@@ -28,7 +28,7 @@ class userAdminSpec
   describe("with os/java/user attributes") {
     it("should be available") { implicit session =>
       val user = FactoryGirl(User)
-        .withAttributes(Symbol("os") -> "MacOS X", Symbol("java") -> "8", Symbol("user") -> "sera")
+        .withAttributes("os" -> "MacOS X", "java" -> "8", "user" -> "sera")
         .create()
       user.os should equal("MacOS X")
       user.java should equal("8")

--- a/factory-girl/src/test/scala/sysadmin/User.scala
+++ b/factory-girl/src/test/scala/sysadmin/User.scala
@@ -7,7 +7,7 @@ case class User(id: Long, os: String, java: String, user: String)
 
 object User extends SkinnyCRUDMapper[User] {
 
-  override val connectionPoolName = Symbol("sysadmin")
+  override val connectionPoolName = "sysadmin"
   override def defaultAlias       = createAlias("u")
 
   override def extract(rs: WrappedResultSet, n: ResultName[User]): User = new User(

--- a/factory-girl/src/test/scala/whitespace/BlogSpec.scala
+++ b/factory-girl/src/test/scala/whitespace/BlogSpec.scala
@@ -9,21 +9,21 @@ import skinny.logging.Logging
 
 class BlogSpec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback with Logging {
 
-  override def db(): DB = NamedDB(Symbol("ws")).toDB()
+  override def db(): DB = NamedDB("ws").toDB()
 
   describe("variables") {
     it("should be available") { implicit session =>
       val fg = FactoryGirl(Post)
       fg.factoriesDir = "foo bar baz"
-      val post = fg.withVariables(Symbol("name") -> "Kaz").create()
+      val post = fg.withVariables("name" -> "Kaz").create()
       post.title should equal("I just started this blog")
       post.body should equal("Hello, everyone! My name is Kaz. And bulah bulah...")
     }
 
     it("should be available with string interpolation") { implicit session =>
-      val fg = FactoryGirl(Post, Symbol("post2"))
+      val fg = FactoryGirl(Post, "post2")
       fg.factoriesDir = "foo bar baz"
-      val post = fg.withVariables(Symbol("name") -> "Kaz").create()
+      val post = fg.withVariables("name" -> "Kaz").create()
       post.title should equal("I just started this blog")
       post.body should not equal ("Hello, everyone! My name is Kaz. And bulah bulah... ${System.currentTimeMillis}")
     }
@@ -47,7 +47,7 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
       intercept[Exception] {
         val fg = FactoryGirl(Post)
         fg.factoriesDir = "foo bar baz"
-        fg.create(Symbol("name") -> None) // should not accepted as 'None'
+        fg.create("name" -> None) // should not accepted as 'None'
       }
     }
   }

--- a/factory-girl/src/test/scala/whitespace/Connection.scala
+++ b/factory-girl/src/test/scala/whitespace/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("ws"), "jdbc:h2:mem:ws", "sa", "sa")
+  ConnectionPool.add("ws", "jdbc:h2:mem:ws", "sa", "sa")
 }

--- a/factory-girl/src/test/scala/whitespace/CreateTables.scala
+++ b/factory-girl/src/test/scala/whitespace/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("ws"))
+  override val dbSeedsAutoSession = NamedAutoSession("ws")
 
   addSeedSQL(
     sql"""

--- a/factory-girl/src/test/scala/whitespace/Post.scala
+++ b/factory-girl/src/test/scala/whitespace/Post.scala
@@ -15,7 +15,7 @@ case class Post(
 )
 
 object Post extends SkinnyCRUDMapper[Post] with TimestampsFeature[Post] {
-  override val connectionPoolName = Symbol("ws")
+  override val connectionPoolName = "ws"
   override val tableName          = "posts"
   override val defaultAlias       = createAlias("p")
 

--- a/factory-girl/src/test/scala/whitespace/PostTag.scala
+++ b/factory-girl/src/test/scala/whitespace/PostTag.scala
@@ -12,7 +12,7 @@ case class PostTag(
 )
 
 object PostTag extends SkinnyJoinTable[PostTag] {
-  override val connectionPoolName = Symbol("ws")
+  override val connectionPoolName = "ws"
   override val tableName          = "posts_tags"
   override val defaultAlias       = createAlias("pt")
 

--- a/factory-girl/src/test/scala/whitespace/Tag.scala
+++ b/factory-girl/src/test/scala/whitespace/Tag.scala
@@ -12,7 +12,7 @@ case class Tag(
 )
 
 object Tag extends SkinnyCRUDMapper[Tag] with TimestampsFeature[Tag] {
-  override val connectionPoolName = Symbol("ws")
+  override val connectionPoolName = "ws"
   override val tableName          = "tags"
   override val defaultAlias       = createAlias("t")
 

--- a/framework/src/main/scala/skinny/controller/ActionDefinition.scala
+++ b/framework/src/main/scala/skinny/controller/ActionDefinition.scala
@@ -5,15 +5,15 @@ import skinny.micro.constant.HttpMethod
 /**
   * Action definition.
   *
-  * Action represents a tuple of symbol name, HTTP method and path matcher.
+  * Action represents a tuple of the name, HTTP method and path matcher.
   * For example, actions will be used for predicating filters should be applied.
   *
-  * @param name symbol value for this action method
+  * @param name name for this action method
   * @param method http method
   * @param matcher path matcher
   */
 case class ActionDefinition(
-    name: Symbol,
+    name: String,
     method: HttpMethod,
     matcher: (HttpMethod, String) => Boolean
 )

--- a/framework/src/main/scala/skinny/controller/SkinnyApiResourceRoutes.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyApiResourceRoutes.scala
@@ -36,7 +36,7 @@ trait SkinnyApiResourceRoutes[Id] extends SkinnyControllerBase with RoutesAsImpl
   val createApiUrl = post(s"${resourcesBasePath}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     createApiAction
-  }).as(Symbol("createApi"))
+  }).as("createApi")
 
   protected def createApiAction =
     params.get("ext").map {
@@ -51,7 +51,7 @@ trait SkinnyApiResourceRoutes[Id] extends SkinnyControllerBase with RoutesAsImpl
   val indexApiUrl: Route = get(s"${resourcesBasePath}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     indexApiAction
-  }).as(Symbol("indexApi"))
+  }).as("indexApi")
 
   protected def indexApiAction =
     (for {
@@ -73,7 +73,7 @@ trait SkinnyApiResourceRoutes[Id] extends SkinnyControllerBase with RoutesAsImpl
     get(s"${resourcesBasePath}/:${idParamName}.:ext")({
       setContentTypeFromSkinnyApiResourceExtParam
       showApiAction
-    }).as(Symbol("showApi"))
+    }).as("showApi")
   }
   protected def showApiAction =
     (for {
@@ -93,17 +93,17 @@ trait SkinnyApiResourceRoutes[Id] extends SkinnyControllerBase with RoutesAsImpl
   val updatePostApiUrl = post(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
 
   val updatePutApiUrl = put(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
 
   val updatePatchApiUrl = patch(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
 
   protected def updateApiAction = {
     params
@@ -128,7 +128,7 @@ trait SkinnyApiResourceRoutes[Id] extends SkinnyControllerBase with RoutesAsImpl
   val destroyApiUrl = delete(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     deleteApiAction
-  }).as(Symbol("destroyApi"))
+  }).as("destroyApi")
 
   protected def deleteApiAction = {
     params

--- a/framework/src/main/scala/skinny/controller/SkinnyResourceRoutes.scala
+++ b/framework/src/main/scala/skinny/controller/SkinnyResourceRoutes.scala
@@ -11,12 +11,12 @@ trait SkinnyResourceRoutes[Id] extends SkinnyApiResourceRoutes[Id] with Routes {
   // --------------
   // show
 
-  val indexUrl          = get(s"${resourcesBasePath}")(showResources()).as(Symbol("index"))
-  val indexWithSlashUrl = get(s"${resourcesBasePath}/")(showResources()).as(Symbol("index"))
+  val indexUrl          = get(s"${resourcesBasePath}")(showResources()).as("index")
+  val indexWithSlashUrl = get(s"${resourcesBasePath}/")(showResources()).as("index")
 
   val showUrl = get(s"${resourcesBasePath}/:${idParamName}") {
     params.getAs[Id](idParamName).map(id => showResource(id)).getOrElse(haltWithBody(404))
-  }.as(Symbol("show"))
+  }.as("show")
 
   // Scalatra takes priority to route definition which is defined later.
   // So showExtUrl is defined again here.
@@ -25,21 +25,21 @@ trait SkinnyResourceRoutes[Id] extends SkinnyApiResourceRoutes[Id] with Routes {
   // --------------
   // create
   // Scalatra takes priority to route definition which is defined later.
-  val newUrl = get(s"${resourcesBasePath}/new")(newResource).as(Symbol("new"))
+  val newUrl = get(s"${resourcesBasePath}/new")(newResource).as("new")
 
-  val createUrl          = post(s"${resourcesBasePath}")(createResource).as(Symbol("create"))
-  val createWithSlashUrl = post(s"${resourcesBasePath}/")(createResource).as(Symbol("create"))
+  val createUrl          = post(s"${resourcesBasePath}")(createResource).as("create")
+  val createWithSlashUrl = post(s"${resourcesBasePath}/")(createResource).as("create")
 
   // --------------
   // update
 
   val editUrl = get(s"${resourcesBasePath}/:${idParamName}/edit") {
     params.getAs[Id](idParamName).map(id => editResource(id)) getOrElse haltWithBody(404)
-  }.as(Symbol("edit"))
+  }.as("edit")
 
-  val updatePostUrl  = post(s"${resourcesBasePath}/:${idParamName}")(updateAction).as(Symbol("update"))
-  val updateUrl      = put(s"${resourcesBasePath}/:${idParamName}")(updateAction).as(Symbol("update"))
-  val updatePatchUrl = patch(s"${resourcesBasePath}/:${idParamName}")(updateAction).as(Symbol("update"))
+  val updatePostUrl  = post(s"${resourcesBasePath}/:${idParamName}")(updateAction).as("update")
+  val updateUrl      = put(s"${resourcesBasePath}/:${idParamName}")(updateAction).as("update")
+  val updatePatchUrl = patch(s"${resourcesBasePath}/:${idParamName}")(updateAction).as("update")
 
   protected def updateAction = {
     params.getAs[Id](idParamName).map(id => updateResource(id)) getOrElse haltWithBody(404)
@@ -48,7 +48,7 @@ trait SkinnyResourceRoutes[Id] extends SkinnyApiResourceRoutes[Id] with Routes {
   // --------------
   // delete
 
-  val destroyUrl = delete(s"${resourcesBasePath}/:${idParamName}")(deleteAction).as(Symbol("destroy"))
+  val destroyUrl = delete(s"${resourcesBasePath}/:${idParamName}")(deleteAction).as("destroy")
 
   protected def deleteAction = {
     params.getAs[Id](idParamName).map(id => destroyResource(id)) getOrElse haltWithBody(404)
@@ -59,25 +59,25 @@ trait SkinnyResourceRoutes[Id] extends SkinnyApiResourceRoutes[Id] with Routes {
   post(s"${resourcesBasePath}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     createApiAction
-  }).as(Symbol("createApi"))
+  }).as("createApi")
 
   post(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
   put(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
   patch(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     updateApiAction
-  }).as(Symbol("updateApi"))
+  }).as("updateApi")
 
   delete(s"${resourcesBasePath}/:${idParamName}.:ext")({
     setContentTypeFromSkinnyApiResourceExtParam
     deleteApiAction
-  }).as(Symbol("destroyApi"))
+  }).as("destroyApi")
   // ###########################
 
 }

--- a/framework/src/main/scala/skinny/controller/feature/ActionDefinitionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/ActionDefinitionFeature.scala
@@ -31,7 +31,7 @@ trait ActionDefinitionFeature extends SkinnyMicroBase {
     *
     * @return action name
     */
-  def currentActionName(implicit cxt: SkinnyContext = context): Option[Symbol] = {
+  def currentActionName(implicit cxt: SkinnyContext = context): Option[String] = {
     // Scalatra takes priority to routing definition which is defined later.
     // So we should take priority to the first action name found from reversed action definitions here.
     actionDefinitions.reverse

--- a/framework/src/main/scala/skinny/controller/feature/AngularXSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/AngularXSRFProtectionFeature.scala
@@ -24,12 +24,12 @@ trait AngularXSRFProtectionFeature extends AngularXSRFCookieProviderFeature {
   /**
     * Excluded actions.
     */
-  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Included actions.
     */
-  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Cookie name.
@@ -47,7 +47,7 @@ trait AngularXSRFProtectionFeature extends AngularXSRFCookieProviderFeature {
     * @param only should be applied only for these action methods
     * @param except should not be applied for these action methods
     */
-  def protectFromForgery(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil): Unit = {
+  def protectFromForgery(only: Seq[String] = Nil, except: Seq[String] = Nil): Unit = {
     forgeryProtectionEnabled = true
     forgeryProtectionIncludedActionNames ++= only
     forgeryProtectionExcludedActionNames ++= except

--- a/framework/src/main/scala/skinny/controller/feature/AsyncBeforeAfterActionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/AsyncBeforeAfterActionFeature.scala
@@ -25,7 +25,7 @@ trait AsyncBeforeAfterActionFeature extends SkinnyMicroBase with AsyncBeforeAfte
   /**
     * If you prefer #beforeFilter than #beforeAction, keep going!
     */
-  def beforeFilter(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: (Context) => Any): Unit = {
+  def beforeFilter(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: (Context) => Any): Unit = {
     beforeAction(only, except)(action)
   }
 
@@ -36,7 +36,7 @@ trait AsyncBeforeAfterActionFeature extends SkinnyMicroBase with AsyncBeforeAfte
     * @param except this action should not be applied for these action methods
     * @param action action
     */
-  def beforeAction(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: (Context) => Any): Unit = {
+  def beforeAction(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: (Context) => Any): Unit = {
     skinnyBeforeActions += (
         (ctx) => {
           currentActionName.map { name =>
@@ -55,7 +55,7 @@ trait AsyncBeforeAfterActionFeature extends SkinnyMicroBase with AsyncBeforeAfte
   /**
     * If you prefer #afterFilter than #afterAction, keep going!
     */
-  def afterFilter(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: (Context) => Any): Unit = {
+  def afterFilter(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: (Context) => Any): Unit = {
     afterAction(only, except)(action)
   }
 
@@ -66,7 +66,7 @@ trait AsyncBeforeAfterActionFeature extends SkinnyMicroBase with AsyncBeforeAfte
     * @param except this action should not be applied for these action methods
     * @param action action
     */
-  def afterAction(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: (Context) => Any): Unit = {
+  def afterAction(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: (Context) => Any): Unit = {
     skinnyAfterActions += (
         (ctx) => {
           currentActionName.map { name =>

--- a/framework/src/main/scala/skinny/controller/feature/AsyncCSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/AsyncCSRFProtectionFeature.scala
@@ -36,12 +36,12 @@ trait AsyncCSRFProtectionFeature extends AsyncCSRFTokenSupport {
   /**
     * Excluded actions.
     */
-  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Included actions.
     */
-  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Declarative activation of CSRF protection. Of course, highly inspired by Ruby on Rails.
@@ -49,7 +49,7 @@ trait AsyncCSRFProtectionFeature extends AsyncCSRFTokenSupport {
     * @param only should be applied only for these action methods
     * @param except should not be applied for these action methods
     */
-  def protectFromForgery(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil): Unit = {
+  def protectFromForgery(only: Seq[String] = Nil, except: Seq[String] = Nil): Unit = {
     forgeryProtectionEnabled = true
     forgeryProtectionIncludedActionNames ++= only
     forgeryProtectionExcludedActionNames ++= except

--- a/framework/src/main/scala/skinny/controller/feature/BeforeAfterActionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/BeforeAfterActionFeature.scala
@@ -1,7 +1,7 @@
 package skinny.controller.feature
 
-import skinny.micro.{ Handler, SkinnyMicroBase }
 import skinny.micro.base.BeforeAfterDsl
+import skinny.micro.{ Handler, SkinnyMicroBase }
 
 /**
   * beforeAction/afterAction support.
@@ -25,7 +25,7 @@ trait BeforeAfterActionFeature extends SkinnyMicroBase with BeforeAfterDsl {
   /**
     * If you prefer #beforeFilter than #beforeAction, keep going!
     */
-  def beforeFilter(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: => Any): Unit = {
+  def beforeFilter(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: => Any): Unit = {
     beforeAction(only, except)(action)
   }
 
@@ -36,7 +36,7 @@ trait BeforeAfterActionFeature extends SkinnyMicroBase with BeforeAfterDsl {
     * @param except this action should not be applied for these action methods
     * @param action action
     */
-  def beforeAction(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: => Any): Unit = {
+  def beforeAction(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: => Any): Unit = {
     skinnyBeforeActions += (
         () => {
           currentActionName.map { name =>
@@ -55,7 +55,7 @@ trait BeforeAfterActionFeature extends SkinnyMicroBase with BeforeAfterDsl {
   /**
     * If you prefer #afterFilter than #afterAction, keep going!
     */
-  def afterFilter(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: => Any): Unit = {
+  def afterFilter(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: => Any): Unit = {
     afterAction(only, except)(action)
   }
 
@@ -66,7 +66,7 @@ trait BeforeAfterActionFeature extends SkinnyMicroBase with BeforeAfterDsl {
     * @param except this action should not be applied for these action methods
     * @param action action
     */
-  def afterAction(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil)(action: => Any): Unit = {
+  def afterAction(only: Seq[String] = Nil, except: Seq[String] = Nil)(action: => Any): Unit = {
     skinnyAfterActions += (
         () => {
           currentActionName.map { name =>

--- a/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
+++ b/framework/src/main/scala/skinny/controller/feature/CSRFProtectionFeature.scala
@@ -35,12 +35,12 @@ trait CSRFProtectionFeature extends CSRFTokenSupport {
   /**
     * Excluded actions.
     */
-  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionExcludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Included actions.
     */
-  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[Symbol]
+  private[this] val forgeryProtectionIncludedActionNames = new scala.collection.mutable.ArrayBuffer[String]
 
   /**
     * Declarative activation of CSRF protection. Of course, highly inspired by Ruby on Rails.
@@ -48,7 +48,7 @@ trait CSRFProtectionFeature extends CSRFTokenSupport {
     * @param only should be applied only for these action methods
     * @param except should not be applied for these action methods
     */
-  def protectFromForgery(only: Seq[Symbol] = Nil, except: Seq[Symbol] = Nil): Unit = {
+  def protectFromForgery(only: Seq[String] = Nil, except: Seq[String] = Nil): Unit = {
     forgeryProtectionEnabled = true
     forgeryProtectionIncludedActionNames ++= only
     forgeryProtectionExcludedActionNames ++= except

--- a/framework/src/main/scala/skinny/filter/SkinnySessionFilterBase.scala
+++ b/framework/src/main/scala/skinny/filter/SkinnySessionFilterBase.scala
@@ -56,6 +56,7 @@ private[skinny] trait SkinnySessionFilterBase extends SkinnyFilter { self: Flash
 
   def skinnySession[A](key: String)(implicit ctx: SkinnyContext): Option[A] = skinnySession(ctx).getAs[A](key)
 
+  @deprecated(message = "Use skinnySession(String) instead.", since = "4.0.0")
   def skinnySession[A](key: Symbol)(implicit ctx: SkinnyContext): Option[A] = skinnySession[A](key.name)(ctx)
 
   // --------------------------------------

--- a/framework/src/main/scala/skinny/routing/RichRoute.scala
+++ b/framework/src/main/scala/skinny/routing/RichRoute.scala
@@ -1,11 +1,11 @@
 package skinny.routing
 
-import skinny.controller.feature.SkinnyControllerCommonBase
 import skinny.controller.ActionDefinition
+import skinny.controller.feature.SkinnyControllerCommonBase
+import skinny.exception.RouteMetadataException
 import skinny.micro.Handler
 import skinny.micro.constant.HttpMethod
 import skinny.micro.routing.Route
-import skinny.exception.RouteMetadataException
 
 /**
   * Route wrapper.
@@ -22,6 +22,7 @@ case class RichRoute(route: Route, method: HttpMethod, controller: SkinnyControl
     * @param name action name
     * @return route
     */
+  @deprecated(since = "4.0.0", message = "use as(String) instead.")
   def as(name: Symbol): Route = {
     val expectedMethod = route.metadata
       .get(Handler.RouteMetadataHttpMethodCacheKey)
@@ -33,7 +34,7 @@ case class RichRoute(route: Route, method: HttpMethod, controller: SkinnyControl
       }
     controller.addActionDefinition(
       ActionDefinition(
-        name = name,
+        name = name.name,
         method = expectedMethod,
         matcher = (method: HttpMethod, path: String) => method == expectedMethod && route.apply(path).isDefined
       )

--- a/framework/src/main/scala/skinny/routing/Routes.scala
+++ b/framework/src/main/scala/skinny/routing/Routes.scala
@@ -7,7 +7,7 @@ import skinny.routing.implicits.RoutesAsImplicits
 /**
   * Route configurator for SkinnyController.
   *
-  * When using this trait, Route can be a RichRoute, so you can call #as(Symbol) method now.
+  * When using this trait, Route can be a RichRoute, so you can call #as(String) method now.
   */
 trait Routes { self: SkinnyMicroBase with SkinnyControllerCommonBase with RoutesAsImplicits =>
 

--- a/framework/src/main/scala/skinny/routing/implicits/RoutesAsImplicits.scala
+++ b/framework/src/main/scala/skinny/routing/implicits/RoutesAsImplicits.scala
@@ -16,7 +16,7 @@ import skinny.routing.RichRoute
 object RoutesAsImplicits extends RoutesAsImplicits
 
 /**
-  * Implicits for RichRoute which enables Route to call #as(Symbol) method.
+  * Implicits for RichRoute which enables Route to call #as(String) method.
   */
 trait RoutesAsImplicits {
 

--- a/framework/src/test/scala/skinny/SkinnySpec.scala
+++ b/framework/src/test/scala/skinny/SkinnySpec.scala
@@ -104,7 +104,7 @@ class SkinnySpec extends ScalatraFlatSpec with MockitoSugar {
   }
 
   object Controller extends SkinnyController with Routes {
-    val indexUrl = get("/")("ok").as(Symbol("index"))
+    val indexUrl = get("/")("ok").as("index")
     get("/redirect") {
       val skinnyObject =
         Skinny(SkinnyContext.buildWithRequest(request, UnstableAccessValidation(true, false)), requestScope)

--- a/framework/src/test/scala/skinny/controller/ActionDefinitionSpec.scala
+++ b/framework/src/test/scala/skinny/controller/ActionDefinitionSpec.scala
@@ -9,9 +9,9 @@ class ActionDefinitionSpec extends FlatSpec with Matchers {
 
   it should "be available" in {
     val method     = HttpMethod.apply("GET")
-    val definition = ActionDefinition(Symbol("index"), method, (m: HttpMethod, path: String) => true)
+    val definition = ActionDefinition("index", method, (m: HttpMethod, path: String) => true)
 
-    definition.name should equal(Symbol("index"))
+    definition.name should equal("index")
     definition.method should equal(method)
     definition.matcher.apply(null, null) should equal(true)
   }

--- a/framework/src/test/scala/skinny/controller/AsyncSkinnyApiControllerSpec.scala
+++ b/framework/src/test/scala/skinny/controller/AsyncSkinnyApiControllerSpec.scala
@@ -12,14 +12,14 @@ class AsyncSkinnyApiControllerSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("AsyncSkinnyApiController"), "jdbc:h2:mem:AsyncSkinnyApiController", "", "")
-  NamedDB(Symbol("AsyncSkinnyApiController")).localTx { implicit s =>
+  ConnectionPool.add("AsyncSkinnyApiController", "jdbc:h2:mem:AsyncSkinnyApiController", "", "")
+  NamedDB("AsyncSkinnyApiController").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("AsyncSkinnyApiController")
+    override def connectionPoolName = "AsyncSkinnyApiController"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -38,8 +38,8 @@ class AsyncSkinnyApiControllerSpec extends ScalatraFlatSpec {
 
     def create(implicit ctx: Context) = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
@@ -53,9 +53,9 @@ class AsyncSkinnyApiControllerSpec extends ScalatraFlatSpec {
     }
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl     = post("/companies")(implicit ctx => create).as(Symbol("list"))
-    val listUrl         = get("/companies.json")(implicit ctx => list).as(Symbol("list"))
-    val beforeFilterUrl = get("/filter")(implicit ctx => filter).as(Symbol("filter"))
+    val creationUrl     = post("/companies")(implicit ctx => create).as("list")
+    val listUrl         = get("/companies.json")(implicit ctx => list).as("list")
+    val beforeFilterUrl = get("/filter")(implicit ctx => filter).as("filter")
   }
   addFilter(controller, "/*")
 

--- a/framework/src/test/scala/skinny/controller/AsyncSkinnyApiServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/AsyncSkinnyApiServletSpec.scala
@@ -12,14 +12,14 @@ class AsyncSkinnyApiServletSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("AsyncSkinnyServlet"), "jdbc:h2:mem:AsyncSkinnyServlet", "", "")
-  NamedDB(Symbol("AsyncSkinnyServlet")).localTx { implicit s =>
+  ConnectionPool.add("AsyncSkinnyServlet", "jdbc:h2:mem:AsyncSkinnyServlet", "", "")
+  NamedDB("AsyncSkinnyServlet").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("AsyncSkinnyServlet")
+    override def connectionPoolName = "AsyncSkinnyServlet"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -31,16 +31,16 @@ class AsyncSkinnyApiServletSpec extends ScalatraFlatSpec {
   class CompaniesController extends AsyncSkinnyServlet {
     def create(implicit ctx: Context) = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
     def list(implicit ctx: Context) = toPrettyJSONString(Company.findAll())
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl = post("/companies")(implicit ctx => create).as(Symbol("list"))
-    val listUrl     = get("/companies.json")(implicit ctx => list).as(Symbol("list"))
+    val creationUrl = post("/companies")(implicit ctx => create).as("list")
+    val listUrl     = get("/companies.json")(implicit ctx => list).as("list")
   }
 
   addServlet(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/AsyncSkinnyControllerSpec.scala
+++ b/framework/src/test/scala/skinny/controller/AsyncSkinnyControllerSpec.scala
@@ -11,14 +11,14 @@ class AsyncSkinnyControllerSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("AsyncSkinnyController"), "jdbc:h2:mem:AsyncSkinnyController", "", "")
-  NamedDB(Symbol("AsyncSkinnyController")).localTx { implicit s =>
+  ConnectionPool.add("AsyncSkinnyController", "jdbc:h2:mem:AsyncSkinnyController", "", "")
+  NamedDB("AsyncSkinnyController").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("AsyncSkinnyController")
+    override def connectionPoolName = "AsyncSkinnyController"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -30,8 +30,8 @@ class AsyncSkinnyControllerSpec extends ScalatraFlatSpec {
   class CompaniesController extends AsyncSkinnyController {
     def create(implicit ctx: Context) = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
@@ -41,8 +41,8 @@ class AsyncSkinnyControllerSpec extends ScalatraFlatSpec {
     }
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl = post("/companies")(implicit ctx => create).as(Symbol("list"))
-    val listUrl     = get("/companies.json")(implicit ctx => list).as(Symbol("list"))
+    val creationUrl = post("/companies")(implicit ctx => create).as("list")
+    val listUrl     = get("/companies.json")(implicit ctx => list).as("list")
   }
   addFilter(controller, "/*")
 

--- a/framework/src/test/scala/skinny/controller/AsyncSkinnyServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/AsyncSkinnyServletSpec.scala
@@ -12,14 +12,14 @@ class AsyncSkinnyServletSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("AsyncSkinnyApiServlet"), "jdbc:h2:mem:AsyncSkinnyApiServlet", "", "")
-  NamedDB(Symbol("AsyncSkinnyApiServlet")).localTx { implicit s =>
+  ConnectionPool.add("AsyncSkinnyApiServlet", "jdbc:h2:mem:AsyncSkinnyApiServlet", "", "")
+  NamedDB("AsyncSkinnyApiServlet").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("AsyncSkinnyApiServlet")
+    override def connectionPoolName = "AsyncSkinnyApiServlet"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -31,16 +31,16 @@ class AsyncSkinnyServletSpec extends ScalatraFlatSpec {
   class CompaniesController extends AsyncSkinnyApiServlet {
     def create(implicit ctx: Context) = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
     def list(implicit ctx: Context) = toPrettyJSONString(Company.findAll())
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl = post("/companies")(implicit ctx => create).as(Symbol("list"))
-    val listUrl     = get("/companies.json")(implicit ctx => list).as(Symbol("list"))
+    val creationUrl = post("/companies")(implicit ctx => create).as("list")
+    val listUrl     = get("/companies.json")(implicit ctx => list).as("list")
   }
 
   addServlet(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/ManualIdControllerSpec.scala
+++ b/framework/src/test/scala/skinny/controller/ManualIdControllerSpec.scala
@@ -11,18 +11,18 @@ class ManualIdControllerSpec extends ScalatraFlatSpec {
   behavior of "SkinnyController with manual ID"
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("ManualIdController"), "jdbc:h2:mem:ManualIdController", "", "")
+  ConnectionPool.add("ManualIdController", "jdbc:h2:mem:ManualIdController", "", "")
 
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
 
-  NamedDB(Symbol("ManualIdController")).localTx { implicit s =>
+  NamedDB("ManualIdController").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
 
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("ManualIdController")
+    override def connectionPoolName = "ManualIdController"
 
     override def defaultAlias               = createAlias("c")
     override def useAutoIncrementPrimaryKey = false

--- a/framework/src/test/scala/skinny/controller/ParamsSpec.scala
+++ b/framework/src/test/scala/skinny/controller/ParamsSpec.scala
@@ -54,13 +54,13 @@ class ParamsSpec extends ScalatraFlatSpec {
       Params(params).withTime("time").getAs[String]("time").orNull
     }
 
-    post("/date")(date).as(Symbol("date"))
-    post("/date2")(date2).as(Symbol("date2"))
-    post("/datetime")(datetime).as(Symbol("datetime"))
-    post("/datetime2")(datetime2).as(Symbol("datetime2"))
-    post("/datetime3")(datetime3).as(Symbol("datetime3"))
-    post("/time")(time).as(Symbol("time"))
-    post("/time2")(time2).as(Symbol("time2"))
+    post("/date")(date).as("date")
+    post("/date2")(date2).as("date2")
+    post("/datetime")(datetime).as("datetime")
+    post("/datetime2")(datetime2).as("datetime2")
+    post("/datetime3")(datetime3).as("datetime3")
+    post("/time")(time).as("time")
+    post("/time2")(time2).as("time2")
   }
 
   addFilter(ParasController, "/*")

--- a/framework/src/test/scala/skinny/controller/SkinnyApiControllerSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiControllerSpec.scala
@@ -11,14 +11,14 @@ class SkinnyApiControllerSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyApiController"), "jdbc:h2:mem:SkinnyApiController", "", "")
-  NamedDB(Symbol("SkinnyApiController")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyApiController", "jdbc:h2:mem:SkinnyApiController", "", "")
+  NamedDB("SkinnyApiController").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("SkinnyApiController")
+    override def connectionPoolName = "SkinnyApiController"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -30,8 +30,8 @@ class SkinnyApiControllerSpec extends ScalatraFlatSpec {
   class CompaniesController extends SkinnyApiController {
     def create = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
@@ -41,8 +41,8 @@ class SkinnyApiControllerSpec extends ScalatraFlatSpec {
     }
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl = post("/companies")(create).as(Symbol("list"))
-    val listUrl     = get("/companies.json")(list).as(Symbol("list"))
+    val creationUrl = post("/companies")(create).as("list")
+    val listUrl     = get("/companies.json")(list).as("list")
   }
 
   addFilter(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/SkinnyApiResourceServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiResourceServletSpec.scala
@@ -12,8 +12,8 @@ class SkinnyApiResourceServletSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyApiResourceServlet"), "jdbc:h2:mem:SkinnyApiResourceServlet", "", "")
-  NamedDB(Symbol("SkinnyApiResourceServlet")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyApiResourceServlet", "jdbc:h2:mem:SkinnyApiResourceServlet", "", "")
+  NamedDB("SkinnyApiResourceServlet").localTx { implicit s =>
     sql"create table api (id serial primary key, name varchar(64) not null, url varchar(128) not null);".execute
       .apply()
   }
@@ -24,7 +24,7 @@ class SkinnyApiResourceServletSpec extends ScalatraFlatSpec {
       url: String
   )
   object Api extends SkinnyCRUDMapper[Api] {
-    override def connectionPoolName = Symbol("SkinnyApiResourceServlet")
+    override def connectionPoolName = "SkinnyApiResourceServlet"
     override def defaultAlias       = createAlias("api")
     override def extract(rs: WrappedResultSet, n: ResultName[Api]) = new Api(
       id = rs.get(n.id),
@@ -91,7 +91,7 @@ class SkinnyApiResourceServletSpec extends ScalatraFlatSpec {
   }
 
   it should "have update API" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     put(s"/bar/apis/${id}.xml") {
       status should equal(400)
       body should equal("""<?xml version="1.0" encoding="utf-8"?><apis><name>name is required</name></apis>""")
@@ -120,7 +120,7 @@ class SkinnyApiResourceServletSpec extends ScalatraFlatSpec {
 
   it should "have delete API" in {
     {
-      val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+      val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
       delete(s"/bar/apis/${id}.xml") {
         status should equal(200)
         header("Content-Type") should fullyMatch regex ("application/xml;\\s*charset=utf-8")
@@ -130,7 +130,7 @@ class SkinnyApiResourceServletSpec extends ScalatraFlatSpec {
     }
 
     {
-      val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+      val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
       delete(s"/bar/apis/${id}.json") {
         status should equal(200)
         header("Content-Type") should fullyMatch regex ("application/json;\\s*charset=utf-8")

--- a/framework/src/test/scala/skinny/controller/SkinnyApiResourceSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiResourceSpec.scala
@@ -12,15 +12,15 @@ class SkinnyApiResourceSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyApiResource"), "jdbc:h2:mem:SkinnyApiResource", "", "")
-  NamedDB(Symbol("SkinnyApiResource")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyApiResource", "jdbc:h2:mem:SkinnyApiResource", "", "")
+  NamedDB("SkinnyApiResource").localTx { implicit s =>
     sql"create table api (id serial primary key, name varchar(64) not null, url varchar(128) not null);".execute
       .apply()
   }
 
   case class Api(id: Long, name: String, url: String)
   object Api extends SkinnyCRUDMapper[Api] {
-    override def connectionPoolName = Symbol("SkinnyApiResource")
+    override def connectionPoolName = "SkinnyApiResource"
     override def defaultAlias       = createAlias("api")
     override def extract(rs: WrappedResultSet, n: ResultName[Api]) = new Api(
       id = rs.get(n.id),
@@ -88,7 +88,7 @@ class SkinnyApiResourceSpec extends ScalatraFlatSpec {
   }
 
   it should "have update API" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     put(s"/bar/apis/${id}.xml") {
       body should equal("""<?xml version="1.0" encoding="utf-8"?><apis><name>name is required</name></apis>""")
       header("Content-Type") should fullyMatch regex ("application/xml;\\s*charset=utf-8")
@@ -116,7 +116,7 @@ class SkinnyApiResourceSpec extends ScalatraFlatSpec {
 
   it should "have delete API" in {
     {
-      val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+      val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
       delete(s"/bar/apis/${id}.xml") {
         status should equal(200)
         header("Content-Type") should fullyMatch regex ("application/xml;\\s*charset=utf-8")
@@ -126,7 +126,7 @@ class SkinnyApiResourceSpec extends ScalatraFlatSpec {
     }
 
     {
-      val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+      val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
       delete(s"/bar/apis/${id}.json") {
         status should equal(200)
         header("Content-Type") should fullyMatch regex ("application/json;\\s*charset=utf-8")

--- a/framework/src/test/scala/skinny/controller/SkinnyApiServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyApiServletSpec.scala
@@ -11,14 +11,14 @@ class SkinnyApiServletSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyApiServlet"), "jdbc:h2:mem:SkinnyApiServlet", "", "")
-  NamedDB(Symbol("SkinnyApiServlet")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyApiServlet", "jdbc:h2:mem:SkinnyApiServlet", "", "")
+  NamedDB("SkinnyApiServlet").localTx { implicit s =>
     sql"create table company (id serial primary key, name varchar(64), url varchar(128));".execute.apply()
   }
 
   case class Company(id: Long, name: String, url: String)
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName = Symbol("SkinnyApiServlet")
+    override def connectionPoolName = "SkinnyApiServlet"
     override def defaultAlias       = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = new Company(
       id = rs.get(n.id),
@@ -30,16 +30,16 @@ class SkinnyApiServletSpec extends ScalatraFlatSpec {
   class CompaniesController extends SkinnyApiServlet {
     def create = {
       val count = Company.createWithAttributes(
-        Symbol("name") -> params.getAs[String]("name"),
-        Symbol("url")  -> params.getAs[String]("url")
+        "name" -> params.getAs[String]("name"),
+        "url"  -> params.getAs[String]("url")
       )
       if (count == 1) status = 201 else status = 400
     }
     def list = toPrettyJSONString(Company.findAll())
   }
   val controller = new CompaniesController with Routes {
-    val creationUrl = post("/companies")(create).as(Symbol("list"))
-    val listUrl     = get("/companies.json")(list).as(Symbol("list"))
+    val creationUrl = post("/companies")(create).as("list")
+    val listUrl     = get("/companies.json")(list).as("list")
   }
 
   addServlet(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/SkinnyResourceServletSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyResourceServletSpec.scala
@@ -12,15 +12,15 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyResourceServlet"), "jdbc:h2:mem:SkinnyResourceServlet", "", "")
-  NamedDB(Symbol("SkinnyResourceServlet")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyResourceServlet", "jdbc:h2:mem:SkinnyResourceServlet", "", "")
+  NamedDB("SkinnyResourceServlet").localTx { implicit s =>
     sql"create table api (id serial primary key, name varchar(64) not null, url varchar(128) not null);".execute
       .apply()
   }
 
   case class Api(id: Long, name: String, url: String)
   object Api extends SkinnyCRUDMapper[Api] {
-    override def connectionPoolName = Symbol("SkinnyResourceServlet")
+    override def connectionPoolName = "SkinnyResourceServlet"
     override def defaultAlias       = createAlias("api")
     override def extract(rs: WrappedResultSet, n: ResultName[Api]) = new Api(
       id = rs.get(n.id),
@@ -103,7 +103,7 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
   }
 
   it should "have update API" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     put(s"/foo/apis/${id}.xml") {
       status should equal(400)
       body should equal("""<?xml version="1.0" encoding="utf-8"?><apis><name>name is required</name></apis>""")
@@ -125,7 +125,7 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
   // delete
 
   it should "have delete API in XML format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}.xml") {
       status should equal(202)
       header("Content-Type") should fullyMatch regex ("application/xml;\\s*charset=utf-8")
@@ -134,7 +134,7 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
     Api.findById(id).isDefined should equal(false)
   }
   it should "have delete API in JSON format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}.json") {
       status should equal(202)
       header("Content-Type") should fullyMatch regex ("application/json;\\s*charset=utf-8")
@@ -143,7 +143,7 @@ class SkinnyResourceServletSpec extends ScalatraFlatSpec {
     Api.findById(id).isDefined should equal(false)
   }
   it should "have delete API in HTML format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}") {
       status should equal(200)
       body should equal("")

--- a/framework/src/test/scala/skinny/controller/SkinnyResourceSpec.scala
+++ b/framework/src/test/scala/skinny/controller/SkinnyResourceSpec.scala
@@ -12,15 +12,15 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
   GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(singleLineMode = true)
-  ConnectionPool.add(Symbol("SkinnyResource"), "jdbc:h2:mem:SkinnyResource", "", "")
-  NamedDB(Symbol("SkinnyResource")).localTx { implicit s =>
+  ConnectionPool.add("SkinnyResource", "jdbc:h2:mem:SkinnyResource", "", "")
+  NamedDB("SkinnyResource").localTx { implicit s =>
     sql"create table api (id serial primary key, name varchar(64) not null, url varchar(128) not null);".execute
       .apply()
   }
 
   case class Api(id: Long, name: String, url: String)
   object Api extends SkinnyCRUDMapper[Api] {
-    override def connectionPoolName = Symbol("SkinnyResource")
+    override def connectionPoolName = "SkinnyResource"
     override def defaultAlias       = createAlias("api")
     override def extract(rs: WrappedResultSet, n: ResultName[Api]) = new Api(
       id = rs.get(n.id),
@@ -103,7 +103,7 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
   }
 
   it should "have update API" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     put(s"/foo/apis/${id}.xml") {
       status should equal(400)
       body should equal("""<?xml version="1.0" encoding="utf-8"?><apis><name>name is required</name></apis>""")
@@ -125,7 +125,7 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
   // delete
 
   it should "have delete API in XML format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}.xml") {
       status should equal(202)
       header("Content-Type") should fullyMatch regex ("application/xml;\\s*charset=utf-8")
@@ -134,7 +134,7 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
     Api.findById(id).isDefined should equal(false)
   }
   it should "have delete API in JSON format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}.json") {
       status should equal(202)
       header("Content-Type") should fullyMatch regex ("application/json;\\s*charset=utf-8")
@@ -143,7 +143,7 @@ class SkinnyResourceSpec extends ScalatraFlatSpec {
     Api.findById(id).isDefined should equal(false)
   }
   it should "have delete API in HTML format" in {
-    val id = Api.createWithAttributes(Symbol("name") -> "Twitter", Symbol("url") -> "https://dev.twitter.com")
+    val id = Api.createWithAttributes("name" -> "Twitter", "url" -> "https://dev.twitter.com")
     delete(s"/foo/apis/${id}") {
       status should equal(200)
       body should equal("")

--- a/framework/src/test/scala/skinny/controller/feature/AfterActionSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/AfterActionSpec.scala
@@ -8,12 +8,12 @@ class AfterActionSpec extends ScalatraFlatSpec {
   behavior of "afterAction"
 
   object After1 extends SkinnyController with Routes {
-    get("/1") { response.writer.write("0") }.as(Symbol("index"))
+    get("/1") { response.writer.write("0") }.as("index")
     afterAction() { response.writer.write("1") }
     afterAction() { response.writer.write("2") }
   }
   object After2 extends SkinnyController with Routes {
-    get("/2") { response.writer.write("OK") }.as(Symbol("index"))
+    get("/2") { response.writer.write("OK") }.as("index")
     afterAction() { response.writer.write(" Computer") }
   }
   addFilter(After1, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/AngularXSRFCookieProviderFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/AngularXSRFCookieProviderFeatureSpec.scala
@@ -12,7 +12,7 @@ class AngularXSRFCookieProviderFeatureSpec extends ScalatraFlatSpec {
     def showAlice = toJSONString(Map("name" -> "Alice", "age" -> 23))
   }
   val controller = new Controller with Routes {
-    get("/alice")(showAlice).as(Symbol("alice"))
+    get("/alice")(showAlice).as("alice")
   }
 
   addFilter(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/AngularXSRFProtectionFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/AngularXSRFProtectionFeatureSpec.scala
@@ -14,8 +14,8 @@ class AngularXSRFProtectionFeatureSpec extends ScalatraFlatSpec {
     def create = "ok"
   }
   val controller = new Controller with Routes {
-    get("/token")(token).as(Symbol("token"))
-    post("/")(create).as(Symbol("create"))
+    get("/token")(token).as("token")
+    post("/")(create).as("create")
   }
 
   addFilter(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/BeforeActionSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/BeforeActionSpec.scala
@@ -8,12 +8,12 @@ class BeforeActionSpec extends ScalatraFlatSpec {
   behavior of "beforeAction"
 
   object Before1 extends SkinnyController with Routes {
-    get("/1") { response.writer.write("2") }.as(Symbol("index"))
+    get("/1") { response.writer.write("2") }.as("index")
     beforeAction() { response.writer.write("0") }
     beforeAction() { response.writer.write("1") }
   }
   object Before2 extends SkinnyController with Routes {
-    get("/2") { response.writer.write("Computer") }.as(Symbol("index"))
+    get("/2") { response.writer.write("Computer") }.as("index")
     beforeAction() { response.writer.write("OK ") }
   }
   addFilter(Before1, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/BeforeAfterFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/BeforeAfterFeatureSpec.scala
@@ -14,20 +14,20 @@ class BeforeAfterFeatureSpec extends ScalatraFlatSpec {
 
     def index = getFromRequestScope("x").orNull[String]
 
-    get("/first")(index).as(Symbol("index"))
+    get("/first")(index).as("index")
     get("/first/y")(getFromRequestScope("y").orNull[String])
-    get("/first/z")(getFromRequestScope("z").orNull[String]).as(Symbol("z"))
+    get("/first/z")(getFromRequestScope("z").orNull[String]).as("z")
   }
 
   object Second extends SkinnyController with Routes {
-    beforeAction(only = Seq(Symbol("filtered"))) { set("x", "bar") }
+    beforeAction(only = Seq("filtered")) { set("x", "bar") }
 
     def index                 = getFromRequestScope("x").orNull[String]
     def updatedByBeforeAction = getFromRequestScope("x").orNull[String]
 
-    get("/second")(index).as(Symbol("index"))
+    get("/second")(index).as("index")
     get("/second/y")(getFromRequestScope("y").orNull[String])
-    get("/second/filtered")(updatedByBeforeAction).as(Symbol("filtered"))
+    get("/second/filtered")(updatedByBeforeAction).as("filtered")
   }
 
   object Third extends SkinnyController with Routes {
@@ -35,7 +35,7 @@ class BeforeAfterFeatureSpec extends ScalatraFlatSpec {
     def bar  = getFromRequestScope("x").orNull[String]
     def buzz = getFromRequestScope("x").orNull[String]
 
-    get("/third")(bar).as(Symbol("bar"))
+    get("/third")(bar).as("bar")
     get("/third/y")(getFromRequestScope("y").orNull[String])
   }
 

--- a/framework/src/test/scala/skinny/controller/feature/CORSFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/CORSFeatureSpec.scala
@@ -16,7 +16,7 @@ class CORSFeatureSpec extends ScalatraFlatSpec {
     def showAlice = toJSONString(Map("name" -> "Alice", "age" -> 23))
   }
   val controller = new SampleController with Routes {
-    val creationUrl = get("/alice")(showAlice).as(Symbol("alice"))
+    val creationUrl = get("/alice")(showAlice).as("alice")
   }
 
   addFilter(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/ChunkedResponseFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/ChunkedResponseFeatureSpec.scala
@@ -14,7 +14,7 @@ class ChunkedResponseFeatureSpec extends ScalatraFlatSpec {
     }
   }
   val controller = new Controller with Routes {
-    get("/")(index).as(Symbol("index"))
+    get("/")(index).as("index")
   }
 
   addFilter(controller, "/*")

--- a/framework/src/test/scala/skinny/controller/feature/FormParamsFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/FormParamsFeatureSpec.scala
@@ -12,10 +12,10 @@ class FormParamsFeatureSpec extends ScalatraFlatSpec {
     def multi  = formMultiParams.getAs[String]("foo").map(_.mkString(",")).getOrElse("<empty>")
   }
   object ctrl extends Controller with Routes {
-    get("/get")(single).as(Symbol("get"))
-    post("/post")(single).as(Symbol("post"))
-    get("/multi/get")(multi).as(Symbol("multiGet"))
-    post("/multi/post")(multi).as(Symbol("multiPost"))
+    get("/get")(single).as("get")
+    post("/post")(single).as("post")
+    get("/multi/get")(multi).as("multiGet")
+    post("/multi/post")(multi).as("multiPost")
   }
   addFilter(ctrl, "/*")
 

--- a/framework/src/test/scala/skinny/controller/feature/FutureOpsFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/FutureOpsFeatureSpec.scala
@@ -23,8 +23,8 @@ class FutureOpsFeatureSpec extends ScalatraFlatSpec {
       }
       awaitFutures(1.seconds)(f)
     }
-    get("/")(index).as(Symbol("index"))
-    get("/context")(withContext).as(Symbol("context"))
+    get("/")(index).as("index")
+    get("/context")(withContext).as("context")
   }
   addFilter(Controller, "/*")
 

--- a/framework/src/test/scala/skinny/controller/feature/JSONParamsAutoBinderFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/JSONParamsAutoBinderFeatureSpec.scala
@@ -13,7 +13,7 @@ class JSONParamsAutoBinderFeatureSpec extends ScalatraFlatSpec {
     def index = {
       params.getAs[String]("name") should equal(Some("Alice"))
     }
-    post("/")(index).as(Symbol("index"))
+    post("/")(index).as("index")
   }
   addFilter(Controller, "/*")
 

--- a/framework/src/test/scala/skinny/controller/feature/QueryParamsFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/QueryParamsFeatureSpec.scala
@@ -12,10 +12,10 @@ class QueryParamsFeatureSpec extends ScalatraFlatSpec {
     def multi  = queryMultiParams.getAs[String]("foo").map(_.mkString(",")).getOrElse("<empty>")
   }
   object ctrl extends Controller with Routes {
-    get("/get")(single).as(Symbol("get"))
-    post("/post")(single).as(Symbol("post"))
-    get("/multi/get")(multi).as(Symbol("multiGet"))
-    post("/multi/post")(multi).as(Symbol("multiPost"))
+    get("/get")(single).as("get")
+    post("/post")(single).as("post")
+    get("/multi/get")(multi).as("multiGet")
+    post("/multi/post")(multi).as("multiPost")
   }
   addFilter(ctrl, "/*")
 

--- a/framework/src/test/scala/skinny/controller/feature/RequestScopeFeatureSpec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/RequestScopeFeatureSpec.scala
@@ -20,9 +20,9 @@ class RequestScopeFeatureSpec extends ScalatraFlatSpec {
     }
     def showErrorMessages = errorMessages
 
-    get("/echo")(echo).as(Symbol("echo"))
-    get("/nameModel")(nameModel).as(Symbol("nameModel"))
-    get("/showErrorMessages")(showErrorMessages).as(Symbol("showErrorMessages"))
+    get("/echo")(echo).as("echo")
+    get("/nameModel")(nameModel).as("nameModel")
+    get("/showErrorMessages")(showErrorMessages).as("showErrorMessages")
   }
   addFilter(Controller, "/*")
 

--- a/framework/src/test/scala/skinny/controller/feature/ScalateTemplateEngineFeaturespec.scala
+++ b/framework/src/test/scala/skinny/controller/feature/ScalateTemplateEngineFeaturespec.scala
@@ -33,7 +33,7 @@ class ScalateTemplateEngineFeatureSpec extends ScalatraFlatSpec with BeforeAndAf
     def c                          = render("foo/c")
     def xyz                        = render("foo/xyz")
 
-    get("/ssp/a")(a).as(Symbol("a"))
+    get("/ssp/a")(a).as("a")
     get("/ssp/c")(c)
     get("/ssp/xyz")(xyz)
   }

--- a/framework/src/test/scala/skinny/filter/AsyncErrorPageFilterSpec.scala
+++ b/framework/src/test/scala/skinny/filter/AsyncErrorPageFilterSpec.scala
@@ -27,12 +27,12 @@ class AsyncErrorPageFilterSpec extends ScalatraFlatSpec {
 
   object ErrorController extends AsyncSkinnyController with AsyncErrorMessageFilter with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error")(implicit ctx => execute).as(Symbol("execute"))
+    get("/error")(implicit ctx => execute).as("execute")
   }
 
   object Error2Controller extends AsyncSkinnyController with AsyncErrorPageFilter with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error2")(implicit ctx => execute).as(Symbol("execute"))
+    get("/error2")(implicit ctx => execute).as("execute")
   }
   object Error3Controller
       extends AsyncSkinnyController
@@ -40,7 +40,7 @@ class AsyncErrorPageFilterSpec extends ScalatraFlatSpec {
       with AsyncErrorMessageFilter
       with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error3")(implicit ctx => execute).as(Symbol("execute"))
+    get("/error3")(implicit ctx => execute).as("execute")
   }
 
   addFilter(ErrorController, "/*")

--- a/framework/src/test/scala/skinny/filter/ErrorPageFilterSpec.scala
+++ b/framework/src/test/scala/skinny/filter/ErrorPageFilterSpec.scala
@@ -25,16 +25,16 @@ class ErrorPageFilterSpec extends ScalatraFlatSpec {
 
   object ErrorController extends SkinnyController with ErrorMessageFilter with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error")(execute).as(Symbol("execute"))
+    get("/error")(execute).as("execute")
   }
 
   object Error2Controller extends SkinnyController with ErrorPageFilter with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error2")(execute).as(Symbol("execute"))
+    get("/error2")(execute).as("execute")
   }
   object Error3Controller extends SkinnyController with ErrorPageFilter with ErrorMessageFilter with Routes {
     def execute = throw new RuntimeException("foo-bar-baz")
-    get("/error3")(execute).as(Symbol("execute"))
+    get("/error3")(execute).as("execute")
   }
 
   addFilter(ErrorController, "/*")

--- a/framework/src/test/scala/skinny/filter/SkinnyFilterActivationSpec.scala
+++ b/framework/src/test/scala/skinny/filter/SkinnyFilterActivationSpec.scala
@@ -9,7 +9,7 @@ class SkinnyFilterActivationSpec extends ScalatraFlatSpec with skinny.Logging {
   object Controller extends SkinnyApiController with SkinnyFilterActivation with Routes {
     override def detectTooManyErrorFilterRegistrationAsAnErrorAtSkinnyMicroBase = true
     def index                                                                   = "ok"
-    get("/")(index).as(Symbol("index"))
+    get("/")(index).as("index")
   }
   addFilter(Controller, "/*")
 

--- a/framework/src/test/scala/skinny/filter/SkinnySessionFilterSpec.scala
+++ b/framework/src/test/scala/skinny/filter/SkinnySessionFilterSpec.scala
@@ -10,14 +10,14 @@ class SkinnySessionFilterSpec extends ScalatraFlatSpec with Connection with Crea
   behavior of "SkinnySessionFilter"
 
   object SyncController extends SkinnyController with SkinnySessionFilter with Routes {
-    get("/sync")("ok").as(Symbol("index"))
+    get("/sync")("ok").as("index")
   }
   addFilter(SyncController, "/*")
 
   object AsyncController extends AsyncSkinnyController with AsyncSkinnySessionFilter with Routes {
     get("/async") { implicit ctx =>
       "ok"
-    }.as(Symbol("index"))
+    }.as("index")
   }
   addFilter(AsyncController, "/*")
 

--- a/framework/src/test/scala/skinny/filter/TxPerRequestFilterSpec.scala
+++ b/framework/src/test/scala/skinny/filter/TxPerRequestFilterSpec.scala
@@ -8,12 +8,12 @@ import skinny.routing.Routes
 class TxPerRequestFilterSpec extends ScalatraFlatSpec {
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("TxPerRequestFilterSpec"), "jdbc:h2:mem:TxPerRequestFilterSpec", "sa", "sa")
+  ConnectionPool.add("TxPerRequestFilterSpec", "jdbc:h2:mem:TxPerRequestFilterSpec", "sa", "sa")
 
   object Controller extends SkinnyApiController with TxPerRequestFilter with Routes {
-    override def connectionPoolForTxPerRequestFilter = ConnectionPool.get(Symbol("TxPerRequestFilterSpec"))
+    override def connectionPoolForTxPerRequestFilter = ConnectionPool.get("TxPerRequestFilterSpec")
     def index                                        = "ok"
-    get("/")(index).as(Symbol("index"))
+    get("/")(index).as("index")
   }
   addFilter(Controller, "/*")
 

--- a/orm/src/main/scala/skinny/orm/feature/CRUDFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/CRUDFeature.scala
@@ -255,7 +255,7 @@ trait CRUDFeatureWithId[Id, Entity]
     }
   }
 
-  override def createWithAttributes(parameters: (Symbol, Any)*)(implicit s: DBSession): Id = {
+  override def createWithAttributes(parameters: (String, Any)*)(implicit s: DBSession): Id = {
     super.createWithAttributes(parameters: _*).asInstanceOf[Id]
   }
 

--- a/orm/src/main/scala/skinny/orm/feature/CalculationFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/CalculationFeature.scala
@@ -20,17 +20,17 @@ trait CalculationFeature[Entity] extends SkinnyMapperBase[Entity] {
   /**
     * Count only.
     */
-  def count(fieldName: Symbol = Symbol(""), distinct: Boolean = false)(
+  def count(fieldName: String = "", distinct: Boolean = false)(
       implicit s: DBSession = autoSession
   ): Long = {
-    if (fieldName == Symbol("")) {
+    if (fieldName == "") {
       withSQL {
         select(sqls.count).from(as(syntax))
       }.map(_.long(1)).single.apply().getOrElse(0L)
     } else {
       calculate {
-        if (distinct) sqls.count(sqls.distinct(defaultAlias.field(fieldName.name)))
-        else sqls.count(defaultAlias.field(fieldName.name))
+        if (distinct) sqls.count(sqls.distinct(defaultAlias.field(fieldName)))
+        else sqls.count(defaultAlias.field(fieldName))
       }.toLong
     }
   }
@@ -38,19 +38,19 @@ trait CalculationFeature[Entity] extends SkinnyMapperBase[Entity] {
   /**
     * Counts distinct rows.
     */
-  def distinctCount(fieldName: Symbol = Symbol(primaryKeyFieldName))(implicit s: DBSession = autoSession): Long =
+  def distinctCount(fieldName: String = primaryKeyFieldName)(implicit s: DBSession = autoSession): Long =
     count(fieldName, true)
 
   /**
     * Calculates sum of a column.
     */
-  def sum(fieldName: Symbol)(implicit s: DBSession = autoSession): BigDecimal =
-    calculate(sqls.sum(defaultAlias.field(fieldName.name)))
+  def sum(fieldName: String)(implicit s: DBSession = autoSession): BigDecimal =
+    calculate(sqls.sum(defaultAlias.field(fieldName)))
 
   /**
     * Calculates average of a column.
     */
-  def average(fieldName: Symbol, decimals: Option[Int] = None)(implicit s: DBSession = autoSession): BigDecimal = {
+  def average(fieldName: String, decimals: Option[Int] = None)(implicit s: DBSession = autoSession): BigDecimal = {
     calculate(decimals match {
       case Some(dcml) =>
         val decimalsValue = dcml match {
@@ -65,29 +65,29 @@ trait CalculationFeature[Entity] extends SkinnyMapperBase[Entity] {
           case 9 => sqls"9"
           case _ => sqls"10"
         }
-        sqls"round(${sqls.avg(defaultAlias.field(fieldName.name))}, ${decimalsValue})"
+        sqls"round(${sqls.avg(defaultAlias.field(fieldName))}, ${decimalsValue})"
       case _ =>
-        sqls.avg(defaultAlias.field(fieldName.name))
+        sqls.avg(defaultAlias.field(fieldName))
     })
   }
 
-  def avg(fieldName: Symbol, decimals: Option[Int] = None)(implicit s: DBSession = autoSession): BigDecimal =
+  def avg(fieldName: String, decimals: Option[Int] = None)(implicit s: DBSession = autoSession): BigDecimal =
     average(fieldName, decimals)
 
   /**
     * Calculates minimum value of a column.
     */
-  def minimum(fieldName: Symbol)(implicit s: DBSession = autoSession): BigDecimal =
-    calculate(sqls.min(defaultAlias.field(fieldName.name)))
+  def minimum(fieldName: String)(implicit s: DBSession = autoSession): BigDecimal =
+    calculate(sqls.min(defaultAlias.field(fieldName)))
 
-  def min(fieldName: Symbol)(implicit s: DBSession = autoSession): BigDecimal = minimum(fieldName)
+  def min(fieldName: String)(implicit s: DBSession = autoSession): BigDecimal = minimum(fieldName)
 
   /**
     * Calculates minimum value of a column.
     */
-  def maximum(fieldName: Symbol)(implicit s: DBSession = autoSession): BigDecimal =
-    calculate(sqls.max(defaultAlias.field(fieldName.name)))
+  def maximum(fieldName: String)(implicit s: DBSession = autoSession): BigDecimal =
+    calculate(sqls.max(defaultAlias.field(fieldName)))
 
-  def max(fieldName: Symbol)(implicit s: DBSession = autoSession): BigDecimal = maximum(fieldName)
+  def max(fieldName: String)(implicit s: DBSession = autoSession): BigDecimal = maximum(fieldName)
 
 }

--- a/orm/src/main/scala/skinny/orm/feature/NoIdCUDFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/NoIdCUDFeature.scala
@@ -120,9 +120,9 @@ trait NoIdCUDFeature[Entity]
     * @param s db session
     * @return created count (actually useless)
     */
-  def createWithAttributes(parameters: (Symbol, Any)*)(implicit s: DBSession = autoSession): Any = {
+  def createWithAttributes(parameters: (String, Any)*)(implicit s: DBSession = autoSession): Any = {
     createWithNamedValues(mergeNamedValuesForCreation(parameters.map {
-      case (name, value) => (column.field(name.name), value)
+      case (name, value) => (column.field(name), value)
     }): _*)
   }
 
@@ -300,9 +300,9 @@ trait NoIdCUDFeature[Entity]
       * @param s db session
       * @return updated count
       */
-    def withAttributes(parameters: (Symbol, Any)*)(implicit s: DBSession = autoSession): Int = {
+    def withAttributes(parameters: (String, Any)*)(implicit s: DBSession = autoSession): Int = {
       withNamedValues(parameters.map {
-        case (name, value) => (column.field(name.name), value)
+        case (name, value) => (column.field(name), value)
       }: _*)
     }
 

--- a/orm/src/main/scala/skinny/orm/feature/NoIdQueryingFeature.scala
+++ b/orm/src/main/scala/skinny/orm/feature/NoIdQueryingFeature.scala
@@ -19,16 +19,16 @@ trait NoIdQueryingFeature[Entity]
     * @param conditions
     * @return query builder
     */
-  def where(conditions: (Symbol, Any)*): EntitiesSelectOperationBuilder = new EntitiesSelectOperationBuilder(
+  def where(conditions: (String, Any)*): EntitiesSelectOperationBuilder = new EntitiesSelectOperationBuilder(
     mapper = this,
     conditions = conditions.flatMap {
       case (key, value) =>
         implicit val enableAsIs = ParameterBinderFactory.asisParameterBinderFactory
         value match {
-          case None           => Some(sqls.isNull(defaultAlias.field(key.name)))
+          case None           => Some(sqls.isNull(defaultAlias.field(key)))
           case Nil            => None
-          case values: Seq[_] => Some(sqls.in(defaultAlias.field(key.name), values.asInstanceOf[Seq[Any]]))
-          case value          => Some(sqls.eq(defaultAlias.field(key.name), value))
+          case values: Seq[_] => Some(sqls.in(defaultAlias.field(key), values.asInstanceOf[Seq[Any]]))
+          case value          => Some(sqls.eq(defaultAlias.field(key), value))
         }
     }
   )
@@ -99,7 +99,7 @@ trait NoIdQueryingFeature[Entity]
       * @param additionalConditions conditions
       * @return query builder
       */
-    def where(additionalConditions: (Symbol, Any)*): EntitiesSelectOperationBuilder =
+    def where(additionalConditions: (String, Any)*): EntitiesSelectOperationBuilder =
       new EntitiesSelectOperationBuilder(
         mapper = this.mapper,
         conditions = conditions ++ additionalConditions.flatMap {
@@ -107,8 +107,8 @@ trait NoIdQueryingFeature[Entity]
             implicit val enableAsIs = ParameterBinderFactory.asisParameterBinderFactory
             value match {
               case Nil            => None
-              case values: Seq[_] => Some(sqls.in(defaultAlias.field(key.name), values.asInstanceOf[Seq[Any]]))
-              case value          => Some(sqls.eq(defaultAlias.field(key.name), value))
+              case values: Seq[_] => Some(sqls.in(defaultAlias.field(key), values.asInstanceOf[Seq[Any]]))
+              case value          => Some(sqls.eq(defaultAlias.field(key), value))
             }
         },
         orderings = orderings,

--- a/orm/src/test/scala/blog/BlogSpec.scala
+++ b/orm/src/test/scala/blog/BlogSpec.scala
@@ -8,13 +8,13 @@ import skinny.Pagination
 
 class BlogSpec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("blog")).toDB()
+  override def db(): DB = NamedDB("blog").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
     val postId =
-      Post.createWithAttributes(Symbol("title") -> "Hello World!", Symbol("body") -> "This is the first entry...")
-    val scalaTagId = Tag.createWithAttributes(Symbol("name") -> "Scala")
-    val rubyTagId  = Tag.createWithAttributes(Symbol("name") -> "Ruby")
+      Post.createWithAttributes("title" -> "Hello World!", "body" -> "This is the first entry...")
+    val scalaTagId = Tag.createWithAttributes("name" -> "Scala")
+    val rubyTagId  = Tag.createWithAttributes("name" -> "Ruby")
     val pt         = PostTag.column
     insert.into(PostTag).namedValues(pt.postId -> postId, pt.tagId -> scalaTagId).toSQL.update.apply()
     insert.into(PostTag).namedValues(pt.postId -> postId, pt.tagId -> rubyTagId).toSQL.update.apply()
@@ -35,7 +35,7 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
 
     it("should work with BigDecimal") { implicit session =>
       val post = Post.limit(1).apply().head
-      Post.updateById(post.id).withAttributes(Symbol("viewCount") -> 123)
+      Post.updateById(post.id).withAttributes("viewCount" -> 123)
       Post.findById(post.id).get.viewCount should equal(123)
     }
   }
@@ -49,11 +49,11 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
 
       // prepare data
       val tagIds = (1 to 10).map { i =>
-        Tag.createWithAttributes(Symbol("name") -> s"tag$i")
+        Tag.createWithAttributes("name" -> s"tag$i")
       }
       val pt = PostTag.column
       (1 to 10).map { i =>
-        val id = Post.createWithAttributes(Symbol("title") -> s"entry $i", Symbol("body") -> "foo bar baz")
+        val id = Post.createWithAttributes("title" -> s"entry $i", "body" -> "foo bar baz")
         tagIds.take(3).foreach { tagId =>
           withSQL {
             insert.into(PostTag).namedValues(pt.postId -> id, pt.tagId -> tagId)
@@ -61,7 +61,7 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
         }
       }
       (11 to 20).map { i =>
-        val id = Post.createWithAttributes(Symbol("title") -> s"entry $i", Symbol("body") -> "bulah bulah...")
+        val id = Post.createWithAttributes("title" -> s"entry $i", "body" -> "bulah bulah...")
         tagIds.take(4).foreach { tagId =>
           withSQL {
             insert.into(PostTag).namedValues(pt.postId -> id, pt.tagId -> tagId)
@@ -90,7 +90,7 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
 
       {
         val posts =
-          Post.joins(Post.tagsRef).where(Symbol("body") -> "foo bar baz").paginate(Pagination.page(1).per(3)).apply()
+          Post.joins(Post.tagsRef).where("body" -> "foo bar baz").paginate(Pagination.page(1).per(3)).apply()
         posts.size should equal(3)
         posts(0).tags.size should equal(3)
         posts(1).tags.size should equal(3)
@@ -98,13 +98,13 @@ class BlogSpec extends fixture.FunSpec with Matchers with Connection with Create
       }
       {
         val posts =
-          Post.joins(Post.tagsRef).where(Symbol("body") -> "foo bar baz").paginate(Pagination.page(4).per(3)).apply()
+          Post.joins(Post.tagsRef).where("body" -> "foo bar baz").paginate(Pagination.page(4).per(3)).apply()
         posts.size should equal(1)
         posts(0).tags.size should equal(3)
       }
       {
         val posts =
-          Post.joins(Post.tagsRef).where(Symbol("body") -> "foo bar baz").paginate(Pagination.page(5).per(3)).apply()
+          Post.joins(Post.tagsRef).where("body" -> "foo bar baz").paginate(Pagination.page(5).per(3)).apply()
         posts.size should equal(0)
       }
 

--- a/orm/src/test/scala/blog/Connection.scala
+++ b/orm/src/test/scala/blog/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("blog"), "jdbc:h2:mem:blog", "sa", "sa")
+  ConnectionPool.add("blog", "jdbc:h2:mem:blog", "sa", "sa")
 }

--- a/orm/src/test/scala/blog/CreateTables.scala
+++ b/orm/src/test/scala/blog/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("blog"))
+  override val dbSeedsAutoSession = NamedAutoSession("blog")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/blog/Post.scala
+++ b/orm/src/test/scala/blog/Post.scala
@@ -16,7 +16,7 @@ case class Post(
 )
 
 object Post extends SkinnyCRUDMapper[Post] with TimestampsFeature[Post] {
-  override val connectionPoolName = Symbol("blog")
+  override val connectionPoolName = "blog"
   override val tableName          = "posts"
   override val defaultAlias       = createAlias("p")
 

--- a/orm/src/test/scala/blog/PostTag.scala
+++ b/orm/src/test/scala/blog/PostTag.scala
@@ -12,7 +12,7 @@ case class PostTag(
 )
 
 object PostTag extends SkinnyJoinTable[PostTag] {
-  override val connectionPoolName = Symbol("blog")
+  override val connectionPoolName = "blog"
   override val tableName          = "posts_tags"
   override val defaultAlias       = createAlias("pt")
 

--- a/orm/src/test/scala/blog/Tag.scala
+++ b/orm/src/test/scala/blog/Tag.scala
@@ -12,7 +12,7 @@ case class Tag(
 )
 
 object Tag extends SkinnyCRUDMapper[Tag] with TimestampsFeature[Tag] {
-  override val connectionPoolName = Symbol("blog")
+  override val connectionPoolName = "blog"
   override val tableName          = "tags"
   override val defaultAlias       = createAlias("t")
 

--- a/orm/src/test/scala/blog2/BlogSpec.scala
+++ b/orm/src/test/scala/blog2/BlogSpec.scala
@@ -7,13 +7,13 @@ import org.scalatest.{ Tag => _, _ }
 
 class BlogSpec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("blog2")).toDB()
+  override def db(): DB = NamedDB("blog2").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
     val postId =
-      Post.createWithAttributes(Symbol("title") -> "Hello World!", Symbol("body") -> "This is the first entry...")
-    val scalaTagId = Tag.createWithAttributes(Symbol("name") -> "Scala")
-    val rubyTagId  = Tag.createWithAttributes(Symbol("name") -> "Ruby")
+      Post.createWithAttributes("title" -> "Hello World!", "body" -> "This is the first entry...")
+    val scalaTagId = Tag.createWithAttributes("name" -> "Scala")
+    val rubyTagId  = Tag.createWithAttributes("name" -> "Ruby")
     val pt         = PostTag.column
     insert.into(PostTag).namedValues(pt.postId -> postId, pt.tagId -> scalaTagId).toSQL.update.apply()
     insert.into(PostTag).namedValues(pt.postId -> postId, pt.tagId -> rubyTagId).toSQL.update.apply()

--- a/orm/src/test/scala/blog2/Connection.scala
+++ b/orm/src/test/scala/blog2/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("blog2"), "jdbc:h2:mem:blog2", "sa", "sa")
+  ConnectionPool.add("blog2", "jdbc:h2:mem:blog2", "sa", "sa")
 }

--- a/orm/src/test/scala/blog2/CreateTables.scala
+++ b/orm/src/test/scala/blog2/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("blog2"))
+  override val dbSeedsAutoSession = NamedAutoSession("blog2")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/blog2/Post.scala
+++ b/orm/src/test/scala/blog2/Post.scala
@@ -15,7 +15,7 @@ case class Post(
 )
 
 object Post extends SkinnyCRUDMapper[Post] with TimestampsFeature[Post] {
-  override val connectionPoolName = Symbol("blog2")
+  override val connectionPoolName = "blog2"
   override val tableName          = "posts"
   override val defaultAlias       = createAlias("p")
 

--- a/orm/src/test/scala/blog2/PostTag.scala
+++ b/orm/src/test/scala/blog2/PostTag.scala
@@ -12,7 +12,7 @@ case class PostTag(
 )
 
 object PostTag extends SkinnyJoinTable[PostTag] {
-  override val connectionPoolName = Symbol("blog2")
+  override val connectionPoolName = "blog2"
   override val tableName          = "posts_tags"
   override val defaultAlias       = createAlias("pt")
 

--- a/orm/src/test/scala/blog2/Tag.scala
+++ b/orm/src/test/scala/blog2/Tag.scala
@@ -12,7 +12,7 @@ case class Tag(
 )
 
 object Tag extends SkinnyCRUDMapper[Tag] with TimestampsFeature[Tag] {
-  override val connectionPoolName = Symbol("blog2")
+  override val connectionPoolName = "blog2"
   override val tableName          = "tags"
   override val defaultAlias       = createAlias("t")
 

--- a/orm/src/test/scala/issue219/ByDefaultSpec.scala
+++ b/orm/src/test/scala/issue219/ByDefaultSpec.scala
@@ -8,12 +8,12 @@ import skinny.orm._
 
 trait ByDefaultConnection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue219bydefault"), "jdbc:h2:mem:issue219bydefault;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue219bydefault", "jdbc:h2:mem:issue219bydefault;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait ByDefaultCreateTables extends DBSeeds { self: ByDefaultConnection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue219bydefault"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue219bydefault")
 
   addSeedSQL(
     sql"""
@@ -53,13 +53,13 @@ class ByDefaultSpec
   case class Tag(id: Long, name: String, articleId: Option[Long], article: Option[Article] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName = Symbol("issue219bydefault")
+    override val connectionPoolName = "issue219bydefault"
     override def defaultAlias       = createAlias("u")
 
     override def extract(rs: WrappedResultSet, rn: ResultName[User]) = autoConstruct(rs, rn)
   }
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName = Symbol("issue219bydefault")
+    override val connectionPoolName = "issue219bydefault"
     override def defaultAlias       = createAlias("a")
 
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user", "tags")
@@ -90,7 +90,7 @@ class ByDefaultSpec
     )
   }
   object Tag extends SkinnyCRUDMapper[Tag] {
-    override val connectionPoolName                                 = Symbol("issue219bydefault")
+    override val connectionPoolName                                 = "issue219bydefault"
     override def defaultAlias                                       = createAlias("t")
     override def extract(rs: WrappedResultSet, rn: ResultName[Tag]) = autoConstruct(rs, rn, "article")
 
@@ -111,11 +111,11 @@ class ByDefaultSpec
 
   import Article._
 
-  override def db(): DB = NamedDB(Symbol("issue219bydefault")).toDB()
+  override def db(): DB = NamedDB("issue219bydefault").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob")
     Seq(
       ("Hello World", Some(aliceId)),
       ("Getting Started with Scala", Some(bobId)),
@@ -123,12 +123,12 @@ class ByDefaultSpec
       ("How to user sbt", Some(aliceId))
     ).foreach {
       case (title, userId) =>
-        Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+        Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
   }
 
   def id(implicit session: DBSession): Long = {
-    Article.where(Symbol("title") -> "Functional Programming").apply().head.id
+    Article.where("title" -> "Functional Programming").apply().head.id
   }
 
   describe("find without associations") {

--- a/orm/src/test/scala/issue219/Issue219Spec.scala
+++ b/orm/src/test/scala/issue219/Issue219Spec.scala
@@ -8,12 +8,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue219"), "jdbc:h2:mem:issue219;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue219", "jdbc:h2:mem:issue219;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue219"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue219")
 
   addSeedSQL(
     sql"""
@@ -48,13 +48,13 @@ class Issue219Spec extends fixture.FunSpec with Matchers with Connection with Cr
   case class Tag(id: Long, name: String, articleId: Option[Long], article: Option[Article] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName = Symbol("issue219")
+    override val connectionPoolName = "issue219"
     override def defaultAlias       = createAlias("u")
 
     override def extract(rs: WrappedResultSet, rn: ResultName[User]) = autoConstruct(rs, rn)
   }
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("issue219")
+    override val connectionPoolName                                     = "issue219"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user", "tags")
 
@@ -84,7 +84,7 @@ class Issue219Spec extends fixture.FunSpec with Matchers with Connection with Cr
     )
   }
   object Tag extends SkinnyCRUDMapper[Tag] {
-    override val connectionPoolName                                 = Symbol("issue219")
+    override val connectionPoolName                                 = "issue219"
     override def defaultAlias                                       = createAlias("t")
     override def extract(rs: WrappedResultSet, rn: ResultName[Tag]) = autoConstruct(rs, rn, "article")
 
@@ -105,11 +105,11 @@ class Issue219Spec extends fixture.FunSpec with Matchers with Connection with Cr
 
   import Article._
 
-  override def db(): DB = NamedDB(Symbol("issue219")).toDB()
+  override def db(): DB = NamedDB("issue219").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob")
     Seq(
       ("Hello World", Some(aliceId)),
       ("Getting Started with Scala", Some(bobId)),
@@ -117,16 +117,16 @@ class Issue219Spec extends fixture.FunSpec with Matchers with Connection with Cr
       ("How to user sbt", Some(aliceId))
     ).foreach {
       case (title, userId) =>
-        Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+        Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
     val articles = Article.limit(2).apply()
-    Tag.createWithAttributes(Symbol("name") -> "Technical", Symbol("articleId")   -> articles(0).id)
-    Tag.createWithAttributes(Symbol("name") -> "Programming", Symbol("articleId") -> articles(0).id)
-    Tag.createWithAttributes(Symbol("name") -> "Scala", Symbol("articleId")       -> articles(1).id)
+    Tag.createWithAttributes("name" -> "Technical", "articleId"   -> articles(0).id)
+    Tag.createWithAttributes("name" -> "Programming", "articleId" -> articles(0).id)
+    Tag.createWithAttributes("name" -> "Scala", "articleId"       -> articles(1).id)
   }
 
   def id(implicit session: DBSession): Long = {
-    Article.where(Symbol("title") -> "Functional Programming").apply().head.id
+    Article.where("title" -> "Functional Programming").apply().head.id
   }
 
   describe("find without associations") {

--- a/orm/src/test/scala/issue229/Issue229Spec.scala
+++ b/orm/src/test/scala/issue229/Issue229Spec.scala
@@ -8,12 +8,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue229"), "jdbc:h2:mem:issue229;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue229", "jdbc:h2:mem:issue229;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue229"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue229")
 
   addSeedSQL(
     sql"""
@@ -39,13 +39,13 @@ class Issue229Spec extends fixture.FunSpec with Matchers with Connection with Cr
   case class Article(id: Long, title: String, userId: Option[Long], user: Option[User] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName = Symbol("issue229")
+    override val connectionPoolName = "issue229"
     override def defaultAlias       = createAlias("u")
 
     override def extract(rs: WrappedResultSet, rn: ResultName[User]) = autoConstruct(rs, rn)
   }
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("issue229")
+    override val connectionPoolName                                     = "issue229"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user")
 
@@ -64,28 +64,28 @@ class Issue229Spec extends fixture.FunSpec with Matchers with Connection with Cr
     }
   }
 
-  override def db(): DB = NamedDB(Symbol("issue229")).toDB()
+  override def db(): DB = NamedDB("issue229").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob")
     Seq(
       ("Hello World", Some(aliceId)),
       ("Getting Started with Scala", Some(bobId)),
       ("Functional Programming", None),
       ("How to user sbt", Some(aliceId))
     ).foreach {
-      case (title, userId) => Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+      case (title, userId) => Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
   }
 
   def id(implicit session: DBSession): Long = {
-    Article.where(Symbol("title") -> "Functional Programming").apply().head.id
+    Article.where("title" -> "Functional Programming").apply().head.id
   }
 
   describe("find empty with empty ids") {
     it("should return no results") { implicit session =>
-      Article.where(Symbol("id") -> Nil).apply().size should equal(0)
+      Article.where("id" -> Nil).apply().size should equal(0)
     }
   }
 

--- a/orm/src/test/scala/issue259/Spec.scala
+++ b/orm/src/test/scala/issue259/Spec.scala
@@ -9,12 +9,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue259"), "jdbc:h2:mem:issue259;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue259", "jdbc:h2:mem:issue259;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue259"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue259")
 
   addSeedSQL(
     sql"""
@@ -56,7 +56,7 @@ class HasOneHasManySpec extends fixture.FunSpec with Matchers with Connection wi
   case class Article(title: String, userId: Option[Long], user: Option[User] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName = Symbol("issue259")
+    override val connectionPoolName = "issue259"
     override def defaultAlias       = createAlias("u")
 
     lazy val articlesRef = hasMany[Article](
@@ -74,7 +74,7 @@ class HasOneHasManySpec extends fixture.FunSpec with Matchers with Connection wi
     }
   }
   object Nickname extends SkinnyNoIdCRUDMapper[Nickname] {
-    override val connectionPoolName                                      = Symbol("issue259")
+    override val connectionPoolName                                      = "issue259"
     override def defaultAlias                                            = createAlias("n")
     override def extract(rs: WrappedResultSet, rn: ResultName[Nickname]) = autoConstruct(rs, rn, "user")
 
@@ -84,7 +84,7 @@ class HasOneHasManySpec extends fixture.FunSpec with Matchers with Connection wi
     )
   }
   object Article extends SkinnyNoIdCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("issue259")
+    override val connectionPoolName                                     = "issue259"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user")
 
@@ -94,17 +94,17 @@ class HasOneHasManySpec extends fixture.FunSpec with Matchers with Connection wi
     )
   }
 
-  override def db(): DB = NamedDB(Symbol("issue259")).toDB()
+  override def db(): DB = NamedDB("issue259").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob") // Scala
-    val chrisId = User.createWithAttributes(Symbol("name") -> "Chris") // Scala
-    val denId   = User.createWithAttributes(Symbol("name") -> "Den")
-    val ericId  = User.createWithAttributes(Symbol("name") -> "Eric") // Scala
-    val fredId  = User.createWithAttributes(Symbol("name") -> "Fred")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob") // Scala
+    val chrisId = User.createWithAttributes("name" -> "Chris") // Scala
+    val denId   = User.createWithAttributes("name" -> "Den")
+    val ericId  = User.createWithAttributes("name" -> "Eric") // Scala
+    val fredId  = User.createWithAttributes("name" -> "Fred")
 
-    Nickname.createWithAttributes(Symbol("userId") -> bobId, Symbol("name") -> "Bobby")
+    Nickname.createWithAttributes("userId" -> bobId, "name" -> "Bobby")
 
     val titleAndUser = Seq(
       ("Hello World", Some(aliceId)),
@@ -123,7 +123,7 @@ class HasOneHasManySpec extends fixture.FunSpec with Matchers with Connection wi
     )
     titleAndUser.foreach {
       case (title, userId) =>
-        Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+        Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
   }
 

--- a/orm/src/test/scala/issue263/Issue263Spec.scala
+++ b/orm/src/test/scala/issue263/Issue263Spec.scala
@@ -9,12 +9,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue263"), "jdbc:h2:mem:issue263;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue263", "jdbc:h2:mem:issue263;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue263"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue263")
 
   addSeedSQL(
     sql"""
@@ -41,7 +41,7 @@ class Issue263Spec extends fixture.FunSpec with Matchers with Connection with Cr
   case class Article(id: Long, title: String, userId: Option[Long], user: Option[User] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName = Symbol("issue263")
+    override val connectionPoolName = "issue263"
     override def defaultAlias       = createAlias("u")
 
     lazy val articlesRef = hasMany[Article](
@@ -53,7 +53,7 @@ class Issue263Spec extends fixture.FunSpec with Matchers with Connection with Cr
     override def extract(rs: WrappedResultSet, rn: ResultName[User]) = autoConstruct(rs, rn, "articles")
   }
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("issue263")
+    override val connectionPoolName                                     = "issue263"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user")
 
@@ -63,15 +63,15 @@ class Issue263Spec extends fixture.FunSpec with Matchers with Connection with Cr
     )
   }
 
-  override def db(): DB = NamedDB(Symbol("issue263")).toDB()
+  override def db(): DB = NamedDB("issue263").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob") // Scala
-    val chrisId = User.createWithAttributes(Symbol("name") -> "Chris") // Scala
-    val denId   = User.createWithAttributes(Symbol("name") -> "Den")
-    val ericId  = User.createWithAttributes(Symbol("name") -> "Eric") // Scala
-    val fredId  = User.createWithAttributes(Symbol("name") -> "Fred")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob") // Scala
+    val chrisId = User.createWithAttributes("name" -> "Chris") // Scala
+    val denId   = User.createWithAttributes("name" -> "Den")
+    val ericId  = User.createWithAttributes("name" -> "Eric") // Scala
+    val fredId  = User.createWithAttributes("name" -> "Fred")
 
     val titleAndUser = Seq(
       ("Hello World", Some(aliceId)),
@@ -90,7 +90,7 @@ class Issue263Spec extends fixture.FunSpec with Matchers with Connection with Cr
     )
     titleAndUser.foreach {
       case (title, userId) =>
-        Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+        Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
   }
 

--- a/orm/src/test/scala/issue346/Issue347Spec.scala
+++ b/orm/src/test/scala/issue346/Issue347Spec.scala
@@ -9,12 +9,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("issue347"), "jdbc:h2:mem:issue347;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("issue347", "jdbc:h2:mem:issue347;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("issue347"))
+  override val dbSeedsAutoSession = NamedAutoSession("issue347")
 
   addSeedSQL(
     sql"""
@@ -41,7 +41,7 @@ class Issue347Spec extends fixture.FunSpec with Matchers with Connection with Cr
   case class Article(id: Long, title: String, userId: Option[Long], user: Option[User] = None)
 
   object User extends SkinnyCRUDMapper[User] {
-    override val connectionPoolName  = Symbol("issue347")
+    override val connectionPoolName  = "issue347"
     override val primaryKeyFieldName = "userId"
     override def defaultAlias        = createAlias("u")
 
@@ -61,7 +61,7 @@ class Issue347Spec extends fixture.FunSpec with Matchers with Connection with Cr
   }
 
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("issue347")
+    override val connectionPoolName                                     = "issue347"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "user")
 
@@ -71,15 +71,15 @@ class Issue347Spec extends fixture.FunSpec with Matchers with Connection with Cr
     )
   }
 
-  override def db(): DB = NamedDB(Symbol("issue347")).toDB()
+  override def db(): DB = NamedDB("issue347").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val aliceId = User.createWithAttributes(Symbol("name") -> "Alice")
-    val bobId   = User.createWithAttributes(Symbol("name") -> "Bob") // Scala
-    val chrisId = User.createWithAttributes(Symbol("name") -> "Chris") // Scala
-    val denId   = User.createWithAttributes(Symbol("name") -> "Den")
-    val ericId  = User.createWithAttributes(Symbol("name") -> "Eric") // Scala
-    val fredId  = User.createWithAttributes(Symbol("name") -> "Fred")
+    val aliceId = User.createWithAttributes("name" -> "Alice")
+    val bobId   = User.createWithAttributes("name" -> "Bob") // Scala
+    val chrisId = User.createWithAttributes("name" -> "Chris") // Scala
+    val denId   = User.createWithAttributes("name" -> "Den")
+    val ericId  = User.createWithAttributes("name" -> "Eric") // Scala
+    val fredId  = User.createWithAttributes("name" -> "Fred")
 
     val titleAndUser = Seq(
       ("Hello World", Some(aliceId)),
@@ -98,7 +98,7 @@ class Issue347Spec extends fixture.FunSpec with Matchers with Connection with Cr
     )
     titleAndUser.foreach {
       case (title, userId) =>
-        Article.createWithAttributes(Symbol("title") -> title, Symbol("userId") -> userId)
+        Article.createWithAttributes("title" -> title, "userId" -> userId)
     }
   }
 

--- a/orm/src/test/scala/service/Application.scala
+++ b/orm/src/test/scala/service/Application.scala
@@ -19,7 +19,7 @@ object Application
     with TimestampsFeature[Application]
     with SoftDeleteWithTimestampFeature[Application] {
 
-  override val connectionPoolName = Symbol("service")
+  override val connectionPoolName = "service"
   override val tableName          = "applications"
   override def defaultAlias       = createAlias("a")
 

--- a/orm/src/test/scala/service/Connection.scala
+++ b/orm/src/test/scala/service/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("service"), "jdbc:h2:mem:service", "sa", "sa")
+  ConnectionPool.add("service", "jdbc:h2:mem:service", "sa", "sa")
 }

--- a/orm/src/test/scala/service/CreateTables.scala
+++ b/orm/src/test/scala/service/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("service"))
+  override val dbSeedsAutoSession = NamedAutoSession("service")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/service/Service.scala
+++ b/orm/src/test/scala/service/Service.scala
@@ -16,7 +16,7 @@ case class Service(
 
 object Service extends SkinnyCRUDMapper[Service] with TimestampsFeature[Service] {
 
-  override val connectionPoolName  = Symbol("service")
+  override val connectionPoolName  = "service"
   override val tableName           = "services"
   override def defaultAlias        = createAlias("s")
   override def primaryKeyFieldName = "no"

--- a/orm/src/test/scala/service/ServiceSetting.scala
+++ b/orm/src/test/scala/service/ServiceSetting.scala
@@ -15,7 +15,7 @@ case class ServiceSetting(
 )
 
 object ServiceSetting extends SkinnyCRUDMapper[ServiceSetting] with TimestampsFeature[ServiceSetting] {
-  override val connectionPoolName = Symbol("service")
+  override val connectionPoolName = "service"
   override val tableName          = "service_settings"
   override def defaultAlias       = createAlias("ss")
 

--- a/orm/src/test/scala/service/ServiceSpec.scala
+++ b/orm/src/test/scala/service/ServiceSpec.scala
@@ -7,13 +7,13 @@ import org.scalatest._
 
 class ServiceSpec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("service")).toDB()
+  override def db(): DB = NamedDB("service").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val serviceNo = Service.createWithAttributes(Symbol("name") -> "Cool Web Service")
-    Application.createWithAttributes(Symbol("name") -> "Smartphone site", Symbol("serviceNo")   -> serviceNo)
-    Application.createWithAttributes(Symbol("name") -> "PC site", Symbol("serviceNo")           -> serviceNo)
-    Application.createWithAttributes(Symbol("name") -> "Featurephone site", Symbol("serviceNo") -> serviceNo)
+    val serviceNo = Service.createWithAttributes("name" -> "Cool Web Service")
+    Application.createWithAttributes("name" -> "Smartphone site", "serviceNo"   -> serviceNo)
+    Application.createWithAttributes("name" -> "PC site", "serviceNo"           -> serviceNo)
+    Application.createWithAttributes("name" -> "Featurephone site", "serviceNo" -> serviceNo)
   }
 
   describe("hasMany without byDefault") {

--- a/orm/src/test/scala/skinny/dbmigration/DBMigrationSpec.scala
+++ b/orm/src/test/scala/skinny/dbmigration/DBMigrationSpec.scala
@@ -6,7 +6,7 @@ import scalikejdbc.ConnectionPool
 class DBMigrationSpec extends FlatSpec with Matchers with DBMigration {
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("DBMigrationSpec"), "jdbc:h2:mem:DBMigrationSpec;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("DBMigrationSpec", "jdbc:h2:mem:DBMigrationSpec;MODE=PostgreSQL", "sa", "sa")
 
   it should "have #migrate" in {
     migrate("migration", "DBMigrationSpec")

--- a/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
+++ b/orm/src/test/scala/skinny/orm/SkinnyORMSpec.scala
@@ -20,13 +20,13 @@ class SkinnyORMSpec
   override def fixture(implicit session: DBSession): Unit = {
 
     // #createWithNamedValues
-    val countryId1 = Country.createWithAttributes(Symbol("name") -> "Japan")
-    val countryId2 = Country.createWithAttributes(Symbol("name") -> "China")
+    val countryId1 = Country.createWithAttributes("name" -> "Japan")
+    val countryId2 = Country.createWithAttributes("name" -> "China")
 
-    val groupId1 = GroupMapper.createWithAttributes(Symbol("name") -> "Scala Users Group")
-    val groupId2 = GroupMapper.createWithAttributes(Symbol("name") -> "Java Group")
+    val groupId1 = GroupMapper.createWithAttributes("name" -> "Scala Users Group")
+    val groupId2 = GroupMapper.createWithAttributes("name" -> "Java Group")
 
-    val companyId = Company.createWithAttributes(Symbol("name") -> "Typesafe", Symbol("countryId") -> countryId1)
+    val companyId = Company.createWithAttributes("name" -> "Typesafe", "countryId" -> countryId1)
 
     Member.withColumns { m =>
       // Member doesn't use TimestampsFeature
@@ -46,17 +46,17 @@ class SkinnyORMSpec
         m.createdAt -> DateTime.now
       )
 
-      Name.createWithAttributes(Symbol("memberId") -> alice, Symbol("first") -> "Alice", Symbol("last") -> "Cooper")
-      Name.createWithAttributes(Symbol("memberId") -> bob, Symbol("first")   -> "Bob", Symbol("last")   -> "Marley")
-      Name.createWithAttributes(Symbol("memberId") -> chris, Symbol("first") -> "Chris", Symbol("last") -> "Birchall")
+      Name.createWithAttributes("memberId" -> alice, "first" -> "Alice", "last" -> "Cooper")
+      Name.createWithAttributes("memberId" -> bob, "first"   -> "Bob", "last"   -> "Marley")
+      Name.createWithAttributes("memberId" -> chris, "first" -> "Chris", "last" -> "Birchall")
 
-      GroupMember.createWithAttributes(Symbol("memberId") -> alice, Symbol("groupId") -> groupId1)
-      GroupMember.createWithAttributes(Symbol("memberId") -> bob, Symbol("groupId")   -> groupId1)
-      GroupMember.createWithAttributes(Symbol("memberId") -> bob, Symbol("groupId")   -> groupId2)
+      GroupMember.createWithAttributes("memberId" -> alice, "groupId" -> groupId1)
+      GroupMember.createWithAttributes("memberId" -> bob, "groupId"   -> groupId1)
+      GroupMember.createWithAttributes("memberId" -> bob, "groupId"   -> groupId2)
 
-      val skillId = Skill.createWithAttributes(Symbol("name") -> "Programming")
-      Skill.updateById(skillId).withAttributes(Symbol("name") -> "Web development")
-      MemberSkill.createWithAttributes(Symbol("memberId")     -> alice, Symbol("skillId") -> skillId)
+      val skillId = Skill.createWithAttributes("name" -> "Programming")
+      Skill.updateById(skillId).withAttributes("name" -> "Web development")
+      MemberSkill.createWithAttributes("memberId"     -> alice, "skillId" -> skillId)
     }
   }
 
@@ -86,7 +86,7 @@ class SkinnyORMSpec
 
   describe("SkinnyRecord") {
     it("should act like ActiveRecord") { implicit session =>
-      val countryId = Country.createWithAttributes(Symbol("name") -> "Brazil")
+      val countryId = Country.createWithAttributes("name" -> "Brazil")
       val country   = Country.findById(countryId).get
 
       country.copy(name = "BRAZIL").save()
@@ -116,16 +116,16 @@ class SkinnyORMSpec
       val now    = DateTime.now
 
       val member1Id = Member.createWithAttributes(
-        Symbol("countryId") -> mentor.countryId,
-        Symbol("companyId") -> mentor.companyId,
-        Symbol("mentorId")  -> mentor.id,
-        Symbol("createdAt") -> now
+        "countryId" -> mentor.countryId,
+        "companyId" -> mentor.companyId,
+        "mentorId"  -> mentor.id,
+        "createdAt" -> now
       )
       val member2Id = Member.createWithAttributes(
-        Symbol("countryId") -> mentor.countryId,
-        Symbol("companyId") -> mentor.companyId,
-        Symbol("mentorId")  -> mentor.id,
-        Symbol("createdAt") -> now
+        "countryId" -> mentor.countryId,
+        "companyId" -> mentor.companyId,
+        "mentorId"  -> mentor.id,
+        "createdAt" -> now
       )
 
       val member = Member.findBy(
@@ -171,50 +171,50 @@ class SkinnyORMSpec
       Member.count() should be > (0L)
     }
 
-    it("should have #count(Symbol)") { implicit session =>
-      Member.count(Symbol("countryId"), false) should equal(3L)
-      Member.count(Symbol("countryId"), true) should equal(2L)
+    it("should have #count(String)") { implicit session =>
+      Member.count("countryId", false) should equal(3L)
+      Member.count("countryId", true) should equal(2L)
     }
 
-    it("should have #distinctCount(Symbol)") { implicit session =>
+    it("should have #distinctCount(String)") { implicit session =>
       Member.distinctCount() should equal(3L)
-      Member.distinctCount(Symbol("countryId")) should equal(2L)
+      Member.distinctCount("countryId") should equal(2L)
     }
 
     // http://api.rubyonrails.org/classes/ActiveRecord/Calculations.html
     it("should have #count, #sum, #average, #maximum and #minimum") { implicit s =>
-      val id = Product.createWithAttributes(Symbol("name") -> "How to learn Scala", Symbol("priceYen") -> 1230)
-      Product.createWithAttributes(Symbol("name") -> "How to learn Scala 2", Symbol("priceYen") -> 1800)
+      val id = Product.createWithAttributes("name" -> "How to learn Scala", "priceYen" -> 1230)
+      Product.createWithAttributes("name" -> "How to learn Scala 2", "priceYen" -> 1800)
 
       val p = Product.defaultAlias
 
       Product.count() should equal(2)
       Product.where(sqls.eq(p.id, id.value)).count() should equal(1)
 
-      Product.where(sqls.isNotNull(p.priceYen)).sum(Symbol("priceYen")) should equal(3030)
-      Product.sum(Symbol("priceYen")) should equal(3030)
+      Product.where(sqls.isNotNull(p.priceYen)).sum("priceYen") should equal(3030)
+      Product.sum("priceYen") should equal(3030)
 
       // NOTICE: H2 and others returns value without decimal part.
       // https://hibernate.atlassian.net/browse/HHH-5173
-      Product.average(Symbol("priceYen")) should equal(1515)
-      Product.average(Symbol("priceYen"), Some(2)) should equal(1515)
-      Product.minimum(Symbol("priceYen")) should equal(1230)
-      Product.maximum(Symbol("priceYen")) should equal(1800)
+      Product.average("priceYen") should equal(1515)
+      Product.average("priceYen", Some(2)) should equal(1515)
+      Product.minimum("priceYen") should equal(1230)
+      Product.maximum("priceYen") should equal(1800)
 
-      Product.avg(Symbol("priceYen")) should equal(1515)
-      Product.avg(Symbol("priceYen"), Some(3)) should equal(1515)
-      Product.min(Symbol("priceYen")) should equal(1230)
-      Product.max(Symbol("priceYen")) should equal(1800)
+      Product.avg("priceYen") should equal(1515)
+      Product.avg("priceYen", Some(3)) should equal(1515)
+      Product.min("priceYen") should equal(1230)
+      Product.max("priceYen") should equal(1800)
 
-      Product.where(sqls.isNotNull(p.priceYen)).average(Symbol("priceYen")) should equal(1515)
-      Product.where(sqls.isNotNull(p.priceYen)).average(Symbol("priceYen"), Some(2)) should equal(1515)
-      Product.where(sqls.isNotNull(p.priceYen)).minimum(Symbol("priceYen")) should equal(1230)
-      Product.where(sqls.isNotNull(p.priceYen)).maximum(Symbol("priceYen")) should equal(1800)
+      Product.where(sqls.isNotNull(p.priceYen)).average("priceYen") should equal(1515)
+      Product.where(sqls.isNotNull(p.priceYen)).average("priceYen", Some(2)) should equal(1515)
+      Product.where(sqls.isNotNull(p.priceYen)).minimum("priceYen") should equal(1230)
+      Product.where(sqls.isNotNull(p.priceYen)).maximum("priceYen") should equal(1800)
 
-      Product.where(sqls.isNotNull(p.priceYen)).avg(Symbol("priceYen")) should equal(1515)
-      Product.where(sqls.isNotNull(p.priceYen)).avg(Symbol("priceYen"), Some(3)) should equal(1515)
-      Product.where(sqls.isNotNull(p.priceYen)).min(Symbol("priceYen")) should equal(1230)
-      Product.where(sqls.isNotNull(p.priceYen)).max(Symbol("priceYen")) should equal(1800)
+      Product.where(sqls.isNotNull(p.priceYen)).avg("priceYen") should equal(1515)
+      Product.where(sqls.isNotNull(p.priceYen)).avg("priceYen", Some(3)) should equal(1515)
+      Product.where(sqls.isNotNull(p.priceYen)).min("priceYen") should equal(1230)
+      Product.where(sqls.isNotNull(p.priceYen)).max("priceYen") should equal(1800)
     }
 
     it("should have #findAllBy(SQLSyntax, Int, Int)") { implicit session =>
@@ -258,11 +258,11 @@ class SkinnyORMSpec
     it("should have #updateById(Long)") { implicit session =>
       val countryId = Country.limit(1).offset(0).apply().map(_.id).head
       val memberId = Member.createWithAttributes(
-        Symbol("countryId") -> countryId,
-        Symbol("createdAt") -> DateTime.now
+        "countryId" -> countryId,
+        "createdAt" -> DateTime.now
       )
       val mentorId = Member.limit(1).offset(0).apply().head.id
-      Member.updateById(memberId).withAttributes(Symbol("mentorId") -> mentorId)
+      Member.updateById(memberId).withAttributes("mentorId" -> mentorId)
       val updated = Member.findById(memberId)
       updated.get.mentorId should equal(Some(mentorId))
     }
@@ -270,8 +270,8 @@ class SkinnyORMSpec
     it("should have #deleteById(Long)") { implicit session =>
       val countryId = Country.limit(1).offset(0).apply().map(_.id).head
       val memberId = Member.createWithAttributes(
-        Symbol("countryId") -> countryId,
-        Symbol("createdAt") -> DateTime.now
+        "countryId" -> countryId,
+        "createdAt" -> DateTime.now
       )
       Member.deleteById(memberId)
     }
@@ -322,7 +322,7 @@ class SkinnyORMSpec
       val allMembers = Member.findAll()
 
       val c        = Country.defaultAlias
-      val japan    = Country.where(Symbol("name") -> "Japan").orderBy(c.id.desc).limit(1000).offset(0).apply().head
+      val japan    = Country.where("name" -> "Japan").orderBy(c.id.desc).limit(1000).offset(0).apply().head
       val expected = allMembers.filter(_.countryId == japan.id)
 
       val m      = Member.defaultAlias
@@ -331,17 +331,17 @@ class SkinnyORMSpec
     }
 
     it("should have #orderBy in Querying APIs") { implicit session =>
-      val id1 = Skill.createWithAttributes(Symbol("name") -> "Skill_B")
-      val id2 = Skill.createWithAttributes(Symbol("name") -> "Skill_A")
-      val id3 = Skill.createWithAttributes(Symbol("name") -> "Skill_B")
+      val id1 = Skill.createWithAttributes("name" -> "Skill_B")
+      val id2 = Skill.createWithAttributes("name" -> "Skill_A")
+      val id3 = Skill.createWithAttributes("name" -> "Skill_B")
       val s   = Skill.defaultAlias
-      val ids = Skill.where(Symbol("id") -> Seq(id1, id2, id3)).orderBy(s.name.asc, s.id.desc).apply().map(_.id)
+      val ids = Skill.where("id" -> Seq(id1, id2, id3)).orderBy(s.name.asc, s.id.desc).apply().map(_.id)
       ids should equal(Seq(id2, id3, id1))
     }
 
     it("should have #paginate in Querying APIs") { implicit session =>
       Seq("America", "Russia", "Korea", "India", "Brazil").foreach { name =>
-        Country.createWithAttributes(Symbol("name") -> name)
+        Country.createWithAttributes("name" -> name)
       }
       val res1 = Country.limit(3).offset(3).apply().map(_.id)
       val res2 = Country.paginate(Pagination.page(2).per(3)).apply().map(_.id)
@@ -370,9 +370,9 @@ class SkinnyORMSpec
     it("should have #hasMany") { implicit session =>
       Member.withAlias { m =>
         val members      = Member.findAll()
-        val membersByIds = Member.where(Symbol("id") -> members.map(_.id)).apply()
+        val membersByIds = Member.where("id" -> members.map(_.id)).apply()
         membersByIds.size should equal(members.size)
-        Member.where(Symbol("id") -> members.map(_.id)).count() should equal(members.size)
+        Member.where("id" -> members.map(_.id)).count() should equal(members.size)
 
         val withGroups = members.filter(_.name.get.first == "Bob").head
         withGroups.groups.size should equal(2)
@@ -403,7 +403,7 @@ class SkinnyORMSpec
 
         {
           val membersWithSkills =
-            Member.joins(Member.skillsSimpleRef).where(Symbol("id") -> Member.findAll().map(_.id)).apply()
+            Member.joins(Member.skillsSimpleRef).where("id" -> Member.findAll().map(_.id)).apply()
           val withSkills = membersWithSkills.filter(_.name.get.first == "Alice").head
           withSkills.skills.size should equal(1)
           val withoutSkills = membersWithSkills.filter(_.name.get.first == "Chris").head
@@ -421,7 +421,7 @@ class SkinnyORMSpec
 
         {
           val membersWithSkills =
-            Member.joins(Member.skillsVerboseRef).where(Symbol("id") -> Member.findAll().map(_.id)).apply()
+            Member.joins(Member.skillsVerboseRef).where("id" -> Member.findAll().map(_.id)).apply()
           val withSkills = membersWithSkills.filter(_.name.get.first == "Alice").head
           withSkills.skills.size should equal(1)
           val withoutSkills = membersWithSkills.filter(_.name.get.first == "Chris").head
@@ -434,20 +434,20 @@ class SkinnyORMSpec
 
   describe("Timestamps") {
     it("should fill timestamps correctly") { implicit session =>
-      val id1 = Skill.createWithAttributes(Symbol("name")     -> "Scala")
+      val id1 = Skill.createWithAttributes("name"             -> "Scala")
       val id2 = Skill.createWithNamedValues(Skill.column.name -> "Java")
 
-      Skill.where(Symbol("id") -> Seq(id1, id2)).apply().foreach { skill =>
+      Skill.where("id" -> Seq(id1, id2)).apply().foreach { skill =>
         skill.createdAt should not be (null)
         skill.updatedAt should not be (null)
       }
 
       Thread.sleep(100L)
 
-      Skill.updateById(id1).withAttributes(Symbol("name")     -> "Scala Programming")
+      Skill.updateById(id1).withAttributes("name"             -> "Scala Programming")
       Skill.updateById(id2).withNamedValues(Skill.column.name -> "Java Programming")
 
-      Skill.where(Symbol("id") -> Seq(id1, id2)).apply().foreach { skill =>
+      Skill.where("id" -> Seq(id1, id2)).apply().foreach { skill =>
         skill.updatedAt should not equal (skill.createdAt)
       }
     }
@@ -459,12 +459,12 @@ class SkinnyORMSpec
       val skill = LightFactoryGirl(Skill).create()
 
       // with optimistic lock
-      Skill.updateByIdAndVersion(skill.id, skill.lockVersion).withAttributes(Symbol("name") -> "Java Programming")
+      Skill.updateByIdAndVersion(skill.id, skill.lockVersion).withAttributes("name" -> "Java Programming")
       intercept[OptimisticLockException] {
-        Skill.updateByIdAndVersion(skill.id, skill.lockVersion).withAttributes(Symbol("name") -> "Ruby Programming")
+        Skill.updateByIdAndVersion(skill.id, skill.lockVersion).withAttributes("name" -> "Ruby Programming")
       }
       // without lock
-      Skill.updateById(skill.id).withAttributes(Symbol("name") -> "Ruby Programming")
+      Skill.updateById(skill.id).withAttributes("name" -> "Ruby Programming")
     }
 
     it("should delete with lock version") { implicit session =>
@@ -481,24 +481,24 @@ class SkinnyORMSpec
 
     it("should update with lock timestamp") { implicit session =>
       val member = LightFactoryGirl(Member)
-        .withVariables(Symbol("countryId") -> LightFactoryGirl(Country, Symbol("countryyy")).create().id)
-        .create(Symbol("companyId") -> LightFactoryGirl(Company).create().id, Symbol("createdAt") -> DateTime.now)
-      val name = LightFactoryGirl(Name).create(Symbol("memberId") -> member.id)
+        .withVariables("countryId" -> LightFactoryGirl(Country, "countryyy").create().id)
+        .create("companyId" -> LightFactoryGirl(Company).create().id, "createdAt" -> DateTime.now)
+      val name = LightFactoryGirl(Name).create("memberId" -> member.id)
 
       // with optimistic lock
-      Name.updateByIdAndTimestamp(name.memberId, name.updatedAt).withAttributes(Symbol("first") -> "Kaz")
+      Name.updateByIdAndTimestamp(name.memberId, name.updatedAt).withAttributes("first" -> "Kaz")
       intercept[OptimisticLockException] {
-        Name.updateByIdAndTimestamp(name.memberId, name.updatedAt).withAttributes(Symbol("first") -> "Kaz")
+        Name.updateByIdAndTimestamp(name.memberId, name.updatedAt).withAttributes("first" -> "Kaz")
       }
       // without lock
-      Name.updateById(name.memberId).withAttributes(Symbol("first") -> "Kaz")
+      Name.updateById(name.memberId).withAttributes("first" -> "Kaz")
     }
 
     it("should delete with lock timestamp") { implicit session =>
       val member = LightFactoryGirl(Member)
-        .withVariables(Symbol("countryId") -> LightFactoryGirl(Country, Symbol("countryyy")).create().id)
-        .create(Symbol("companyId") -> LightFactoryGirl(Company).create().id, Symbol("createdAt") -> DateTime.now)
-      val name = LightFactoryGirl(Name).create(Symbol("memberId") -> member.id)
+        .withVariables("countryId" -> LightFactoryGirl(Country, "countryyy").create().id)
+        .create("companyId" -> LightFactoryGirl(Company).create().id, "createdAt" -> DateTime.now)
+      val name = LightFactoryGirl(Name).create("memberId" -> member.id)
 
       // with optimistic lock
       Name.deleteByIdAndOptionalTimestamp(name.memberId, name.updatedAt)
@@ -534,28 +534,28 @@ class SkinnyORMSpec
 
       val book2 =
         LightFactoryGirl(Book)
-          .withAttributes(Symbol("isbn") -> "11111-2222-33333", Symbol("title") -> "Play2 in Action")
+          .withAttributes("isbn" -> "11111-2222-33333", "title" -> "Play2 in Action")
           .create()
       book2.isbn should equal(ISBN("11111-2222-33333"))
       book2.destroy()
 
       val book3 =
-        LightFactoryGirl(Book).create(Symbol("isbn") -> ISBN("aaaa-bbbb-cccc"), Symbol("title") -> "Play3 in Action")
+        LightFactoryGirl(Book).create("isbn" -> ISBN("aaaa-bbbb-cccc"), "title" -> "Play3 in Action")
       book3.isbn should equal(ISBN("aaaa-bbbb-cccc"))
       book3.title should equal("Play3 in Action")
 
-      val isbn: ISBN = Book.createWithAttributes(Symbol("title") -> "ScalikeJDBC Cookbook")
-      ISBNMaster.createWithAttributes(Symbol("isbn") -> isbn, Symbol("publisher") -> "O'Reilly")
-      LightFactoryGirl(ISBNMaster).withVariables(Symbol("isbn") -> java.util.UUID.randomUUID).create()
+      val isbn: ISBN = Book.createWithAttributes("title" -> "ScalikeJDBC Cookbook")
+      ISBNMaster.createWithAttributes("isbn" -> isbn, "publisher" -> "O'Reilly")
+      LightFactoryGirl(ISBNMaster).withVariables("isbn" -> java.util.UUID.randomUUID).create()
 
       val newBook = Book.findById(isbn).get
       newBook.title should equal("ScalikeJDBC Cookbook")
       newBook.isbnMaster.map(_.publisher) should equal(Some("O'Reilly"))
 
-      Book.createWithAttributes(Symbol("title") -> "Skinny Framework in Action")
+      Book.createWithAttributes("title" -> "Skinny Framework in Action")
       Book.findAll().size should equal(3)
 
-      Book.updateById(isbn).withAttributes(Symbol("title") -> "ScalikeJDBC Cookbook 2")
+      Book.updateById(isbn).withAttributes("title" -> "ScalikeJDBC Cookbook 2")
       Book.findById(isbn).map(_.title) should equal(Some("ScalikeJDBC Cookbook 2"))
 
       Book.deleteById(isbn)
@@ -566,7 +566,7 @@ class SkinnyORMSpec
     it("should deal with typed auto-increment value") { implicit s =>
       // using typed auto-increment value
       val productId: ProductId =
-        Product.createWithAttributes(Symbol("name") -> "How to learn Scala", Symbol("priceYen") -> 2000)
+        Product.createWithAttributes("name" -> "How to learn Scala", "priceYen" -> 2000)
       Product.findById(productId).map(_.name) should equal(Some("How to learn Scala"))
 
       Product.deleteById(productId)
@@ -575,11 +575,11 @@ class SkinnyORMSpec
       // since h2 database 1.4.197, setting a specific value for an auto-generated column is no longer allowed.
       val productId2: ProductId = Product.createWithAttributes(
                                                                /*'id -> ProductId(777), */
-                                                               Symbol("name")     -> "How to learn Ruby",
-                                                               Symbol("priceYen") -> 1800)
+                                                               "name"     -> "How to learn Ruby",
+                                                               "priceYen" -> 1800)
       Product.findById(productId2).map(_.name) should equal(Some("How to learn Ruby"))
 
-      Product.updateById(productId2).withAttributes(Symbol("priceYen") -> 1950)
+      Product.updateById(productId2).withAttributes("priceYen" -> 1950)
       Product.findById(productId2).map(_.priceYen) should equal(Some(1950))
     }
 
@@ -702,9 +702,9 @@ class SkinnyORMSpec
         val before  = LegacyAccount.count()
         val before2 = LegacyAccount2.count()
         LegacyAccount.createWithAttributes(
-          Symbol("accountCode") -> "foo",
-          Symbol("userId")      -> None,
-          Symbol("name")        -> "Alice"
+          "accountCode" -> "foo",
+          "userId"      -> None,
+          "name"        -> "Alice"
         )
         val after  = LegacyAccount.count()
         val after2 = LegacyAccount2.count()
@@ -715,14 +715,14 @@ class SkinnyORMSpec
       }
 
       LegacyAccount.createWithAttributes(
-        Symbol("accountCode") -> "sera",
-        Symbol("userId")      -> Some(123),
-        Symbol("name")        -> "Sera"
+        "accountCode" -> "sera",
+        "userId"      -> Some(123),
+        "name"        -> "Sera"
       )
       LegacyAccount.createWithAttributes(
-        Symbol("accountCode") -> "kaz",
-        Symbol("userId")      -> Some(333),
-        Symbol("name")        -> "Kaz"
+        "accountCode" -> "kaz",
+        "userId"      -> Some(333),
+        "name"        -> "Kaz"
       )
 
       val accounts  = LegacyAccount.findAll()
@@ -733,7 +733,7 @@ class SkinnyORMSpec
       {
         LegacyAccount.findBy(sqls.eq(l.name, "Alice")).get.accountCode should equal("foo")
         LegacyAccount2.findBy(sqls.eq(l.name, "Alice")).get.accountCode should equal("foo")
-        LegacyAccount.updateBy(sqls.eq(c.name, "Alice")).withAttributes(Symbol("accountCode") -> "bar")
+        LegacyAccount.updateBy(sqls.eq(c.name, "Alice")).withAttributes("accountCode" -> "bar")
         LegacyAccount.findBy(sqls.eq(l.name, "Alice")).get.accountCode should equal("bar")
         LegacyAccount2.findBy(sqls.eq(l.name, "Alice")).get.accountCode should equal("bar")
       }
@@ -753,10 +753,10 @@ class SkinnyORMSpec
     it("should have associations for SkinnyNoIdCRUDMapper") { implicit s =>
       val (t1, t2) = (Table1.defaultAlias, Table2.defaultAlias)
 
-      Table1.createWithAttributes(Symbol("num") -> 1, Symbol("name") -> "Java")
-      Table1.createWithAttributes(Symbol("num") -> 2, Symbol("name") -> "Scala")
+      Table1.createWithAttributes("num" -> 1, "name" -> "Java")
+      Table1.createWithAttributes("num" -> 2, "name" -> "Scala")
 
-      Table2.createWithAttributes(Symbol("label") -> "Java")
+      Table2.createWithAttributes("label" -> "Java")
 
       {
         val java = Table2.findBy(sqls.eq(t2.label, "Java"))

--- a/orm/src/test/scala/skinny/orm/feature/AssociationsFeatureSpec.scala
+++ b/orm/src/test/scala/skinny/orm/feature/AssociationsFeatureSpec.scala
@@ -9,12 +9,9 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
   behavior of "AssociationsFeature"
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("AssociationsFeatureSpec"),
-                     "jdbc:h2:mem:AssociationsFeatureSpec;MODE=PostgreSQL",
-                     "sa",
-                     "sa")
+  ConnectionPool.add("AssociationsFeatureSpec", "jdbc:h2:mem:AssociationsFeatureSpec;MODE=PostgreSQL", "sa", "sa")
 
-  NamedDB(Symbol("AssociationsFeatureSpec")).autoCommit { implicit s =>
+  NamedDB("AssociationsFeatureSpec").autoCommit { implicit s =>
     sql"create table company(id bigserial, name varchar(100) not null)".execute.apply()
     sql"create table person(id bigserial, name varchar(100) not null, company_id bigint references company(id))".execute
       .apply()
@@ -30,12 +27,12 @@ class AssociationsFeatureSpec extends FlatSpec with Matchers {
   case class Company(id: Long, name: String)
 
   object Person extends SkinnyMapper[Person] {
-    override def connectionPoolName                                   = Symbol("AssociationsFeatureSpec")
+    override def connectionPoolName                                   = "AssociationsFeatureSpec"
     override def defaultAlias                                         = createAlias("p")
     override def extract(rs: WrappedResultSet, n: ResultName[Person]) = autoConstruct(rs, n, "company")
   }
   object Company extends SkinnyMapper[Company] {
-    override def connectionPoolName                                    = Symbol("AssociationsFeatureSpec")
+    override def connectionPoolName                                    = "AssociationsFeatureSpec"
     override def defaultAlias                                          = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = autoConstruct(rs, n)
   }

--- a/orm/src/test/scala/skinny/orm/feature/CRUDFeatureSpec.scala
+++ b/orm/src/test/scala/skinny/orm/feature/CRUDFeatureSpec.scala
@@ -9,9 +9,9 @@ class CRUDFeatureSpec extends FlatSpec with Matchers {
   behavior of "CRUDFeature"
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("CRUDFeatureSpec"), "jdbc:h2:mem:CRUDFeatureSpec;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("CRUDFeatureSpec", "jdbc:h2:mem:CRUDFeatureSpec;MODE=PostgreSQL", "sa", "sa")
 
-  NamedDB(Symbol("CRUDFeatureSpec")).autoCommit { implicit s =>
+  NamedDB("CRUDFeatureSpec").autoCommit { implicit s =>
     sql"create table company(id bigserial, name varchar(100) not null)".execute.apply()
     sql"create table person(id bigserial, name varchar(100) not null, company_id bigint references company(id))".execute
       .apply()
@@ -21,12 +21,12 @@ class CRUDFeatureSpec extends FlatSpec with Matchers {
   case class Company(id: Long, name: String)
 
   object Person extends SkinnyCRUDMapper[Person] {
-    override def connectionPoolName                                   = Symbol("CRUDFeatureSpec")
+    override def connectionPoolName                                   = "CRUDFeatureSpec"
     override def defaultAlias                                         = createAlias("p")
     override def extract(rs: WrappedResultSet, n: ResultName[Person]) = autoConstruct(rs, n, "company")
   }
   object Company extends SkinnyCRUDMapper[Company] {
-    override def connectionPoolName                                    = Symbol("CRUDFeatureSpec")
+    override def connectionPoolName                                    = "CRUDFeatureSpec"
     override def defaultAlias                                          = createAlias("c")
     override def extract(rs: WrappedResultSet, n: ResultName[Company]) = autoConstruct(rs, n)
   }
@@ -49,17 +49,17 @@ class CRUDFeatureSpec extends FlatSpec with Matchers {
     Person.findModels(1, 1)
   }
   it should "have #findModel" in {
-    val id = Person.createWithAttributes(Symbol("name") -> "Alice")
+    val id = Person.createWithAttributes("name" -> "Alice")
     Person.findModel(id).isDefined should equal(true)
   }
 
   it should "have #updateModelById" in {
-    val id = Person.createWithAttributes(Symbol("name") -> "Alice")
+    val id = Person.createWithAttributes("name" -> "Alice")
     Person.updateModelById(id, StrongParameters(Map("name" -> "Bob")).permit("name" -> ParamType.String))
   }
 
   it should "have #deleteModelById" in {
-    val id = Person.createWithAttributes(Symbol("name") -> "Alice")
+    val id = Person.createWithAttributes("name" -> "Alice")
     Person.deleteModelById(id)
   }
 

--- a/orm/src/test/scala/skinny/orm/feature/TimestampsFeatureSpec.scala
+++ b/orm/src/test/scala/skinny/orm/feature/TimestampsFeatureSpec.scala
@@ -77,7 +77,7 @@ create table my_with_id (
       loaded2.updatedAt shouldNot be(loaded1.updatedAt)
 
       info("Specified value is used when a user wants.")
-      WithId.updateById(id).withAttributes(Symbol("createdAt") -> t1, Symbol("updatedAt") -> t2)
+      WithId.updateById(id).withAttributes("createdAt" -> t1, "updatedAt" -> t2)
       val loaded3 = WithId.findById(id).get
       loaded3.createdAt should be(t1)
       loaded3.updatedAt should be(t2)
@@ -87,7 +87,7 @@ create table my_with_id (
   describe("WithoutId") {
     it("assigns/updates timestamps") { implicit session =>
       info("It automatically assigns createdAt and updatedAt.")
-      NoId.createWithAttributes(Symbol("a") -> 1, Symbol("b") -> 2)
+      NoId.createWithAttributes("a" -> 1, "b" -> 2)
       val findCond = sqls.eq(NoId.column.a, 1).and.eq(NoId.column.b, 2)
       val loaded1  = NoId.findBy(findCond).get
       loaded1.createdAt should be(loaded1.updatedAt)
@@ -100,7 +100,7 @@ create table my_with_id (
       loaded2.updatedAt shouldNot be(loaded1.updatedAt)
 
       info("Specified value is used when a user wants.")
-      NoId.updateBy(findCond).withAttributes(Symbol("createdAt") -> t1, Symbol("updatedAt") -> t2)
+      NoId.updateBy(findCond).withAttributes("createdAt" -> t1, "updatedAt" -> t2)
       val loaded3 = NoId.findBy(findCond).get
       loaded3.createdAt should be(t1)
       loaded3.updatedAt should be(t2)

--- a/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
+++ b/orm/src/test/scala/skinny/orm/servlet/TxPerRequestFilterSpec.scala
@@ -11,10 +11,10 @@ import scalikejdbc._
 class TxPerRequestFilterSpec extends FunSpec with Matchers with MockitoSugar {
 
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("TxPerRequestFilterSpec_ORM"), "jdbc:h2:mem:TxPerRequestFilterSpec_ORM", "sa", "sa")
+  ConnectionPool.add("TxPerRequestFilterSpec_ORM", "jdbc:h2:mem:TxPerRequestFilterSpec_ORM", "sa", "sa")
 
   val filter = new TxPerRequestFilter {
-    override def connectionPool = ConnectionPool.get(Symbol("TxPerRequestFilterSpec_ORM"))
+    override def connectionPool = ConnectionPool.get("TxPerRequestFilterSpec_ORM")
   }
 
   describe("TxPerRequestFilter") {

--- a/orm/src/test/scala/test001/Connection.scala
+++ b/orm/src/test/scala/test001/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test001"), "jdbc:h2:mem:test001;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test001", "jdbc:h2:mem:test001;MODE=PostgreSQL", "sa", "sa")
 }

--- a/orm/src/test/scala/test001/CreateTables.scala
+++ b/orm/src/test/scala/test001/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test001"))
+  override val dbSeedsAutoSession = NamedAutoSession("test001")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/test001/Spec.scala
+++ b/orm/src/test/scala/test001/Spec.scala
@@ -10,18 +10,18 @@ import org.scalatest.{ fixture, Matchers }
   */
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test001")).toDB()
+  override def db(): DB = NamedDB("test001").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val t1_1 = Test1.createWithAttributes(Symbol("name") -> "foo-1")
-    val t1_2 = Test1.createWithAttributes(Symbol("name") -> "foo-2")
-    val t1_3 = Test1.createWithAttributes(Symbol("name") -> "foo-3")
-    val t2_1 = Test2.createWithAttributes(Symbol("name") -> "bar-1")
-    val t2_2 = Test2.createWithAttributes(Symbol("name") -> "bar-2")
+    val t1_1 = Test1.createWithAttributes("name" -> "foo-1")
+    val t1_2 = Test1.createWithAttributes("name" -> "foo-2")
+    val t1_3 = Test1.createWithAttributes("name" -> "foo-3")
+    val t2_1 = Test2.createWithAttributes("name" -> "bar-1")
+    val t2_2 = Test2.createWithAttributes("name" -> "bar-2")
 
-    Test1Test2.createWithAttributes(Symbol("test1Id") -> t1_1, Symbol("test2Id") -> t2_1)
-    Test1Test2.createWithAttributes(Symbol("test1Id") -> t1_1, Symbol("test2Id") -> t2_2)
-    Test1Test2.createWithAttributes(Symbol("test1Id") -> t1_2, Symbol("test2Id") -> t2_2)
+    Test1Test2.createWithAttributes("test1Id" -> t1_1, "test2Id" -> t2_1)
+    Test1Test2.createWithAttributes("test1Id" -> t1_1, "test2Id" -> t2_2)
+    Test1Test2.createWithAttributes("test1Id" -> t1_2, "test2Id" -> t2_2)
   }
 
   describe("hasManyThrough byDefault each other") {

--- a/orm/src/test/scala/test001/models.scala
+++ b/orm/src/test/scala/test001/models.scala
@@ -48,7 +48,7 @@ WHERE  t1_default.name = ?
 
 case class Test1(id: Long, name: String, test2: Seq[Test2] = Nil)
 object Test1 extends SkinnyCRUDMapper[Test1] {
-  override def connectionPoolName = Symbol("test001")
+  override def connectionPoolName = "test001"
   override def defaultAlias       = createAlias("t1_default")
   override def extract(rs: WrappedResultSet, n: ResultName[Test1]) =
     new Test1(id = rs.get(n.id), name = rs.get(n.name))
@@ -65,7 +65,7 @@ object Test1 extends SkinnyCRUDMapper[Test1] {
 
 case class Test2(id: Long, name: String, test1: Seq[Test1] = Nil)
 object Test2 extends SkinnyCRUDMapper[Test2] {
-  override def connectionPoolName = Symbol("test001")
+  override def connectionPoolName = "test001"
   override def defaultAlias       = createAlias("t2_default")
   override def extract(rs: WrappedResultSet, n: ResultName[Test2]) =
     new Test2(id = rs.get(n.id), name = rs.get(n.name))
@@ -84,6 +84,6 @@ object Test2 extends SkinnyCRUDMapper[Test2] {
 
 case class Test1Test2(test1Id: Long, test2Id: Long)
 object Test1Test2 extends SkinnyJoinTable[Test1Test2] {
-  override def connectionPoolName = Symbol("test001")
+  override def connectionPoolName = "test001"
   override def defaultAlias       = createAlias("t1t2")
 }

--- a/orm/src/test/scala/test002/Account.scala
+++ b/orm/src/test/scala/test002/Account.scala
@@ -6,7 +6,7 @@ import scalikejdbc._
 case class Account(name: String)
 
 object Account extends SkinnyNoIdCRUDMapper[Account] {
-  override def connectionPoolName = Symbol("test002")
+  override def connectionPoolName = "test002"
 
   override def tableName                                                      = "account"
   override def defaultAlias: Alias[Account]                                   = createAlias("a")

--- a/orm/src/test/scala/test002/Connection.scala
+++ b/orm/src/test/scala/test002/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test002"), "jdbc:h2:mem:test002;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test002", "jdbc:h2:mem:test002;MODE=PostgreSQL", "sa", "sa")
 }

--- a/orm/src/test/scala/test002/CreateTables.scala
+++ b/orm/src/test/scala/test002/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test002"))
+  override val dbSeedsAutoSession = NamedAutoSession("test002")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/test002/Spec.scala
+++ b/orm/src/test/scala/test002/Spec.scala
@@ -7,11 +7,11 @@ import org.scalatest.{ fixture, Matchers }
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test002")).toDB()
+  override def db(): DB = NamedDB("test002").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    Account.createWithAttributes(Symbol("name") -> "Alice")
-    Account.createWithAttributes(Symbol("name") -> "Bob")
+    Account.createWithAttributes("name" -> "Alice")
+    Account.createWithAttributes("name" -> "Bob")
   }
 
   describe("SkinnyNoIdMapper#findAll") {

--- a/orm/src/test/scala/test003/Connection.scala
+++ b/orm/src/test/scala/test003/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test003"), "jdbc:h2:mem:test003;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test003", "jdbc:h2:mem:test003;MODE=PostgreSQL", "sa", "sa")
 }

--- a/orm/src/test/scala/test003/CreateTables.scala
+++ b/orm/src/test/scala/test003/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test003"))
+  override val dbSeedsAutoSession = NamedAutoSession("test003")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/test003/Spec.scala
+++ b/orm/src/test/scala/test003/Spec.scala
@@ -8,7 +8,7 @@ import skinny.orm.{ SkinnyCRUDMapper, SkinnyNoIdCRUDMapper }
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test003")).toDB()
+  override def db(): DB = NamedDB("test003").toDB()
 
   // entities
   case class Person(id: Int, name: String)
@@ -23,19 +23,19 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
 
   // mappers
   object Person extends SkinnyCRUDMapper[Person] {
-    override val connectionPoolName                                    = Symbol("test003")
+    override val connectionPoolName                                    = "test003"
     override lazy val defaultAlias                                     = createAlias("p")
     override def extract(rs: WrappedResultSet, rn: ResultName[Person]) = autoConstruct(rs, rn)
   }
 
   object Company extends SkinnyCRUDMapper[Company] {
-    override val connectionPoolName                                     = Symbol("test003")
+    override val connectionPoolName                                     = "test003"
     override lazy val defaultAlias                                      = createAlias("c")
     override def extract(rs: WrappedResultSet, rn: ResultName[Company]) = autoConstruct(rs, rn)
   }
 
   object Employee extends SkinnyNoIdCRUDMapper[Employee] {
-    override val connectionPoolName                                      = Symbol("test003")
+    override val connectionPoolName                                      = "test003"
     override lazy val defaultAlias                                       = createAlias("e")
     override def extract(rs: WrappedResultSet, rn: ResultName[Employee]) = autoConstruct(rs, rn, "company", "person")
 
@@ -48,13 +48,13 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
   }
 
   override def fixture(implicit session: DBSession): Unit = {
-    val p1 = Person.createWithAttributes(Symbol("name")        -> "Alice")
-    val p2 = Person.createWithAttributes(Symbol("name")        -> "Bob")
-    val p3 = Person.createWithAttributes(Symbol("name")        -> "Chris")
-    val c1 = Company.createWithAttributes(Symbol("name")       -> "Google")
-    val e1 = Employee.createWithAttributes(Symbol("companyId") -> c1, Symbol("personId") -> p1)
+    val p1 = Person.createWithAttributes("name"        -> "Alice")
+    val p2 = Person.createWithAttributes("name"        -> "Bob")
+    val p3 = Person.createWithAttributes("name"        -> "Chris")
+    val c1 = Company.createWithAttributes("name"       -> "Google")
+    val e1 = Employee.createWithAttributes("companyId" -> c1, "personId" -> p1)
     val e2 =
-      Employee.createWithAttributes(Symbol("companyId") -> c1, Symbol("personId") -> p2, Symbol("role") -> "Engineer")
+      Employee.createWithAttributes("companyId" -> c1, "personId" -> p2, "role" -> "Engineer")
   }
 
   describe("Entities with compound primary keys") {

--- a/orm/src/test/scala/test004/Connection.scala
+++ b/orm/src/test/scala/test004/Connection.scala
@@ -4,5 +4,5 @@ import scalikejdbc.ConnectionPool
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test004"), "jdbc:h2:mem:test004;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test004", "jdbc:h2:mem:test004;MODE=PostgreSQL", "sa", "sa")
 }

--- a/orm/src/test/scala/test004/CreateTables.scala
+++ b/orm/src/test/scala/test004/CreateTables.scala
@@ -5,7 +5,7 @@ import skinny.dbmigration.DBSeeds
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test004"))
+  override val dbSeedsAutoSession = NamedAutoSession("test004")
 
   addSeedSQL(
     sql"""

--- a/orm/src/test/scala/test004/Spec.scala
+++ b/orm/src/test/scala/test004/Spec.scala
@@ -9,7 +9,7 @@ import skinny.orm.feature.TimestampsFeature
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test004")).toDB()
+  override def db(): DB = NamedDB("test004").toDB()
 
   // entities
   case class Ability(
@@ -31,14 +31,14 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
 
   // mappers
   object Ability extends SkinnyCRUDMapper[Ability] with TimestampsFeature[Ability] {
-    override val connectionPoolName                                     = Symbol("test004")
+    override val connectionPoolName                                     = "test004"
     override lazy val defaultAlias                                      = createAlias("a")
     lazy val abilityTypeRef                                             = belongsTo[AbilityType](AbilityType, (a, at) => a.copy(abilityType = at))
     override def extract(rs: WrappedResultSet, rn: ResultName[Ability]) = autoConstruct(rs, rn, "abilityType")
   }
 
   object AbilityType extends SkinnyCRUDMapper[AbilityType] {
-    override val connectionPoolName                                         = Symbol("test004")
+    override val connectionPoolName                                         = "test004"
     override lazy val defaultAlias                                          = createAlias("at")
     override def extract(rs: WrappedResultSet, rn: ResultName[AbilityType]) = autoConstruct(rs, rn)
   }
@@ -47,7 +47,7 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
 
   describe("SkinnyRecord") {
     it("should update timestamps") { implicit session =>
-      val id              = Ability.createWithAttributes(Symbol("name") -> "SCALA")
+      val id              = Ability.createWithAttributes("name" -> "SCALA")
       val before: Ability = Ability.findById(id).get
       before.copy(name = "Scala").save()
       val after = Ability.findById(id).get

--- a/orm/src/test/scala/test005/Spec.scala
+++ b/orm/src/test/scala/test005/Spec.scala
@@ -8,12 +8,12 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test005"), "jdbc:h2:mem:test005;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test005", "jdbc:h2:mem:test005;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
 
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test005"))
+  override val dbSeedsAutoSession = NamedAutoSession("test005")
 
   addSeedSQL(sql"create table summary (id bigserial not null, name varchar(100) not null)")
   addSeedSQL(sql"create table data1 (id bigserial not null, summary_id bigint not null references summary(id))")
@@ -58,7 +58,7 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
   case class Data10(id: Long, summaryId: Option[Long], summary: Option[Summary] = None)
 
   object Summary extends SkinnyCRUDMapper[Summary] {
-    override val connectionPoolName = Symbol("test005")
+    override val connectionPoolName = "test005"
     override def defaultAlias       = createAlias("s")
     override def extract(rs: WrappedResultSet, rn: ResultName[Summary]) = {
       autoConstruct(rs, rn, "data1", "data2", "data3", "data4", "data5", "data6", "data7", "data8", "data9", "data10")
@@ -117,85 +117,85 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
     def withAssociations = joins(d1, d2, d3, d4, d5, d6, d7, d8, d9)
   }
   object Data1 extends SkinnyCRUDMapper[Data1] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d1")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data1]) = autoConstruct(rs, rn, "summary")
   }
   object Data2 extends SkinnyCRUDMapper[Data2] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d2")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data2]) = autoConstruct(rs, rn, "summary")
   }
   object Data3 extends SkinnyCRUDMapper[Data3] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d3")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data3]) = autoConstruct(rs, rn, "summary")
   }
   object Data4 extends SkinnyCRUDMapper[Data4] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d4")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data4]) = autoConstruct(rs, rn, "summary")
   }
   object Data5 extends SkinnyCRUDMapper[Data5] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d5")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data5]) = autoConstruct(rs, rn, "summary")
   }
   object Data6 extends SkinnyCRUDMapper[Data6] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d6")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data6]) = autoConstruct(rs, rn, "summary")
   }
   object Data7 extends SkinnyCRUDMapper[Data7] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d7")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data7]) = autoConstruct(rs, rn, "summary")
   }
   object Data8 extends SkinnyCRUDMapper[Data8] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d8")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data8]) = autoConstruct(rs, rn, "summary")
   }
   object Data9 extends SkinnyCRUDMapper[Data9] {
-    override val connectionPoolName                                   = Symbol("test005")
+    override val connectionPoolName                                   = "test005"
     override def defaultAlias                                         = createAlias("d9")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data9]) = autoConstruct(rs, rn, "summary")
   }
   object Data10 extends SkinnyCRUDMapper[Data10] {
-    override val connectionPoolName                                    = Symbol("test005")
+    override val connectionPoolName                                    = "test005"
     override def defaultAlias                                          = createAlias("d10")
     override def extract(rs: WrappedResultSet, rn: ResultName[Data10]) = autoConstruct(rs, rn, "summary")
   }
 
-  override def db(): DB = NamedDB(Symbol("test005")).toDB()
+  override def db(): DB = NamedDB("test005").toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    val summaryId = Summary.createWithAttributes(Symbol("name") -> "Sample")
-    Data1.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data1.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data1.createWithAttributes(Symbol("summaryId") -> summaryId)
+    val summaryId = Summary.createWithAttributes("name" -> "Sample")
+    Data1.createWithAttributes("summaryId" -> summaryId)
+    Data1.createWithAttributes("summaryId" -> summaryId)
+    Data1.createWithAttributes("summaryId" -> summaryId)
 
-    Data2.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data2.createWithAttributes("summaryId" -> summaryId)
 
-    Data3.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data3.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data3.createWithAttributes("summaryId" -> summaryId)
+    Data3.createWithAttributes("summaryId" -> summaryId)
 
-    Data4.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data4.createWithAttributes("summaryId" -> summaryId)
 
-    Data5.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data5.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data5.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data5.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data5.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data5.createWithAttributes("summaryId" -> summaryId)
+    Data5.createWithAttributes("summaryId" -> summaryId)
+    Data5.createWithAttributes("summaryId" -> summaryId)
+    Data5.createWithAttributes("summaryId" -> summaryId)
+    Data5.createWithAttributes("summaryId" -> summaryId)
 
-    Data6.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data6.createWithAttributes("summaryId" -> summaryId)
 
-    Data7.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data7.createWithAttributes("summaryId" -> summaryId)
 
-    Data8.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data8.createWithAttributes("summaryId" -> summaryId)
 
-    Data9.createWithAttributes(Symbol("summaryId") -> summaryId)
-    Data9.createWithAttributes(Symbol("summaryId") -> summaryId)
+    Data9.createWithAttributes("summaryId" -> summaryId)
+    Data9.createWithAttributes("summaryId" -> summaryId)
   }
 
   describe("Entity which has 1 - 8 associations") {

--- a/orm/src/test/scala/test006/Spec.scala
+++ b/orm/src/test/scala/test006/Spec.scala
@@ -8,24 +8,24 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test006"), "jdbc:h2:mem:test006;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test006", "jdbc:h2:mem:test006;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test006"))
+  override val dbSeedsAutoSession = NamedAutoSession("test006")
   addSeedSQL(sql"create table summary (id bigserial not null, name varchar(100) not null)")
   runIfFailed(sql"select count(1) from summary")
 }
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
-  override def db(): DB = NamedDB(Symbol("test006")).toDB()
+  override def db(): DB = NamedDB("test006").toDB()
 
   var (_beforeCreate, _beforeUpdateBy, _beforeDeleteBy, _afterCreate, _afterDeleteBy, _afterUpdateBy) =
     (0, 0, 0, 0, 0, 0)
 
   case class Summary(id: Long, name: String)
   object Summary extends SkinnyCRUDMapper[Summary] {
-    override val connectionPoolName = Symbol("test006")
+    override val connectionPoolName = "test006"
     override def defaultAlias       = createAlias("s")
 
     beforeCreate((session: DBSession, namedValues: Seq[(SQLSyntax, Any)]) => {
@@ -82,8 +82,8 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
       _beforeDeleteBy should equal(0)
       _afterDeleteBy should equal(0)
 
-      val id = Summary.createWithAttributes(Symbol("name") -> "Sample")
-      Summary.updateById(id).withAttributes(Symbol("name") -> "Sample2")
+      val id = Summary.createWithAttributes("name" -> "Sample")
+      Summary.updateById(id).withAttributes("name" -> "Sample2")
       Summary.deleteById(id)
 
       _beforeCreate should equal(2)

--- a/orm/src/test/scala/test007/Spec.scala
+++ b/orm/src/test/scala/test007/Spec.scala
@@ -9,11 +9,11 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test007"), "jdbc:h2:mem:test007;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test007", "jdbc:h2:mem:test007;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test007"))
+  override val dbSeedsAutoSession = NamedAutoSession("test007")
   addSeedSQL(sql"create table blog (id bigserial not null, name varchar(100) not null)")
   addSeedSQL(sql"""
    create table article (
@@ -27,11 +27,11 @@ trait CreateTables extends DBSeeds { self: Connection =>
 }
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
-  override def db(): DB = NamedDB(Symbol("test007")).toDB()
+  override def db(): DB = NamedDB("test007").toDB()
 
   case class Blog(id: Long, name: String, articles: Seq[Article] = Seq.empty)
   object Blog extends SkinnyCRUDMapper[Blog] {
-    override val connectionPoolName                                  = Symbol("test007")
+    override val connectionPoolName                                  = "test007"
     override def defaultAlias                                        = createAlias("b")
     override def extract(rs: WrappedResultSet, rn: ResultName[Blog]) = autoConstruct(rs, rn, "articles")
 
@@ -48,7 +48,7 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
                      createdAt: DateTime,
                      blog: Option[Blog] = None)
   object Article extends SkinnyCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("test007")
+    override val connectionPoolName                                     = "test007"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "blog")
 
@@ -57,19 +57,13 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
 
   describe("associations by default") {
     it("should work") { implicit session =>
-      val blogId1 = Blog.createWithAttributes(Symbol("name") -> "Apply in Tokyo")
-      val blogId2 = Blog.createWithAttributes(Symbol("name") -> "Apply in NY")
-      val blogId3 = Blog.createWithAttributes(Symbol("name") -> "Apply in Paris")
+      val blogId1 = Blog.createWithAttributes("name" -> "Apply in Tokyo")
+      val blogId2 = Blog.createWithAttributes("name" -> "Apply in NY")
+      val blogId3 = Blog.createWithAttributes("name" -> "Apply in Paris")
       (1 to 20).foreach { day =>
-        Article.createWithAttributes(Symbol("title")  -> s"Learning Scala: Day $day",
-                                     Symbol("body")   -> "xxx",
-                                     Symbol("blogId") -> blogId1)
-        Article.createWithAttributes(Symbol("title")  -> s"Learning Scala: Day $day",
-                                     Symbol("body")   -> "xxx",
-                                     Symbol("blogId") -> blogId2)
-        Article.createWithAttributes(Symbol("title")  -> s"Learning Scala: Day $day",
-                                     Symbol("body")   -> "xxx",
-                                     Symbol("blogId") -> blogId3)
+        Article.createWithAttributes("title" -> s"Learning Scala: Day $day", "body" -> "xxx", "blogId" -> blogId1)
+        Article.createWithAttributes("title" -> s"Learning Scala: Day $day", "body" -> "xxx", "blogId" -> blogId2)
+        Article.createWithAttributes("title" -> s"Learning Scala: Day $day", "body" -> "xxx", "blogId" -> blogId3)
       }
       val blogs = Blog.findAllWithLimitOffset(2, 0)
       blogs.size should equal(2)

--- a/orm/src/test/scala/test008/Spec.scala
+++ b/orm/src/test/scala/test008/Spec.scala
@@ -9,11 +9,11 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test008"), "jdbc:h2:mem:test008;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test008", "jdbc:h2:mem:test008;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test008"))
+  override val dbSeedsAutoSession = NamedAutoSession("test008")
   addSeedSQL(sql"create table blog (name varchar(100) not null)")
   addSeedSQL(sql"""
    create table article (
@@ -27,18 +27,18 @@ trait CreateTables extends DBSeeds { self: Connection =>
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test008")).toDB()
+  override def db(): DB = NamedDB("test008").toDB()
 
   case class Blog(name: String)
   object Blog extends SkinnyNoIdCRUDMapper[Blog] {
-    override val connectionPoolName                                  = Symbol("test008")
+    override val connectionPoolName                                  = "test008"
     override def defaultAlias                                        = createAlias("b")
     override def extract(rs: WrappedResultSet, rn: ResultName[Blog]) = autoConstruct(rs, rn)
   }
 
   case class Article(blogName: String, title: String, body: String, createdAt: DateTime, blog: Option[Blog] = None)
   object Article extends SkinnyNoIdCRUDMapper[Article] {
-    override val connectionPoolName                                     = Symbol("test008")
+    override val connectionPoolName                                     = "test008"
     override def defaultAlias                                           = createAlias("a")
     override def extract(rs: WrappedResultSet, rn: ResultName[Article]) = autoConstruct(rs, rn, "blog")
 
@@ -52,27 +52,27 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
 
   describe("associations by default") {
     it("should work") { implicit session =>
-      Blog.createWithAttributes(Symbol("name") -> "Apply in Tokyo")
-      Blog.createWithAttributes(Symbol("name") -> "Apply in NY")
-      Blog.createWithAttributes(Symbol("name") -> "Apply in Paris")
+      Blog.createWithAttributes("name" -> "Apply in Tokyo")
+      Blog.createWithAttributes("name" -> "Apply in NY")
+      Blog.createWithAttributes("name" -> "Apply in Paris")
       (1 to 5).foreach { day =>
-        Article.createWithAttributes(Symbol("title")    -> s"Learning Scala: Day $day",
-                                     Symbol("body")     -> "日本へようこそ。東京は楽しいよ。",
-                                     Symbol("blogName") -> "Apply in Tokyo")
+        Article.createWithAttributes("title"    -> s"Learning Scala: Day $day",
+                                     "body"     -> "日本へようこそ。東京は楽しいよ。",
+                                     "blogName" -> "Apply in Tokyo")
       }
       (1 to 6).foreach { day =>
-        Article.createWithAttributes(Symbol("title")    -> s"Learning Scala: Day $day",
-                                     Symbol("body")     -> "Welcome to New York!",
-                                     Symbol("blogName") -> "Apply in NY")
+        Article.createWithAttributes("title"    -> s"Learning Scala: Day $day",
+                                     "body"     -> "Welcome to New York!",
+                                     "blogName" -> "Apply in NY")
       }
       (1 to 7).foreach { day =>
-        Article.createWithAttributes(Symbol("title")    -> s"Learning Scala: Day $day",
-                                     Symbol("body")     -> "Bonjour et bienvenue à Paris!",
-                                     Symbol("blogName") -> "Apply in Paris")
+        Article.createWithAttributes("title"    -> s"Learning Scala: Day $day",
+                                     "body"     -> "Bonjour et bienvenue à Paris!",
+                                     "blogName" -> "Apply in Paris")
       }
-      Article.joins(Article.blogRef).where(Symbol("blogName") -> "Apply in Tokyo").apply().size should equal(5)
-      Article.joins(Article.blogRef).where(Symbol("blogName") -> "Apply in NY").apply().size should equal(6)
-      Article.joins(Article.blogRef).where(Symbol("blogName") -> "Apply in Paris").apply().size should equal(7)
+      Article.joins(Article.blogRef).where("blogName" -> "Apply in Tokyo").apply().size should equal(5)
+      Article.joins(Article.blogRef).where("blogName" -> "Apply in NY").apply().size should equal(6)
+      Article.joins(Article.blogRef).where("blogName" -> "Apply in Paris").apply().size should equal(7)
     }
   }
 }

--- a/orm/src/test/scala/test009/Spec.scala
+++ b/orm/src/test/scala/test009/Spec.scala
@@ -9,11 +9,11 @@ import skinny.orm._
 
 trait Connection {
   Class.forName("org.h2.Driver")
-  ConnectionPool.add(Symbol("test009"), "jdbc:h2:mem:test009;MODE=PostgreSQL", "sa", "sa")
+  ConnectionPool.add("test009", "jdbc:h2:mem:test009;MODE=PostgreSQL", "sa", "sa")
 }
 
 trait CreateTables extends DBSeeds { self: Connection =>
-  override val dbSeedsAutoSession = NamedAutoSession(Symbol("test009"))
+  override val dbSeedsAutoSession = NamedAutoSession("test009")
   addSeedSQL(sql"""
    create table blog (
      id bigserial not null,
@@ -37,14 +37,14 @@ trait CreateTables extends DBSeeds { self: Connection =>
 
 class Spec extends fixture.FunSpec with Matchers with Connection with CreateTables with AutoRollback {
 
-  override def db(): DB = NamedDB(Symbol("test009")).toDB()
+  override def db(): DB = NamedDB("test009").toDB()
 
   case class Blog(id: Long, name: String, createdAt: DateTime, tags: Seq[Tag] = Nil)
   case class BlogTag(blogId: Long, tagId: Long)
   case class Tag(id: Long, value: String, createdAt: DateTime)
 
   object Blog extends SkinnyCRUDMapper[Blog] {
-    override val connectionPoolName                                  = Symbol("test009")
+    override val connectionPoolName                                  = "test009"
     override def defaultAlias                                        = createAlias("b")
     override def extract(rs: WrappedResultSet, rn: ResultName[Blog]) = autoConstruct(rs, rn, "tags")
 
@@ -63,31 +63,31 @@ class Spec extends fixture.FunSpec with Matchers with Connection with CreateTabl
   }
 
   object BlogTag extends SkinnyCRUDMapper[BlogTag] {
-    override val connectionPoolName                                     = Symbol("test009")
+    override val connectionPoolName                                     = "test009"
     override def defaultAlias                                           = createAlias("bt")
     override def extract(rs: WrappedResultSet, rn: ResultName[BlogTag]) = autoConstruct(rs, rn)
   }
 
   object Tag extends SkinnyCRUDMapper[Tag] {
-    override val connectionPoolName                                 = Symbol("test009")
+    override val connectionPoolName                                 = "test009"
     override def defaultAlias                                       = createAlias("t")
     override def extract(rs: WrappedResultSet, rn: ResultName[Tag]) = autoConstruct(rs, rn)
   }
 
   def dataPreparation()(implicit s: DBSession) = {
-    val blog1 = Blog.createWithAttributes(Symbol("name") -> "Apply in America")
-    val blog2 = Blog.createWithAttributes(Symbol("name") -> "Apply in Brazil")
-    val blog3 = Blog.createWithAttributes(Symbol("name") -> "Apply in China")
-    val blog4 = Blog.createWithAttributes(Symbol("name") -> "Apply in Tokyo")
-    val blog5 = Blog.createWithAttributes(Symbol("name") -> "Apply in NY")
+    val blog1 = Blog.createWithAttributes("name" -> "Apply in America")
+    val blog2 = Blog.createWithAttributes("name" -> "Apply in Brazil")
+    val blog3 = Blog.createWithAttributes("name" -> "Apply in China")
+    val blog4 = Blog.createWithAttributes("name" -> "Apply in Tokyo")
+    val blog5 = Blog.createWithAttributes("name" -> "Apply in NY")
 
-    val tag1 = Tag.createWithAttributes(Symbol("value") -> "scala")
-    val tag2 = Tag.createWithAttributes(Symbol("value") -> "java")
-    val tag3 = Tag.createWithAttributes(Symbol("value") -> "ruby")
+    val tag1 = Tag.createWithAttributes("value" -> "scala")
+    val tag2 = Tag.createWithAttributes("value" -> "java")
+    val tag3 = Tag.createWithAttributes("value" -> "ruby")
 
-    BlogTag.createWithAttributes(Symbol("blogId") -> blog4, Symbol("tagId") -> tag2)
-    BlogTag.createWithAttributes(Symbol("blogId") -> blog4, Symbol("tagId") -> tag1)
-    BlogTag.createWithAttributes(Symbol("blogId") -> blog5, Symbol("tagId") -> tag3)
+    BlogTag.createWithAttributes("blogId" -> blog4, "tagId" -> tag2)
+    BlogTag.createWithAttributes("blogId" -> blog4, "tagId" -> tag1)
+    BlogTag.createWithAttributes("blogId" -> blog5, "tagId" -> tag3)
   }
 
   describe("findAllWithLimitOffset") {

--- a/skinny-blank-app/build.sbt
+++ b/skinny-blank-app/build.sbt
@@ -12,7 +12,7 @@ val appOrganization = "org.skinny-framework"
 val appName = "skinny-blank-app"
 val appVersion = "0.1.0-SNAPSHOT"
 
-val skinnyVersion = "3.2.0"
+val skinnyVersion = "4.0.0-SNAPSHOT"
 val theScalaVersion = "2.13.1"
 val jettyVersion = "9.4.19.v20190610"
 

--- a/task/src/main/scala/skinny/task/generator/ControllerGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ControllerGenerator.scala
@@ -144,13 +144,14 @@ trait ControllerGenerator extends CodeGenerator {
 
     s"""package ${namespace}
       |
-      |import org.scalatest._
+      |import org.scalatest.funspec.AnyFunSpec
+      |import org.scalatest.matchers.should.Matchers
       |import skinny._
       |import skinny.test._
       |import org.joda.time._
       |
       |// NOTICE before/after filters won't be executed by default
-      |class ${controllerClassName}Spec extends FunSpec with Matchers with DBSettings {
+      |class ${controllerClassName}Spec extends AnyFunSpec with Matchers with DBSettings {
       |
       |  def createMockController = new ${controllerClassName} with MockController
       |

--- a/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
+++ b/task/src/main/scala/skinny/task/generator/ScaffoldGenerator.scala
@@ -371,7 +371,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     val modelClassName      = toClassName(resource)
     val factoryNamePart: String = {
       val name = toResourceNameWithNamespace(namespaces, resource)
-      if (name != resource) ", '" + name else ""
+      if (name != resource) ", \"" + name + "\"" else ""
     }
 
     val viewTemplatesPath = s"${toResourcesBasePath(namespaces)}/${resources}"
@@ -381,16 +381,18 @@ trait ScaffoldGenerator extends CodeGenerator {
 
     s"""package ${namespace}
       |
-      |import org.scalatest._
+      |import org.scalatest.funspec.AnyFunSpec
+      |import org.scalatest.matchers.should.Matchers
+      |import org.scalatest.BeforeAndAfterAll
       |import skinny._
       |import skinny.test._
       |import org.joda.time._
       |import ${toNamespace(modelPackage, namespaces)}._
       |
       |// NOTICE before/after filters won't be executed by default
-      |class ${controllerClassName}Spec extends FunSpec with Matchers with BeforeAndAfterAll with DBSettings {
+      |class ${controllerClassName}Spec extends AnyFunSpec with Matchers with BeforeAndAfterAll with DBSettings {
       |
-      |  override def afterAll() {
+      |  override def afterAll(): Unit = {
       |    super.afterAll()
       |    ${modelClassName}.deleteAll()
       |  }
@@ -507,7 +509,7 @@ trait ScaffoldGenerator extends CodeGenerator {
     val modelClassName      = toClassName(resource)
     val factoryNamePart: String = {
       val name = toResourceNameWithNamespace(namespaces, resource)
-      if (name != resource) ", '" + name else ""
+      if (name != resource) ", \"" + name + "\"" else ""
     }
 
     val resourcesInLabel = toSplitName(resources)
@@ -527,7 +529,7 @@ trait ScaffoldGenerator extends CodeGenerator {
         |class ${controllerClassName}_IntegrationTestSpec extends SkinnyFlatSpec with SkinnyTestSupport with BeforeAndAfterAll with DBSettings {
         |  addFilter(Controllers.${controllerName}, "/*")
         |
-        |  override def afterAll() {
+        |  override def afterAll(): Unit = {
         |    super.afterAll()
         |    ${modelClassName}.deleteAll()
         |  }

--- a/task/src/test/scala/skinny/task/generator/ControllerGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ControllerGeneratorSpec.scala
@@ -38,13 +38,14 @@ class ControllerGeneratorSpec extends FunSpec with Matchers {
       val expected =
         """package controller.admin
           |
-          |import org.scalatest._
+          |import org.scalatest.funspec.AnyFunSpec
+          |import org.scalatest.matchers.should.Matchers
           |import skinny._
           |import skinny.test._
           |import org.joda.time._
           |
           |// NOTICE before/after filters won't be executed by default
-          |class MembersControllerSpec extends FunSpec with Matchers with DBSettings {
+          |class MembersControllerSpec extends AnyFunSpec with Matchers with DBSettings {
           |
           |  def createMockController = new MembersController with MockController
           |

--- a/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
+++ b/task/src/test/scala/skinny/task/generator/ScaffoldGeneratorSpec.scala
@@ -158,7 +158,7 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
           |class MembersController_IntegrationTestSpec extends SkinnyFlatSpec with SkinnyTestSupport with BeforeAndAfterAll with DBSettings {
           |  addFilter(Controllers.members, "/*")
           |
-          |  override def afterAll() {
+          |  override def afterAll(): Unit = {
           |    super.afterAll()
           |    Member.deleteAll()
           |  }
@@ -297,12 +297,12 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
           |class MembersController_IntegrationTestSpec extends SkinnyFlatSpec with SkinnyTestSupport with BeforeAndAfterAll with DBSettings {
           |  addFilter(Controllers.adminMembers, "/*")
           |
-          |  override def afterAll() {
+          |  override def afterAll(): Unit = {
           |    super.afterAll()
           |    Member.deleteAll()
           |  }
           |
-          |  def newMember = FactoryGirl(Member, 'adminMember).create()
+          |  def newMember = FactoryGirl(Member, "adminMember").create()
           |
           |  it should "show members" in {
           |    get("/admin/members") {
@@ -458,12 +458,12 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
           |class GroupMembersController_IntegrationTestSpec extends SkinnyFlatSpec with SkinnyTestSupport with BeforeAndAfterAll with DBSettings {
           |  addFilter(Controllers.adminGroupMembers, "/*")
           |
-          |  override def afterAll() {
+          |  override def afterAll(): Unit = {
           |    super.afterAll()
           |    GroupMember.deleteAll()
           |  }
           |
-          |  def newGroupMember = FactoryGirl(GroupMember, 'adminGroupMember).create()
+          |  def newGroupMember = FactoryGirl(GroupMember, "adminGroupMember").create()
           |
           |  it should "show group members" in {
           |    get("/admin/group_members") {
@@ -602,12 +602,12 @@ class ScaffoldGeneratorSpec extends FunSpec with Matchers {
           |class MembersController_IntegrationTestSpec extends SkinnyFlatSpec with SkinnyTestSupport with BeforeAndAfterAll with DBSettings {
           |  addFilter(Controllers.adminMembers, "/*")
           |
-          |  override def afterAll() {
+          |  override def afterAll(): Unit = {
           |    super.afterAll()
           |    Member.deleteAll()
           |  }
           |
-          |  def newMember = FactoryGirl(Member, 'adminMember).create()
+          |  def newMember = FactoryGirl(Member, "adminMember").create()
           |
           |  it should "show members" in {
           |    get("/admin/members") {

--- a/test/src/test/scala/skinny/test/MockControllerSpec.scala
+++ b/test/src/test/scala/skinny/test/MockControllerSpec.scala
@@ -17,7 +17,7 @@ class MockControllerSpec extends FunSpec with Matchers {
     get("/api/useUrl")(useUrl)
     get("/api/useUrl2")(useUrl2)
 
-    val hoge = get("hoge")("aaaa").as(Symbol("hoge"))
+    val hoge = get("hoge")("aaaa").as("hoge")
   }
 
   class ApiTest extends SkinnyApiController with Routes {
@@ -28,7 +28,7 @@ class MockControllerSpec extends FunSpec with Matchers {
     get("/api/useUrl")(useUrl)
     get("/api/useUrl2")(useUrl2)
 
-    val hoge = get("hoge")("aaaa").as(Symbol("hoge"))
+    val hoge = get("hoge")("aaaa").as("hoge")
   }
 
   describe("MockController") {

--- a/test/src/test/scala/skinny/test/SkinnyTestSupportSpec.scala
+++ b/test/src/test/scala/skinny/test/SkinnyTestSupportSpec.scala
@@ -19,7 +19,7 @@ class SkinnyTestSupportSpec extends SkinnyFlatSpec with SkinnyTestSupport with S
     def useUrl = url("/foo")
     get("/useUrl")(useUrl)
 
-    val hoge    = get("hoge")("aaaa").as(Symbol("hoge"))
+    val hoge    = get("hoge")("aaaa").as("hoge")
     def useUrl2 = url(hoge)
     get("/useUrl2")(useUrl2)
   }
@@ -29,7 +29,7 @@ class SkinnyTestSupportSpec extends SkinnyFlatSpec with SkinnyTestSupport with S
     def useUrl = url("/foo")
     get("/api/useUrl")(useUrl)
 
-    val hoge    = get("hoge")("aaaa").as(Symbol("hoge"))
+    val hoge    = get("hoge")("aaaa").as("hoge")
     def useUrl2 = url(hoge)
     get("/api/useUrl2")(useUrl2)
   }


### PR DESCRIPTION
As you know, since Scala 2.13, symbol literals have been marked as deprecated. We have to use `Symbol("foo")` instead of `'foo`. I know this is not beneficial for skinny users at all... 

I really regret to bring backward-incompatibilities to this library but I have to. Since v4, all the methods that used to accept Symbol values go with String values instead. This is a breaking change that probably affects all existing users.

When you upgrade to v4, you will see not small number of compilation errors. There is no other way apart from manually fixing all of them. I'm sorry about that again. I would like all of you to understand this decision.
